### PR TITLE
Empty complexes have 0 (not -1) Betti numbers

### DIFF
--- a/src/Persistent_cohomology/include/gudhi/Persistent_cohomology.h
+++ b/src/Persistent_cohomology/include/gudhi/Persistent_cohomology.h
@@ -600,8 +600,10 @@ class Persistent_cohomology {
    * @return A vector of Betti numbers.
    */
   std::vector<int> betti_numbers() const {
+    // Don't allocate a vector of negative size for an empty complex
+    int siz = std::max(dim_max_, 0);
     // Init Betti numbers vector with zeros until Simplicial complex dimension
-    std::vector<int> betti_numbers(dim_max_, 0);
+    std::vector<int> betti_numbers(siz);
 
     for (auto pair : persistent_pairs_) {
       // Count never ended persistence intervals
@@ -639,8 +641,10 @@ class Persistent_cohomology {
    * @return A vector of persistent Betti numbers.
    */
   std::vector<int> persistent_betti_numbers(Filtration_value from, Filtration_value to) const {
+    // Don't allocate a vector of negative size for an empty complex
+    int siz = std::max(dim_max_, 0);
     // Init Betti numbers vector with zeros until Simplicial complex dimension
-    std::vector<int> betti_numbers(dim_max_, 0);
+    std::vector<int> betti_numbers(siz);
     for (auto pair : persistent_pairs_) {
       // Count persistence intervals that covers the given interval
       // null_simplex test : if the function is called with to=+infinity, we still get something useful. And it will

--- a/src/Persistent_cohomology/test/betti_numbers_unit_test.cpp
+++ b/src/Persistent_cohomology/test/betti_numbers_unit_test.cpp
@@ -284,4 +284,13 @@ BOOST_AUTO_TEST_CASE( betti_numbers )
   auto intervals_in_dimension_2 = pcoh.intervals_in_dimension(2);
   std::cout << "intervals_in_dimension_2.size() = " << intervals_in_dimension_2.size() << std::endl;
   BOOST_CHECK(intervals_in_dimension_2.size() == 0);
+
+  std::cout << "EMPTY COMPLEX" << std::endl;
+  Simplex_tree empty;
+  empty.initialize_filtration();
+  St_persistence pcoh_empty(empty, false);
+  pcoh_empty.init_coefficients(2);
+  pcoh_empty.compute_persistent_cohomology();
+  BOOST_CHECK(pcoh_empty.betti_numbers().size() == 0);
+  BOOST_CHECK(pcoh_empty.persistent_betti_numbers(0,1).size() == 0);
 }


### PR DESCRIPTION
Fix #122.