### PR TITLE
Persistent entropy

### DIFF
--- a/data/persistence_diagram/files_list.txt
+++ b/data/persistence_diagram/files_list.txt
@@ -1,0 +1,6 @@
+/home/luque/Escritorio/Gudhi/gudhi-devel/data/persistence_diagram/first.pers
+/home/luque/Escritorio/Gudhi/gudhi-devel/data/persistence_diagram/rips_on_tore3D_1307.pers
+/home/luque/Escritorio/Gudhi/gudhi-devel/data/persistence_diagram/second.pers
+
+
+

--- a/src/Persistence_representations/example/CMakeLists.txt
+++ b/src/Persistence_representations/example/CMakeLists.txt
@@ -26,3 +26,7 @@ add_test(NAME Persistence_representations_example_heat_maps
     COMMAND $<TARGET_FILE:Persistence_representations_example_heat_maps>)
 install(TARGETS Persistence_representations_example_heat_maps DESTINATION bin)
 
+add_executable ( Persistent_entropy persistent_entropy.cpp )
+add_test(NAME Persistent_entropy
+    COMMAND $<TARGET_FILE:Persistent_entropy>)
+install(TARGETS Persistent_entropy DESTINATION bin)

--- a/src/Persistence_representations/example/persistent_entropy.cpp
+++ b/src/Persistence_representations/example/persistent_entropy.cpp
@@ -1,0 +1,41 @@
+/* 
+ *    Author: Alejandro Luque cerpa
+ */
+
+#include <gudhi/Persistence_intervals.h>
+#include <gudhi/Persistent_entropy.h>
+
+
+#include <iostream>
+#include <utility>
+#include <vector>
+
+using namespace std;
+
+using Persistence_intervals = Gudhi::Persistence_representations::Persistence_intervals;
+
+
+int main(int argc, char** argv) {
+  if (argc != 2 ) {
+    std::cout << "To run this program, please provide the name of a file with a list of files with persistence diagrams \n";
+    return 1;
+}
+  // results vector ignoring infinity bars and not normalized
+  std::vector<double> res = Gudhi::Persistent_entropy::persistent_entropy_from_files_list(argv[1], false, -1, false);
+  // results vector changing infinity bar to 50 (example value)
+  std::vector<double> res2 = Gudhi::Persistent_entropy::persistent_entropy_from_files_list(argv[1], true, 50, true);
+  // results vector normalized
+  std::vector<double> res3 = Gudhi::Persistent_entropy::persistent_entropy_from_files_list(argv[1], false, -1, true);
+  
+  // display
+  for(std::size_t i=0; i<res.size(); i++)
+	std::cout << "The result for diagram " << i << " (standard) is " << res[i] << endl; 
+  std::cout << "-------------------------------------------------------------------" << endl;
+  for(std::size_t i=0; i<res2.size(); i++)
+	std::cout << "The result for diagram " << i << " (infinity_value = 50) is " << res2[i] << endl;
+  std::cout << "-------------------------------------------------------------------" << endl;
+  for(std::size_t i=0; i<res3.size(); i++)
+	std::cout << "The result for diagram " << i << " (standard normalized) is " << res3[i] << endl;
+  std::cout << "-------------------------------------------------------------------" << endl;
+  return 0;
+}

--- a/src/Persistence_representations/include/gudhi/Persistent_entropy.h
+++ b/src/Persistence_representations/include/gudhi/Persistent_entropy.h
@@ -1,0 +1,83 @@
+/*    
+ *    Author(s):       Alejandro Luque Cerpa
+ */
+
+#ifndef PERSISTENT_ENTROPY_H_
+#define PERSISTENT_ENTROPY_H_
+
+// gudhi include
+#include <gudhi/read_persistence_from_file.h>
+#include <gudhi/Persistence_intervals.h>
+
+// standard include
+#include <limits>
+#include <iostream>
+#include <fstream>
+#include <vector>
+#include <algorithm>
+#include <cmath>
+#include <functional>
+#include <utility>
+#include <string>
+
+namespace Gudhi {
+namespace Persistent_entropy{
+
+double persistent_entropy_from_file(const char* filename, bool keep_inf=false, double val_inf=-1.0, bool normalize=false){
+    std::vector<std::pair<double, double>> intervals;
+	if(keep_inf){
+		intervals = Gudhi::Persistence_representations::read_persistence_intervals_in_one_dimension_from_file(filename, -1, val_inf);
+	}else{
+		intervals = Gudhi::Persistence_representations::read_persistence_intervals_in_one_dimension_from_file(filename);
+	}	
+	double res = 0;
+	double SL = 0;
+	double aux;
+	double pi;
+	int N = intervals.size();
+	std::vector<double> props;
+	// This function optimizes the memory access
+	props.reserve(N);
+	for (int i = 0; i < N; i++){
+		aux = intervals.at(i).second - intervals.at(i).first;
+		SL += aux;
+		props.push_back(aux);
+	}
+	for (int i = 0; i < N; i++){
+		pi = props.at(i) / SL;
+		res -= pi * log(pi);
+	}	
+        if (normalize){
+		res = res / log(N);
+	}
+	return res;
+} // double persistent_entropy_from_file
+
+
+std::vector<double> persistent_entropy_from_files_list(const char* filename, bool keep_inf=false, double val_inf=-1.0, bool normalize=false){
+	std::vector<double> res;
+	std::ifstream in(filename);
+	if(!in.is_open()){
+		std::string error_str("Persistent entropy from files list - Unable to open file ");
+		error_str.append(filename);
+		std::cerr << error_str << std::endl;
+		throw std::invalid_argument(error_str);
+	}
+
+	while (!in.eof()){
+		std::string line;
+		getline(in, line);
+		char cstr[line.size() + 1];
+		line.copy(cstr, line.size() + 1);
+		cstr[line.size()] = '\0';
+		if(line.length() != 0 && line[0] != '#'){
+			res.push_back(persistent_entropy_from_file(cstr, keep_inf, val_inf, normalize));
+		}
+	}
+	return res;
+} // double persistent_entropy_from_files_list
+
+} // namespace Persistent_entropy
+} // namespace Gudhi
+
+#endif  // PERSISTENT_ENTROPY_H_


### PR DESCRIPTION
Three files have been included:
- The file Persistent_entropy.h includes two functions. One of them calculate the persistent entropy of a persistence_diagram. The parameters can be used to ignore or keep the infinity bars and to normalize. The other function calculate the persistent entropy of a list of persistence diagrams. They should be given in a file, as a list of the files directions.
- The file files_list.txt is a list of the directions of three persistence diagrams. It should be modified on each computer to be used. The modification needed is just changing the root folder of the persistence diagrams.
- The file persistent_entropy.cpp is an example of usage, using files_list.txt.
- The CMakeLists.txt file has been modified in order to compile persistent_entropy.cpp