### PR TITLE
fix documentation not being generated with Doxygen 1.8.16

### DIFF
--- a/src/Doxyfile.in
+++ b/src/Doxyfile.in
@@ -765,7 +765,7 @@ INPUT_ENCODING         = UTF-8
 # *.md, *.mm, *.dox, *.py, *.f90, *.f, *.for, *.tcl, *.vhd, *.vhdl, *.ucf,
 # *.qsf, *.as and *.js.
 
-FILE_PATTERNS          =
+#FILE_PATTERNS          =
 
 # The RECURSIVE tag can be used to specify whether or not subdirectories should
 # be searched for input files as well.


### PR DESCRIPTION
This fixes issue #108 
Caused by a known [bug](https://github.com/doxygen/doxygen/issues/7190) in Doxygen-1.8.16.