### PR TITLE
Fix #118 - protect some bottleneck tests

### DIFF
--- a/src/Bottleneck_distance/test/bottleneck_unit_test.cpp
+++ b/src/Bottleneck_distance/test/bottleneck_unit_test.cpp
@@ -15,6 +15,7 @@
 
 #include <random>
 #include <gudhi/Bottleneck.h>
+#include <gudhi/Unitary_tests_utils.h>
 
 using namespace Gudhi::persistence_diagram;
 
@@ -59,24 +60,24 @@ BOOST_AUTO_TEST_CASE(persistence_graph) {
   BOOST_CHECK(g.size() == (n1 + n2));
   //
   BOOST_CHECK((int) d.size() == (n1 + n2)*(n1 + n2) + n1 + n2 + 1);
-  BOOST_CHECK(std::count(d.begin(), d.end(), g.distance(0, 0)) > 0);
-  BOOST_CHECK(std::count(d.begin(), d.end(), g.distance(0, n1 - 1)) > 0);
-  BOOST_CHECK(std::count(d.begin(), d.end(), g.distance(0, n1)) > 0);
-  BOOST_CHECK(std::count(d.begin(), d.end(), g.distance(0, n2 - 1)) > 0);
-  BOOST_CHECK(std::count(d.begin(), d.end(), g.distance(0, n2)) > 0);
-  BOOST_CHECK(std::count(d.begin(), d.end(), g.distance(0, (n1 + n2) - 1)) > 0);
-  BOOST_CHECK(std::count(d.begin(), d.end(), g.distance(n1, 0)) > 0);
-  BOOST_CHECK(std::count(d.begin(), d.end(), g.distance(n1, n1 - 1)) > 0);
-  BOOST_CHECK(std::count(d.begin(), d.end(), g.distance(n1, n1)) > 0);
-  BOOST_CHECK(std::count(d.begin(), d.end(), g.distance(n1, n2 - 1)) > 0);
-  BOOST_CHECK(std::count(d.begin(), d.end(), g.distance(n1, n2)) > 0);
-  BOOST_CHECK(std::count(d.begin(), d.end(), g.distance(n1, (n1 + n2) - 1)) > 0);
-  BOOST_CHECK(std::count(d.begin(), d.end(), g.distance((n1 + n2) - 1, 0)) > 0);
-  BOOST_CHECK(std::count(d.begin(), d.end(), g.distance((n1 + n2) - 1, n1 - 1)) > 0);
-  BOOST_CHECK(std::count(d.begin(), d.end(), g.distance((n1 + n2) - 1, n1)) > 0);
-  BOOST_CHECK(std::count(d.begin(), d.end(), g.distance((n1 + n2) - 1, n2 - 1)) > 0);
-  BOOST_CHECK(std::count(d.begin(), d.end(), g.distance((n1 + n2) - 1, n2)) > 0);
-  BOOST_CHECK(std::count(d.begin(), d.end(), g.distance((n1 + n2) - 1, (n1 + n2) - 1)) > 0);
+  BOOST_CHECK(std::count(d.begin(), d.end(), GUDHI_PROTECT_FLOAT(g.distance(0, 0))) > 0);
+  BOOST_CHECK(std::count(d.begin(), d.end(), GUDHI_PROTECT_FLOAT(g.distance(0, n1 - 1))) > 0);
+  BOOST_CHECK(std::count(d.begin(), d.end(), GUDHI_PROTECT_FLOAT(g.distance(0, n1))) > 0);
+  BOOST_CHECK(std::count(d.begin(), d.end(), GUDHI_PROTECT_FLOAT(g.distance(0, n2 - 1))) > 0);
+  BOOST_CHECK(std::count(d.begin(), d.end(), GUDHI_PROTECT_FLOAT(g.distance(0, n2))) > 0);
+  BOOST_CHECK(std::count(d.begin(), d.end(), GUDHI_PROTECT_FLOAT(g.distance(0, (n1 + n2) - 1))) > 0);
+  BOOST_CHECK(std::count(d.begin(), d.end(), GUDHI_PROTECT_FLOAT(g.distance(n1, 0))) > 0);
+  BOOST_CHECK(std::count(d.begin(), d.end(), GUDHI_PROTECT_FLOAT(g.distance(n1, n1 - 1))) > 0);
+  BOOST_CHECK(std::count(d.begin(), d.end(), GUDHI_PROTECT_FLOAT(g.distance(n1, n1))) > 0);
+  BOOST_CHECK(std::count(d.begin(), d.end(), GUDHI_PROTECT_FLOAT(g.distance(n1, n2 - 1))) > 0);
+  BOOST_CHECK(std::count(d.begin(), d.end(), GUDHI_PROTECT_FLOAT(g.distance(n1, n2))) > 0);
+  BOOST_CHECK(std::count(d.begin(), d.end(), GUDHI_PROTECT_FLOAT(g.distance(n1, (n1 + n2) - 1))) > 0);
+  BOOST_CHECK(std::count(d.begin(), d.end(), GUDHI_PROTECT_FLOAT(g.distance((n1 + n2) - 1, 0))) > 0);
+  BOOST_CHECK(std::count(d.begin(), d.end(), GUDHI_PROTECT_FLOAT(g.distance((n1 + n2) - 1, n1 - 1))) > 0);
+  BOOST_CHECK(std::count(d.begin(), d.end(), GUDHI_PROTECT_FLOAT(g.distance((n1 + n2) - 1, n1))) > 0);
+  BOOST_CHECK(std::count(d.begin(), d.end(), GUDHI_PROTECT_FLOAT(g.distance((n1 + n2) - 1, n2 - 1))) > 0);
+  BOOST_CHECK(std::count(d.begin(), d.end(), GUDHI_PROTECT_FLOAT(g.distance((n1 + n2) - 1, n2))) > 0);
+  BOOST_CHECK(std::count(d.begin(), d.end(), GUDHI_PROTECT_FLOAT(g.distance((n1 + n2) - 1, (n1 + n2) - 1))) > 0);
 }
 
 BOOST_AUTO_TEST_CASE(neighbors_finder) {

--- a/src/Persistence_representations/include/gudhi/Persistence_intervals.h
+++ b/src/Persistence_representations/include/gudhi/Persistence_intervals.h
@@ -6,6 +6,8 @@
  *
  *    Modification(s):
  *      - YYYY/MM Author: Description of the modification
+ *      - 2019/12 Vincent Rouvreau: Fix #118 - Make histogram_of_lengths and cumulative_histogram_of_lengths
+ *          return the exact number_of_bins (was failing on x86)
  */
 
 #ifndef PERSISTENCE_INTERVALS_H_
@@ -335,6 +337,9 @@ std::vector<size_t> Persistence_intervals::histogram_of_lengths(size_t number_of
       getchar();
     }
   }
+  // we want number of bins equals to number_of_bins (some unexpected results on x86)
+  result[number_of_bins-1]+=result[number_of_bins];
+  result.resize(number_of_bins);
 
   if (dbg) {
     for (size_t i = 0; i != result.size(); ++i) std::cerr << result[i] << std::endl;

--- a/src/Persistence_representations/test/persistence_intervals_test.cpp
+++ b/src/Persistence_representations/test/persistence_intervals_test.cpp
@@ -6,6 +6,8 @@
  *
  *    Modification(s):
  *      - YYYY/MM Author: Description of the modification
+ *      - 2019/12 Vincent Rouvreau: Fix #118 - Make histogram_of_lengths and cumulative_histogram_of_lengths
+ *          return the exact number_of_bins (was failing on x86)
  */
 
 #define BOOST_TEST_DYN_LINK
@@ -32,17 +34,8 @@ BOOST_AUTO_TEST_CASE(check_min_max_function) {
 BOOST_AUTO_TEST_CASE(check_length_of_dominant_intervals) {
   Persistence_intervals p("data/file_with_diagram");
   std::vector<double> dominant_ten_intervals_length = p.length_of_dominant_intervals(10);
-  std::vector<double> dominant_intervals_length;
-  dominant_intervals_length.push_back(0.862625);
-  dominant_intervals_length.push_back(0.800893);
-  dominant_intervals_length.push_back(0.762061);
-  dominant_intervals_length.push_back(0.756501);
-  dominant_intervals_length.push_back(0.729367);
-  dominant_intervals_length.push_back(0.718177);
-  dominant_intervals_length.push_back(0.708395);
-  dominant_intervals_length.push_back(0.702844);
-  dominant_intervals_length.push_back(0.700468);
-  dominant_intervals_length.push_back(0.622177);
+  std::vector<double> dominant_intervals_length{0.862625, 0.800893, 0.762061, 0.756501, 0.729367,
+                                                0.718177, 0.708395, 0.702844, 0.700468, 0.622177};
   for (size_t i = 0; i != dominant_ten_intervals_length.size(); ++i) {
     GUDHI_TEST_FLOAT_EQUALITY_CHECK(dominant_ten_intervals_length[i], dominant_intervals_length[i],
                                     Gudhi::Persistence_representations::epsi);
@@ -52,17 +45,11 @@ BOOST_AUTO_TEST_CASE(check_dominant_intervals) {
   Persistence_intervals p("data/file_with_diagram");
   std::vector<std::pair<double, double> > ten_dominant_intervals = p.dominant_intervals(10);
 
-  std::vector<std::pair<double, double> > templ;
-  templ.push_back(std::pair<double, double>(0.114718, 0.977343));
-  templ.push_back(std::pair<double, double>(0.133638, 0.93453));
-  templ.push_back(std::pair<double, double>(0.104599, 0.866659));
-  templ.push_back(std::pair<double, double>(0.149798, 0.906299));
-  templ.push_back(std::pair<double, double>(0.247352, 0.976719));
-  templ.push_back(std::pair<double, double>(0.192675, 0.910852));
-  templ.push_back(std::pair<double, double>(0.191836, 0.900231));
-  templ.push_back(std::pair<double, double>(0.284998, 0.987842));
-  templ.push_back(std::pair<double, double>(0.294069, 0.994537));
-  templ.push_back(std::pair<double, double>(0.267421, 0.889597));
+  std::vector<std::pair<double, double> > templ{ {0.114718, 0.977343}, {0.133638, 0.93453},
+                                                 {0.104599, 0.866659}, {0.149798, 0.906299},
+                                                 {0.247352, 0.976719}, {0.192675, 0.910852},
+                                                 {0.191836, 0.900231}, {0.284998, 0.987842},
+                                                 {0.294069, 0.994537}, {0.267421, 0.889597} };
 
   for (size_t i = 0; i != ten_dominant_intervals.size(); ++i) {
     GUDHI_TEST_FLOAT_EQUALITY_CHECK(ten_dominant_intervals[i].first, templ[i].first,
@@ -75,17 +62,7 @@ BOOST_AUTO_TEST_CASE(check_dominant_intervals) {
 BOOST_AUTO_TEST_CASE(check_histogram_of_lengths) {
   Persistence_intervals p("data/file_with_diagram");
   std::vector<size_t> histogram = p.histogram_of_lengths(10);
-  std::vector<size_t> template_histogram;
-  template_histogram.push_back(10);
-  template_histogram.push_back(5);
-  template_histogram.push_back(3);
-  template_histogram.push_back(4);
-  template_histogram.push_back(4);
-  template_histogram.push_back(3);
-  template_histogram.push_back(6);
-  template_histogram.push_back(1);
-  template_histogram.push_back(7);
-  template_histogram.push_back(2);
+  std::vector<size_t> template_histogram{10, 5, 3, 4, 4, 3, 6, 1, 7, 2};
   for (size_t i = 0; i != histogram.size(); ++i) {
     BOOST_CHECK(histogram[i] == template_histogram[i]);
   }
@@ -94,17 +71,7 @@ BOOST_AUTO_TEST_CASE(check_histogram_of_lengths) {
 BOOST_AUTO_TEST_CASE(check_cumulative_histograms_of_lengths) {
   Persistence_intervals p("data/file_with_diagram");
   std::vector<size_t> cumulative_histogram = p.cumulative_histogram_of_lengths(10);
-  std::vector<size_t> template_cumulative_histogram;
-  template_cumulative_histogram.push_back(10);
-  template_cumulative_histogram.push_back(15);
-  template_cumulative_histogram.push_back(18);
-  template_cumulative_histogram.push_back(22);
-  template_cumulative_histogram.push_back(26);
-  template_cumulative_histogram.push_back(29);
-  template_cumulative_histogram.push_back(35);
-  template_cumulative_histogram.push_back(36);
-  template_cumulative_histogram.push_back(43);
-  template_cumulative_histogram.push_back(45);
+  std::vector<size_t> template_cumulative_histogram{10, 15, 18, 22, 26, 29, 35, 36, 43, 45};
 
   for (size_t i = 0; i != cumulative_histogram.size(); ++i) {
     BOOST_CHECK(cumulative_histogram[i] == template_cumulative_histogram[i]);
@@ -114,17 +81,8 @@ BOOST_AUTO_TEST_CASE(check_characteristic_function_of_diagram) {
   Persistence_intervals p("data/file_with_diagram");
   std::pair<double, double> min_max_ = p.get_x_range();
   std::vector<double> char_funct_diag = p.characteristic_function_of_diagram(min_max_.first, min_max_.second);
-  std::vector<double> template_char_funct_diag;
-  template_char_funct_diag.push_back(0.370665);
-  template_char_funct_diag.push_back(0.84058);
-  template_char_funct_diag.push_back(1.24649);
-  template_char_funct_diag.push_back(1.3664);
-  template_char_funct_diag.push_back(1.34032);
-  template_char_funct_diag.push_back(1.31904);
-  template_char_funct_diag.push_back(1.14076);
-  template_char_funct_diag.push_back(0.991259);
-  template_char_funct_diag.push_back(0.800714);
-  template_char_funct_diag.push_back(0.0676303);
+  std::vector<double> template_char_funct_diag{0.370665, 0.84058, 1.24649, 1.3664, 1.34032,
+                                               1.31904, 1.14076, 0.991259, 0.800714, 0.0676303};
 
   for (size_t i = 0; i != char_funct_diag.size(); ++i) {
     GUDHI_TEST_FLOAT_EQUALITY_CHECK(char_funct_diag[i], template_char_funct_diag[i],
@@ -137,18 +95,8 @@ BOOST_AUTO_TEST_CASE(check_cumulative_characteristic_function_of_diagram) {
   std::pair<double, double> min_max_ = p.get_x_range();
   std::vector<double> cumul_char_funct_diag =
       p.cumulative_characteristic_function_of_diagram(min_max_.first, min_max_.second);
-  std::vector<double> template_char_funct_diag_cumul;
-
-  template_char_funct_diag_cumul.push_back(0.370665);
-  template_char_funct_diag_cumul.push_back(1.21125);
-  template_char_funct_diag_cumul.push_back(2.45774);
-  template_char_funct_diag_cumul.push_back(3.82414);
-  template_char_funct_diag_cumul.push_back(5.16446);
-  template_char_funct_diag_cumul.push_back(6.4835);
-  template_char_funct_diag_cumul.push_back(7.62426);
-  template_char_funct_diag_cumul.push_back(8.61552);
-  template_char_funct_diag_cumul.push_back(9.41623);
-  template_char_funct_diag_cumul.push_back(9.48386);
+  std::vector<double> template_char_funct_diag_cumul{0.370665, 1.21125, 2.45774, 3.82414, 5.16446,
+                                                     6.4835, 7.62426, 8.61552, 9.41623, 9.48386};
 
   for (size_t i = 0; i != cumul_char_funct_diag.size(); ++i) {
     GUDHI_TEST_FLOAT_EQUALITY_CHECK(cumul_char_funct_diag[i], template_char_funct_diag_cumul[i],
@@ -158,97 +106,29 @@ BOOST_AUTO_TEST_CASE(check_cumulative_characteristic_function_of_diagram) {
 
 BOOST_AUTO_TEST_CASE(check_compute_persistent_betti_numbers) {
   Persistence_intervals p("data/file_with_diagram");
-  std::vector<std::pair<double, size_t> > pbns;
-  pbns.push_back(std::pair<double, size_t>(0.0290362, 1));
-  pbns.push_back(std::pair<double, size_t>(0.0307676, 2));
-  pbns.push_back(std::pair<double, size_t>(0.0366312, 3));
-  pbns.push_back(std::pair<double, size_t>(0.0544614, 4));
-  pbns.push_back(std::pair<double, size_t>(0.0920033, 5));
-  pbns.push_back(std::pair<double, size_t>(0.104599, 6));
-  pbns.push_back(std::pair<double, size_t>(0.114718, 7));
-  pbns.push_back(std::pair<double, size_t>(0.117379, 8));
-  pbns.push_back(std::pair<double, size_t>(0.123493, 9));
-  pbns.push_back(std::pair<double, size_t>(0.133638, 10));
-  pbns.push_back(std::pair<double, size_t>(0.137798, 9));
-  pbns.push_back(std::pair<double, size_t>(0.149798, 10));
-  pbns.push_back(std::pair<double, size_t>(0.155421, 11));
-  pbns.push_back(std::pair<double, size_t>(0.158443, 12));
-  pbns.push_back(std::pair<double, size_t>(0.176956, 13));
-  pbns.push_back(std::pair<double, size_t>(0.183234, 12));
-  pbns.push_back(std::pair<double, size_t>(0.191069, 13));
-  pbns.push_back(std::pair<double, size_t>(0.191333, 14));
-  pbns.push_back(std::pair<double, size_t>(0.191836, 15));
-  pbns.push_back(std::pair<double, size_t>(0.192675, 16));
-  pbns.push_back(std::pair<double, size_t>(0.208564, 17));
-  pbns.push_back(std::pair<double, size_t>(0.218425, 18));
-  pbns.push_back(std::pair<double, size_t>(0.219902, 17));
-  pbns.push_back(std::pair<double, size_t>(0.23233, 16));
-  pbns.push_back(std::pair<double, size_t>(0.234558, 17));
-  pbns.push_back(std::pair<double, size_t>(0.237166, 16));
-  pbns.push_back(std::pair<double, size_t>(0.247352, 17));
-  pbns.push_back(std::pair<double, size_t>(0.267421, 18));
-  pbns.push_back(std::pair<double, size_t>(0.268093, 19));
-  pbns.push_back(std::pair<double, size_t>(0.278734, 18));
-  pbns.push_back(std::pair<double, size_t>(0.284722, 19));
-  pbns.push_back(std::pair<double, size_t>(0.284998, 20));
-  pbns.push_back(std::pair<double, size_t>(0.294069, 21));
-  pbns.push_back(std::pair<double, size_t>(0.306293, 22));
-  pbns.push_back(std::pair<double, size_t>(0.322361, 21));
-  pbns.push_back(std::pair<double, size_t>(0.323152, 22));
-  pbns.push_back(std::pair<double, size_t>(0.371021, 23));
-  pbns.push_back(std::pair<double, size_t>(0.372395, 24));
-  pbns.push_back(std::pair<double, size_t>(0.387744, 25));
-  pbns.push_back(std::pair<double, size_t>(0.435537, 26));
-  pbns.push_back(std::pair<double, size_t>(0.462911, 25));
-  pbns.push_back(std::pair<double, size_t>(0.483569, 26));
-  pbns.push_back(std::pair<double, size_t>(0.489209, 25));
-  pbns.push_back(std::pair<double, size_t>(0.517115, 24));
-  pbns.push_back(std::pair<double, size_t>(0.522197, 23));
-  pbns.push_back(std::pair<double, size_t>(0.532665, 22));
-  pbns.push_back(std::pair<double, size_t>(0.545262, 23));
-  pbns.push_back(std::pair<double, size_t>(0.587227, 22));
-  pbns.push_back(std::pair<double, size_t>(0.593036, 23));
-  pbns.push_back(std::pair<double, size_t>(0.602647, 24));
-  pbns.push_back(std::pair<double, size_t>(0.605044, 25));
-  pbns.push_back(std::pair<double, size_t>(0.621962, 24));
-  pbns.push_back(std::pair<double, size_t>(0.629449, 23));
-  pbns.push_back(std::pair<double, size_t>(0.636719, 22));
-  pbns.push_back(std::pair<double, size_t>(0.64957, 21));
-  pbns.push_back(std::pair<double, size_t>(0.650781, 22));
-  pbns.push_back(std::pair<double, size_t>(0.654951, 23));
-  pbns.push_back(std::pair<double, size_t>(0.683489, 24));
-  pbns.push_back(std::pair<double, size_t>(0.687172, 23));
-  pbns.push_back(std::pair<double, size_t>(0.69703, 22));
-  pbns.push_back(std::pair<double, size_t>(0.701174, 21));
-  pbns.push_back(std::pair<double, size_t>(0.717623, 22));
-  pbns.push_back(std::pair<double, size_t>(0.722023, 21));
-  pbns.push_back(std::pair<double, size_t>(0.722298, 20));
-  pbns.push_back(std::pair<double, size_t>(0.725347, 19));
-  pbns.push_back(std::pair<double, size_t>(0.73071, 18));
-  pbns.push_back(std::pair<double, size_t>(0.758355, 17));
-  pbns.push_back(std::pair<double, size_t>(0.770913, 18));
-  pbns.push_back(std::pair<double, size_t>(0.790833, 17));
-  pbns.push_back(std::pair<double, size_t>(0.821211, 16));
-  pbns.push_back(std::pair<double, size_t>(0.849305, 17));
-  pbns.push_back(std::pair<double, size_t>(0.853669, 16));
-  pbns.push_back(std::pair<double, size_t>(0.866659, 15));
-  pbns.push_back(std::pair<double, size_t>(0.872896, 16));
-  pbns.push_back(std::pair<double, size_t>(0.889597, 15));
-  pbns.push_back(std::pair<double, size_t>(0.900231, 14));
-  pbns.push_back(std::pair<double, size_t>(0.903847, 13));
-  pbns.push_back(std::pair<double, size_t>(0.906299, 12));
-  pbns.push_back(std::pair<double, size_t>(0.910852, 11));
-  pbns.push_back(std::pair<double, size_t>(0.93453, 10));
-  pbns.push_back(std::pair<double, size_t>(0.944757, 9));
-  pbns.push_back(std::pair<double, size_t>(0.947812, 8));
-  pbns.push_back(std::pair<double, size_t>(0.959154, 7));
-  pbns.push_back(std::pair<double, size_t>(0.975654, 6));
-  pbns.push_back(std::pair<double, size_t>(0.976719, 5));
-  pbns.push_back(std::pair<double, size_t>(0.977343, 4));
-  pbns.push_back(std::pair<double, size_t>(0.980129, 3));
-  pbns.push_back(std::pair<double, size_t>(0.987842, 2));
-  pbns.push_back(std::pair<double, size_t>(0.990127, 1));
-  pbns.push_back(std::pair<double, size_t>(0.994537, 0));
+  std::vector<std::pair<double, size_t> > pbns{ {0.0290362, 1}, {0.0307676, 2}, {0.0366312, 3}, {0.0544614, 4},
+                                                {0.0920033, 5}, {0.104599, 6}, {0.114718, 7}, {0.117379, 8},
+                                                {0.123493, 9}, {0.133638, 10}, {0.137798, 9}, {0.149798, 10},
+                                                {0.155421, 11}, {0.158443, 12}, {0.176956, 13}, {0.183234, 12},
+                                                {0.191069, 13}, {0.191333, 14}, {0.191836, 15}, {0.192675, 16},
+                                                {0.208564, 17}, {0.218425, 18}, {0.219902, 17}, {0.23233, 16},
+                                                {0.234558, 17}, {0.237166, 16}, {0.247352, 17}, {0.267421, 18},
+                                                {0.268093, 19}, {0.278734, 18}, {0.284722, 19}, {0.284998, 20},
+                                                {0.294069, 21}, {0.306293, 22}, {0.322361, 21}, {0.323152, 22},
+                                                {0.371021, 23}, {0.372395, 24}, {0.387744, 25}, {0.435537, 26},
+                                                {0.462911, 25}, {0.483569, 26}, {0.489209, 25}, {0.517115, 24},
+                                                {0.522197, 23}, {0.532665, 22}, {0.545262, 23}, {0.587227, 22},
+                                                {0.593036, 23}, {0.602647, 24}, {0.605044, 25}, {0.621962, 24},
+                                                {0.629449, 23}, {0.636719, 22}, {0.64957, 21}, {0.650781, 22},
+                                                {0.654951, 23}, {0.683489, 24}, {0.687172, 23}, {0.69703, 22},
+                                                {0.701174, 21}, {0.717623, 22}, {0.722023, 21}, {0.722298, 20},
+                                                {0.725347, 19}, {0.73071, 18}, {0.758355, 17}, {0.770913, 18},
+                                                {0.790833, 17}, {0.821211, 16}, {0.849305, 17}, {0.853669, 16},
+                                                {0.866659, 15}, {0.872896, 16}, {0.889597, 15}, {0.900231, 14},
+                                                {0.903847, 13}, {0.906299, 12}, {0.910852, 11}, {0.93453, 10},
+                                                {0.944757, 9}, {0.947812, 8}, {0.959154, 7}, {0.975654, 6},
+                                                {0.976719, 5}, {0.977343, 4}, {0.980129, 3}, {0.987842, 2},
+                                                {0.990127, 1}, {0.994537, 0} };
 
   std::vector<std::pair<double, size_t> > pbns_new = p.compute_persistent_betti_numbers();
   for (size_t i = 0; i != pbns.size(); ++i) {
@@ -260,17 +140,8 @@ BOOST_AUTO_TEST_CASE(check_compute_persistent_betti_numbers) {
 BOOST_AUTO_TEST_CASE(check_k_n_n) {
   Persistence_intervals p("data/file_with_diagram");
   std::vector<double> knn = p.k_n_n(5);
-  std::vector<double> knn_template;
-  knn_template.push_back(1.04208);
-  knn_template.push_back(1.00344);
-  knn_template.push_back(0.979395);
-  knn_template.push_back(0.890643);
-  knn_template.push_back(0.874769);
-  knn_template.push_back(0.845787);
-  knn_template.push_back(0.819713);
-  knn_template.push_back(0.803984);
-  knn_template.push_back(0.799864);
-  knn_template.push_back(0.786945);
+  std::vector<double> knn_template{1.04208, 1.00344, 0.979395, 0.890643, 0.874769,
+                                   0.845787, 0.819713, 0.803984, 0.799864, 0.786945};
 
   for (size_t i = 0; i != knn.size(); ++i) {
     GUDHI_TEST_FLOAT_EQUALITY_CHECK(knn[i], knn_template[i], Gudhi::Persistence_representations::epsi);

--- a/src/Persistence_representations/test/persistence_intervals_test.cpp
+++ b/src/Persistence_representations/test/persistence_intervals_test.cpp
@@ -85,8 +85,7 @@ BOOST_AUTO_TEST_CASE(check_histogram_of_lengths) {
   template_histogram.push_back(6);
   template_histogram.push_back(1);
   template_histogram.push_back(7);
-  template_histogram.push_back(1);
-  template_histogram.push_back(1);
+  template_histogram.push_back(2);
   for (size_t i = 0; i != histogram.size(); ++i) {
     BOOST_CHECK(histogram[i] == template_histogram[i]);
   }
@@ -105,7 +104,6 @@ BOOST_AUTO_TEST_CASE(check_cumulative_histograms_of_lengths) {
   template_cumulative_histogram.push_back(35);
   template_cumulative_histogram.push_back(36);
   template_cumulative_histogram.push_back(43);
-  template_cumulative_histogram.push_back(44);
   template_cumulative_histogram.push_back(45);
 
   for (size_t i = 0; i != cumulative_histogram.size(); ++i) {

--- a/src/common/include/gudhi/Unitary_tests_utils.h
+++ b/src/common/include/gudhi/Unitary_tests_utils.h
@@ -26,4 +26,15 @@ void GUDHI_TEST_FLOAT_EQUALITY_CHECK(FloatingType a, FloatingType b,
   BOOST_CHECK(std::fabs(a - b) <= epsilon);
 }
 
+// That's the usual x86 issue where a+b==a+b can return false (without any NaN) because one of them was stored in
+// memory (and thus rounded to 64 bits) while the other is still in a register (80 bits).
+template<typename FloatingType >
+FloatingType GUDHI_PROTECT_FLOAT(FloatingType value) {
+  volatile FloatingType protected_value = value;
+#ifdef DEBUG_TRACES
+  std::cout << "GUDHI_PROTECT_FLOAT - " << protected_value << std::endl;
+#endif
+  return protected_value;
+}
+
 #endif  // UNITARY_TESTS_UTILS_H_


### PR DESCRIPTION
Do you have an idea of what needs to be protected on persistence_intervals_test ?
I have no x86 available for the moment.
Fix #118 