### PR TITLE
Add examples of 3d plots of complexes

### DIFF
--- a/src/python/doc/examples.rst
+++ b/src/python/doc/examples.rst
@@ -16,6 +16,9 @@ Examples
     * :download:`periodic_cubical_complex_barcode_persistence_from_perseus_file_example.py <../example/periodic_cubical_complex_barcode_persistence_from_perseus_file_example.py>`
     * :download:`bottleneck_basic_example.py <../example/bottleneck_basic_example.py>`
     * :download:`gudhi_graphical_tools_example.py <../example/gudhi_graphical_tools_example.py>`
+    * :download:`plot_simplex_tree_dim012.py <../example/plot_simplex_tree_dim012.py>`
+    * :download:`plot_rips_complex.py <../example/plot_rips_complex.py>`
+    * :download:`plot_alpha_complex.py <../example/plot_alpha_complex.py>`
     * :download:`witness_complex_from_nearest_landmark_table.py <../example/witness_complex_from_nearest_landmark_table.py>`
     * :download:`euclidean_strong_witness_complex_diagram_persistence_from_off_file_example.py <../example/euclidean_strong_witness_complex_diagram_persistence_from_off_file_example.py>`
     * :download:`euclidean_witness_complex_diagram_persistence_from_off_file_example.py <../example/euclidean_witness_complex_diagram_persistence_from_off_file_example.py>`

--- a/src/python/example/plot_alpha_complex.py
+++ b/src/python/example/plot_alpha_complex.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+
+import numpy as np
+import gudhi
+ac = gudhi.AlphaComplex(off_file='../../data/points/tore3D_1307.off')
+st = ac.create_simplex_tree()
+points = np.array([ac.get_point(i) for i in range(st.num_vertices())])
+# We want to plot the alpha-complex with alpha=0.1.
+# We are only going to plot the triangles
+triangles = np.array([s[0] for s in st.get_skeleton(2) if len(s[0])==3 and s[1] <= .1])
+
+# First possibility: plotly
+import plotly.graph_objects as go
+fig = go.Figure(data=[
+    go.Mesh3d(
+        x=points[:,0],
+        y=points[:,1],
+        z=points[:,2],
+        i = triangles[:,0],
+        j = triangles[:,1],
+        k = triangles[:,2],
+    )
+])
+fig.show()
+
+# Second possibility: matplotlib
+from mpl_toolkits.mplot3d import Axes3D
+import matplotlib.pyplot as plt
+fig = plt.figure()
+ax = fig.gca(projection='3d')
+ax.plot_trisurf(points[:,0], points[:,1], points[:,2], triangles=triangles)
+plt.show()
+
+# Third possibility: mayavi.mlab.triangular_mesh

--- a/src/python/example/plot_alpha_complex.py
+++ b/src/python/example/plot_alpha_complex.py
@@ -31,4 +31,7 @@ ax = fig.gca(projection='3d')
 ax.plot_trisurf(points[:,0], points[:,1], points[:,2], triangles=triangles)
 plt.show()
 
-# Third possibility: mayavi.mlab.triangular_mesh
+# Third possibility: mayavi
+from mayavi import mlab
+mlab.triangular_mesh(points[:,0], points[:,1], points[:,2], triangles);
+mlab.show()

--- a/src/python/example/plot_rips_complex.py
+++ b/src/python/example/plot_rips_complex.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+
+import numpy as np
+import gudhi
+points = np.array(gudhi.read_off('../../data/points/Kl.off'))
+rc = gudhi.RipsComplex(points=points, max_edge_length=.2)
+st = rc.create_simplex_tree(max_dimension=2)
+# We are only going to plot the triangles
+triangles = np.array([s[0] for s in st.get_skeleton(2) if len(s[0])==3])
+
+# First possibility: plotly
+import plotly.graph_objects as go
+fig = go.Figure(data=[
+    go.Mesh3d(
+        # Use the first 3 coordinates, but we could as easily pick others
+        x=points[:,0],
+        y=points[:,1],
+        z=points[:,2],
+        i = triangles[:,0],
+        j = triangles[:,1],
+        k = triangles[:,2],
+    )
+])
+fig.show()
+
+# Second possibility: matplotlib
+from mpl_toolkits.mplot3d import Axes3D
+import matplotlib.pyplot as plt
+fig = plt.figure()
+ax = fig.gca(projection='3d')
+ax.plot_trisurf(points[:,0], points[:,1], points[:,2], triangles=triangles)
+plt.show()
+
+# Third possibility: mayavi.mlab.triangular_mesh

--- a/src/python/example/plot_rips_complex.py
+++ b/src/python/example/plot_rips_complex.py
@@ -31,4 +31,8 @@ ax = fig.gca(projection='3d')
 ax.plot_trisurf(points[:,0], points[:,1], points[:,2], triangles=triangles)
 plt.show()
 
-# Third possibility: mayavi.mlab.triangular_mesh
+# Third possibility: mayavi
+# (this may take a while)
+from mayavi import mlab
+mlab.triangular_mesh(points[:,0], points[:,1], points[:,2], triangles);
+mlab.show()

--- a/src/python/example/plot_simplex_tree_dim012.py
+++ b/src/python/example/plot_simplex_tree_dim012.py
@@ -9,17 +9,37 @@ cplx=gudhi.SimplexTree()
 cplx.insert([1,2,3,5])
 cplx.insert([4,6])
 cplx.insert([0])
+triangles = np.array([s[0] for s in cplx.get_skeleton(2) if len(s[0])==3])
 
+## With matplotlib
+from mpl_toolkits.mplot3d import Axes3D
+from mpl_toolkits.mplot3d.art3d import Line3DCollection
+import matplotlib.pyplot as plt
+fig = plt.figure()
+ax = fig.gca(projection='3d')
+# Plot triangles
+ax.plot_trisurf(points[:,0], points[:,1], points[:,2], triangles=triangles)
+# Plot points
+ax.scatter3D(points[:,0], points[:,1], points[:,2])
+# Plot edges
+edges=[]
+for s in cplx.get_skeleton(1):
+    e = s[0]
+    if len(e) == 2:
+        edges.append(points[[e[0],e[1]]])
+ax.add_collection3d(Line3DCollection(segments=edges))
+plt.show()
+
+## With mayavi
 from mayavi import mlab
 # Plot triangles
-triangles = np.array([s[0] for s in cplx.get_skeleton(2) if len(s[0])==3])
 mlab.triangular_mesh(points[:,0], points[:,1], points[:,2], triangles);
+# Plot points
+mlab.points3d(points[:,0], points[:,1], points[:,2])
 # Plot edges
 for s in cplx.get_skeleton(1):
     e = s[0]
     if len(e) == 2:
         pts = points[[e[0],e[1]]]
         mlab.plot3d(pts[:,0],pts[:,1],pts[:,2],tube_radius=None)
-# Plot points
-mlab.points3d(points[:,0], points[:,1], points[:,2])
 mlab.show()

--- a/src/python/example/plot_simplex_tree_dim012.py
+++ b/src/python/example/plot_simplex_tree_dim012.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+import numpy as np
+import gudhi
+
+# Coordinates of the points
+points=np.array([[0,0,0],[1,0,0],[0,1,0],[0,0,1],[1,1,1],[1,1,0],[0,1,1]])
+# Build the simplicial complex with a tetrahedon, an edge and an isolated vertex
+cplx=gudhi.SimplexTree()
+cplx.insert([1,2,3,5])
+cplx.insert([4,6])
+cplx.insert([0])
+
+from mayavi import mlab
+# Plot triangles
+triangles = np.array([s[0] for s in cplx.get_skeleton(2) if len(s[0])==3])
+mlab.triangular_mesh(points[:,0], points[:,1], points[:,2], triangles);
+# Plot edges
+for s in cplx.get_skeleton(1):
+    e = s[0]
+    if len(e) == 2:
+        pts = points[[e[0],e[1]]]
+        mlab.plot3d(pts[:,0],pts[:,1],pts[:,2],tube_radius=None)
+# Plot points
+mlab.points3d(points[:,0], points[:,1], points[:,2])
+mlab.show()

--- a/src/python/example/plot_simplex_tree_dim012.py
+++ b/src/python/example/plot_simplex_tree_dim012.py
@@ -9,7 +9,36 @@ cplx=gudhi.SimplexTree()
 cplx.insert([1,2,3,5])
 cplx.insert([4,6])
 cplx.insert([0])
+# List of triangles (point indices)
 triangles = np.array([s[0] for s in cplx.get_skeleton(2) if len(s[0])==3])
+# List of edges (point coordinates)
+edges = []
+for s in cplx.get_skeleton(1):
+    e = s[0]
+    if len(e) == 2:
+        edges.append(points[[e[0],e[1]]])
+
+## With plotly
+import plotly.graph_objects as go
+# Plot triangles
+f2 = go.Mesh3d(
+        x=points[:,0],
+        y=points[:,1],
+        z=points[:,2],
+        i = triangles[:,0],
+        j = triangles[:,1],
+        k = triangles[:,2],
+    )
+# Plot points
+f0 = go.Scatter3d(x=points[:,0], y=points[:,1], z=points[:,2], mode="markers")
+data = [f2, f0]
+# Plot edges
+for pts in edges:
+    seg = go.Scatter3d(x=pts[:,0],y=pts[:,1],z=pts[:,2],mode="lines",line=dict(color='green'))
+    data.append(seg)
+fig = go.Figure(data=data,layout=dict(showlegend=False))
+# By default plotly would give each edge its own color and legend, that's too much
+fig.show()
 
 ## With matplotlib
 from mpl_toolkits.mplot3d import Axes3D
@@ -22,11 +51,6 @@ ax.plot_trisurf(points[:,0], points[:,1], points[:,2], triangles=triangles)
 # Plot points
 ax.scatter3D(points[:,0], points[:,1], points[:,2])
 # Plot edges
-edges=[]
-for s in cplx.get_skeleton(1):
-    e = s[0]
-    if len(e) == 2:
-        edges.append(points[[e[0],e[1]]])
 ax.add_collection3d(Line3DCollection(segments=edges))
 plt.show()
 
@@ -37,9 +61,6 @@ mlab.triangular_mesh(points[:,0], points[:,1], points[:,2], triangles);
 # Plot points
 mlab.points3d(points[:,0], points[:,1], points[:,2])
 # Plot edges
-for s in cplx.get_skeleton(1):
-    e = s[0]
-    if len(e) == 2:
-        pts = points[[e[0],e[1]]]
-        mlab.plot3d(pts[:,0],pts[:,1],pts[:,2],tube_radius=None)
+for pts in edges:
+    mlab.plot3d(pts[:,0],pts[:,1],pts[:,2],tube_radius=None)
 mlab.show()


### PR DESCRIPTION
I tried to show a few different python libraries that can do it.
It isn't clear to me if we should at some point provide a function (`SimplexTree.draw()`?) that does something like this. Mayavi is a pain to install (currently conda works, but not pip, and debian only has the python2 version) and can be very slow. Matplotlib can also be a bit slow. Plotly opens a web browser. And in all 3 cases it looks like a good idea to pass other options to the functions.