### PR TITLE
Add some `except +` for cython

### DIFF
--- a/src/python/example/alpha_complex_from_points_example.py
+++ b/src/python/example/alpha_complex_from_points_example.py
@@ -52,4 +52,9 @@ print("star([0])=", simplex_tree.get_star([0]))
 print("coface([0], 1)=", simplex_tree.get_cofaces([0], 1))
 
 print("point[0]=", alpha_complex.get_point(0))
-print("point[5]=", alpha_complex.get_point(5))
+try:
+    print("point[5]=", alpha_complex.get_point(5))
+except IndexError:
+    pass
+else:
+    assert False

--- a/src/python/gudhi/alpha_complex.pyx
+++ b/src/python/gudhi/alpha_complex.pyx
@@ -24,11 +24,11 @@ __license__ = "GPL v3"
 
 cdef extern from "Alpha_complex_interface.h" namespace "Gudhi":
     cdef cppclass Alpha_complex_interface "Gudhi::alpha_complex::Alpha_complex_interface":
-        Alpha_complex_interface(vector[vector[double]] points)
+        Alpha_complex_interface(vector[vector[double]] points) except +
         # bool from_file is a workaround for cython to find the correct signature
-        Alpha_complex_interface(string off_file, bool from_file)
-        vector[double] get_point(int vertex)
-        void create_simplex_tree(Simplex_tree_interface_full_featured* simplex_tree, double max_alpha_square)
+        Alpha_complex_interface(string off_file, bool from_file) except +
+        vector[double] get_point(int vertex) except +
+        void create_simplex_tree(Simplex_tree_interface_full_featured* simplex_tree, double max_alpha_square) except +
 
 # AlphaComplex python interface
 cdef class AlphaComplex:
@@ -96,8 +96,7 @@ cdef class AlphaComplex:
         :rtype: list of float
         :returns: the point.
         """
-        cdef vector[double] point = self.thisptr.get_point(vertex)
-        return point
+        return self.thisptr.get_point(vertex)
 
     def create_simplex_tree(self, max_alpha_square = float('inf')):
         """

--- a/src/python/gudhi/euclidean_strong_witness_complex.pyx
+++ b/src/python/gudhi/euclidean_strong_witness_complex.pyx
@@ -22,9 +22,9 @@ __license__ = "GPL v3"
 cdef extern from "Euclidean_strong_witness_complex_interface.h" namespace "Gudhi":
     cdef cppclass Euclidean_strong_witness_complex_interface "Gudhi::witness_complex::Euclidean_strong_witness_complex_interface":
         Euclidean_strong_witness_complex_interface(vector[vector[double]] landmarks, vector[vector[double]] witnesses)
-        void create_simplex_tree(Simplex_tree_interface_full_featured* simplex_tree, double max_alpha_square)
+        void create_simplex_tree(Simplex_tree_interface_full_featured* simplex_tree, double max_alpha_square) except +
         void create_simplex_tree(Simplex_tree_interface_full_featured* simplex_tree, double max_alpha_square,
-            unsigned limit_dimension)
+            unsigned limit_dimension) except +
         vector[double] get_point(unsigned vertex)
 
 # EuclideanStrongWitnessComplex python interface

--- a/src/python/gudhi/euclidean_witness_complex.pyx
+++ b/src/python/gudhi/euclidean_witness_complex.pyx
@@ -22,9 +22,9 @@ __license__ = "GPL v3"
 cdef extern from "Euclidean_witness_complex_interface.h" namespace "Gudhi":
     cdef cppclass Euclidean_witness_complex_interface "Gudhi::witness_complex::Euclidean_witness_complex_interface":
         Euclidean_witness_complex_interface(vector[vector[double]] landmarks, vector[vector[double]] witnesses)
-        void create_simplex_tree(Simplex_tree_interface_full_featured* simplex_tree, double max_alpha_square)
+        void create_simplex_tree(Simplex_tree_interface_full_featured* simplex_tree, double max_alpha_square) except +
         void create_simplex_tree(Simplex_tree_interface_full_featured* simplex_tree, double max_alpha_square,
-            unsigned limit_dimension)
+            unsigned limit_dimension) except +
         vector[double] get_point(unsigned vertex)
 
 # EuclideanWitnessComplex python interface

--- a/src/python/gudhi/rips_complex.pyx
+++ b/src/python/gudhi/rips_complex.pyx
@@ -28,7 +28,7 @@ cdef extern from "Rips_complex_interface.h" namespace "Gudhi":
         void init_matrix(vector[vector[double]] values, double threshold)
         void init_points_sparse(vector[vector[double]] values, double threshold, double sparse)
         void init_matrix_sparse(vector[vector[double]] values, double threshold, double sparse)
-        void create_simplex_tree(Simplex_tree_interface_full_featured* simplex_tree, int dim_max)
+        void create_simplex_tree(Simplex_tree_interface_full_featured* simplex_tree, int dim_max) except +
 
 # RipsComplex python interface
 cdef class RipsComplex:

--- a/src/python/gudhi/simplex_tree.pxd
+++ b/src/python/gudhi/simplex_tree.pxd
@@ -39,7 +39,7 @@ cdef extern from "Simplex_tree_interface.h" namespace "Gudhi":
         vector[pair[vector[int], double]] get_star(vector[int] simplex)
         vector[pair[vector[int], double]] get_cofaces(vector[int] simplex,
                                                           int dimension)
-        void expansion(int max_dim)
+        void expansion(int max_dim) except +
         void remove_maximal_simplex(vector[int] simplex)
         bool prune_above_filtration(double filtration)
         bool make_filtration_non_decreasing()

--- a/src/python/gudhi/strong_witness_complex.pyx
+++ b/src/python/gudhi/strong_witness_complex.pyx
@@ -22,9 +22,9 @@ __license__ = "MIT"
 cdef extern from "Strong_witness_complex_interface.h" namespace "Gudhi":
     cdef cppclass Strong_witness_complex_interface "Gudhi::witness_complex::Strong_witness_complex_interface":
         Strong_witness_complex_interface(vector[vector[pair[size_t, double]]] nearest_landmark_table)
-        void create_simplex_tree(Simplex_tree_interface_full_featured* simplex_tree, double max_alpha_square)
+        void create_simplex_tree(Simplex_tree_interface_full_featured* simplex_tree, double max_alpha_square) except +
         void create_simplex_tree(Simplex_tree_interface_full_featured* simplex_tree, double max_alpha_square,
-            unsigned limit_dimension)
+            unsigned limit_dimension) except +
 
 # StrongWitnessComplex python interface
 cdef class StrongWitnessComplex:

--- a/src/python/gudhi/witness_complex.pyx
+++ b/src/python/gudhi/witness_complex.pyx
@@ -22,9 +22,9 @@ __license__ = "MIT"
 cdef extern from "Witness_complex_interface.h" namespace "Gudhi":
     cdef cppclass Witness_complex_interface "Gudhi::witness_complex::Witness_complex_interface":
         Witness_complex_interface(vector[vector[pair[size_t, double]]] nearest_landmark_table)
-        void create_simplex_tree(Simplex_tree_interface_full_featured* simplex_tree, double max_alpha_square)
+        void create_simplex_tree(Simplex_tree_interface_full_featured* simplex_tree, double max_alpha_square) except +
         void create_simplex_tree(Simplex_tree_interface_full_featured* simplex_tree, double max_alpha_square,
-            unsigned limit_dimension)
+            unsigned limit_dimension) except +
 
 # WitnessComplex python interface
 cdef class WitnessComplex:

--- a/src/python/include/Alpha_complex_interface.h
+++ b/src/python/include/Alpha_complex_interface.h
@@ -50,13 +50,9 @@ class Alpha_complex_interface {
 
   std::vector<double> get_point(int vh) {
     std::vector<double> vd;
-    try {
-      Point_d const& ph = alpha_complex_->get_point(vh);
-      for (auto coord = ph.cartesian_begin(); coord != ph.cartesian_end(); coord++)
-        vd.push_back(CGAL::to_double(*coord));
-    } catch (std::out_of_range const&) {
-      // std::out_of_range is thrown in case not found. Other exceptions must be re-thrown
-    }
+    Point_d const& ph = alpha_complex_->get_point(vh);
+    for (auto coord = ph.cartesian_begin(); coord != ph.cartesian_end(); coord++)
+      vd.push_back(CGAL::to_double(*coord));
     return vd;
   }
 

--- a/src/python/test/test_alpha_complex.py
+++ b/src/python/test/test_alpha_complex.py
@@ -65,8 +65,18 @@ def test_infinite_alpha():
     assert point_list[1] == alpha_complex.get_point(1)
     assert point_list[2] == alpha_complex.get_point(2)
     assert point_list[3] == alpha_complex.get_point(3)
-    assert alpha_complex.get_point(4) == []
-    assert alpha_complex.get_point(125) == []
+    try:
+        alpha_complex.get_point(4) == []
+    except IndexError:
+        pass
+    else:
+        assert False
+    try:
+        alpha_complex.get_point(125) == []
+    except IndexError:
+        pass
+    else:
+        assert False
 
 
 def test_filtered_alpha():
@@ -82,8 +92,18 @@ def test_filtered_alpha():
     assert point_list[1] == filtered_alpha.get_point(1)
     assert point_list[2] == filtered_alpha.get_point(2)
     assert point_list[3] == filtered_alpha.get_point(3)
-    assert filtered_alpha.get_point(4) == []
-    assert filtered_alpha.get_point(125) == []
+    try:
+        filtered_alpha.get_point(4) == []
+    except IndexError:
+        pass
+    else:
+        assert False
+    try:
+        filtered_alpha.get_point(125) == []
+    except IndexError:
+        pass
+    else:
+        assert False
 
     assert simplex_tree.get_filtration() == [
         ([0], 0.0),


### PR DESCRIPTION
I just added a few, I haven't tested many yet.
Strangely, doing a parallel build with
> python3 setup.py build_ext --inplace -j20

breaks the exception conversion for get_point in AlphaComplex, and rebuilding just this module makes it work. Serial builds also work.

From issue #116.