### PR TITLE
#2: add a simplex iterator in Python

### DIFF
--- a/src/python/gudhi/simplex_tree.pxd
+++ b/src/python/gudhi/simplex_tree.pxd
@@ -18,6 +18,8 @@ __author__ = "Vincent Rouvreau"
 __copyright__ = "Copyright (C) 2016 Inria"
 __license__ = "MIT"
 
+# TODO: add cdef for SimplexTreeIterator ...
+
 cdef extern from "Simplex_tree_interface.h" namespace "Gudhi":
     cdef cppclass Simplex_tree_options_full_featured:
         pass

--- a/src/python/gudhi/simplex_tree.pxd
+++ b/src/python/gudhi/simplex_tree.pxd
@@ -35,6 +35,7 @@ cdef extern from "Simplex_tree_interface.h" namespace "Gudhi":
         bool find_simplex(vector[int] simplex)
         bool insert_simplex_and_subfaces(vector[int] simplex,
                                          double filtration)
+        pair[vector[int], double] get_next_in_filtration()
         vector[pair[vector[int], double]] get_filtration()
         vector[pair[vector[int], double]] get_skeleton(int dimension)
         vector[pair[vector[int], double]] get_star(vector[int] simplex)

--- a/src/python/gudhi/simplex_tree.pxd
+++ b/src/python/gudhi/simplex_tree.pxd
@@ -35,9 +35,8 @@ cdef extern from "Simplex_tree_interface.h" namespace "Gudhi":
         bool find_simplex(vector[int] simplex)
         bool insert_simplex_and_subfaces(vector[int] simplex,
                                          double filtration)
-        long get_filtration_iterator()
-        pair[vector[int], double] get_next_in_filtration(long psti)
-        void end_filtration_iteration(long psti)
+        int init_or_stop_iteration(int key)
+        pair[vector[int], double] get_next_in_filtration(int key)
         vector[pair[vector[int], double]] get_filtration()
         vector[pair[vector[int], double]] get_skeleton(int dimension)
         vector[pair[vector[int], double]] get_star(vector[int] simplex)

--- a/src/python/gudhi/simplex_tree.pxd
+++ b/src/python/gudhi/simplex_tree.pxd
@@ -18,8 +18,6 @@ __author__ = "Vincent Rouvreau"
 __copyright__ = "Copyright (C) 2016 Inria"
 __license__ = "MIT"
 
-# TODO: add cdef for SimplexTreeIterator ...
-
 cdef extern from "Simplex_tree_interface.h" namespace "Gudhi":
     cdef cppclass Simplex_tree_options_full_featured:
         pass
@@ -37,7 +35,9 @@ cdef extern from "Simplex_tree_interface.h" namespace "Gudhi":
         bool find_simplex(vector[int] simplex)
         bool insert_simplex_and_subfaces(vector[int] simplex,
                                          double filtration)
-        pair[vector[int], double] get_next_in_filtration()
+        long get_filtration_iterator()
+        pair[vector[int], double] get_next_in_filtration(long psti)
+        void end_filtration_iteration(long psti)
         vector[pair[vector[int], double]] get_filtration()
         vector[pair[vector[int], double]] get_skeleton(int dimension)
         vector[pair[vector[int], double]] get_star(vector[int] simplex)

--- a/src/python/gudhi/simplex_tree.pyx
+++ b/src/python/gudhi/simplex_tree.pyx
@@ -19,11 +19,14 @@ cdef class SimplexTreeIterator:
     cdef intptr_t _sti;
     cdef SimplexTree _st;
 
+    cdef do_init(self):
+        self._st.get_ptr().initialize_filtration()
+        self._sti = self._st.get_ptr().get_filtration_iterator()
+
     """Iterator class for SimplexTree"""
     def __init__(self, st):
         self._st = st
-        st.get_ptr().initialize_filtration()
-        self._sti = st.get_ptr().get_filtration_iterator()
+        self.do_init()
 
     def __next__(self):
         """Returns the next simplex with its filtration value"""

--- a/src/python/gudhi/simplex_tree.pyx
+++ b/src/python/gudhi/simplex_tree.pyx
@@ -23,7 +23,7 @@ class SimplexTreeIterator:
     def __next__(self):
         """Returns the next simplex with its filtration value"""
         simplex = self._st.get_next_in_filtration();
-        if simplex is None:
+        if len(simplex[0]) == 0:
             raise StopIteration
         return simplex
 
@@ -224,7 +224,12 @@ cdef class SimplexTree:
         return SimplexTreeIterator(self)
 
     def get_next_in_filtration(self):
-        """TODO"""
+        """Returns the next simplex in the filtration, in an iteration
+        context.
+
+        :returns:  The current simplex (following iterator state).
+        :rtype:  tuple(simplex, filtration)
+        """
         cdef pair[vector[int], double] simplex \
             = self.get_ptr().get_next_in_filtration();
         return simplex

--- a/src/python/gudhi/simplex_tree.pyx
+++ b/src/python/gudhi/simplex_tree.pyx
@@ -16,16 +16,18 @@ __copyright__ = "Copyright (C) 2016 Inria"
 __license__ = "MIT"
 
 cdef class SimplexTreeIterator:
-    cdef SimplexTree _st;
+    cdef Simplex_tree_complex_simplex_iterator[Simplex_tree[Simplex_tree_options_full_featured]] _sti;
 
     """Iterator class for SimplexTree"""
     def __init__(self, st):
         self._st = st
+        self._sti = Simplex_tree_complex_simplex_iterator[Simplex_tree[Simplex_tree_options_full_featured]](st)
+        st.get_ptr().initialize_filtration()
 
     def __next__(self):
         """Returns the next simplex with its filtration value"""
         cdef pair[vector[int], double] simplex \
-            = self._st.get_ptr().get_next_in_filtration();
+            = self._st.get_ptr().get_next_in_filtration(self._sti)
         if len(simplex.first) == 0:
             raise StopIteration
         return simplex

--- a/src/python/gudhi/simplex_tree.pyx
+++ b/src/python/gudhi/simplex_tree.pyx
@@ -15,15 +15,18 @@ __author__ = "Vincent Rouvreau"
 __copyright__ = "Copyright (C) 2016 Inria"
 __license__ = "MIT"
 
-class SimplexTreeIterator:
+cdef class SimplexTreeIterator:
+    cdef SimplexTree _st;
+
     """Iterator class for SimplexTree"""
     def __init__(self, st):
         self._st = st
 
     def __next__(self):
         """Returns the next simplex with its filtration value"""
-        simplex = self._st.get_next_in_filtration();
-        if len(simplex[0]) == 0:
+        cdef pair[vector[int], double] simplex \
+            = self._st.get_ptr().get_next_in_filtration();
+        if len(simplex.first) == 0:
             raise StopIteration
         return simplex
 
@@ -222,17 +225,6 @@ cdef class SimplexTree:
     def __iter__(self):
         """Returns an Iterator object for this instance"""
         return SimplexTreeIterator(self)
-
-    def get_next_in_filtration(self):
-        """Returns the next simplex in the filtration, in an iteration
-        context.
-
-        :returns:  The current simplex (following iterator state).
-        :rtype:  tuple(simplex, filtration)
-        """
-        cdef pair[vector[int], double] simplex \
-            = self.get_ptr().get_next_in_filtration();
-        return simplex
 
     def get_filtration(self):
         """This function returns a list of all simplices with their given

--- a/src/python/gudhi/simplex_tree.pyx
+++ b/src/python/gudhi/simplex_tree.pyx
@@ -16,19 +16,21 @@ __copyright__ = "Copyright (C) 2016 Inria"
 __license__ = "MIT"
 
 cdef class SimplexTreeIterator:
-    cdef Simplex_tree_complex_simplex_iterator[Simplex_tree[Simplex_tree_options_full_featured]] _sti;
+    cdef intptr_t _sti;
+    cdef SimplexTree _st;
 
     """Iterator class for SimplexTree"""
     def __init__(self, st):
         self._st = st
-        self._sti = Simplex_tree_complex_simplex_iterator[Simplex_tree[Simplex_tree_options_full_featured]](st)
         st.get_ptr().initialize_filtration()
+        self._sti = st.get_ptr().get_filtration_iterator()
 
     def __next__(self):
         """Returns the next simplex with its filtration value"""
         cdef pair[vector[int], double] simplex \
             = self._st.get_ptr().get_next_in_filtration(self._sti)
         if len(simplex.first) == 0:
+            self._st.get_ptr().end_filtration_iteration(self._sti)
             raise StopIteration
         return simplex
 

--- a/src/python/gudhi/simplex_tree.pyx
+++ b/src/python/gudhi/simplex_tree.pyx
@@ -15,6 +15,26 @@ __author__ = "Vincent Rouvreau"
 __copyright__ = "Copyright (C) 2016 Inria"
 __license__ = "MIT"
 
+class SimplexTreeIterator:
+    """Iterator class for SimplexTree"""
+    def __init__(self, st):
+        # Filtration list object reference
+        self._filtration = st.get_unprocessed_filtration()
+        # member variable to keep track of current index
+        self._index = 0
+
+    def __next__(self):
+        """Returns the next simplex with its filtration value"""
+        if self._index < len(self._filtration):
+            filtered_complex = self._filtration[self._index]
+            v = []
+            for vertex in filtered_complex[0]:
+                v.append(vertex)
+            self._index +=1
+            return (v, filtered_complex[1])
+        # End of Iteration
+        raise StopIteration
+
 # SimplexTree python interface
 cdef class SimplexTree:
     """The simplex tree is an efficient and flexible data structure for
@@ -223,6 +243,26 @@ cdef class SimplexTree:
                 v.append(vertex)
             ct.append((v, filtered_complex.second))
         return ct
+
+    # NOTE: getting rid of this iintrnal function by calling get_ptr() or
+    # trying to cast the pointer outside the class fails.
+    # TODO: the returned object is identical to the one returned by
+    # get_filtration(() above: replace the function?
+    def get_unprocessed_filtration(self):
+        """This function returns the filtration object as computed in
+        get_filtration() above, but does not post-process the result,
+        for iteration purpose.
+
+        :returns:  The simplices sorted by increasing filtration values.
+        :rtype:  list of tuples(simplex, filtration)
+        """
+        cdef vector[pair[vector[int], double]] filtration \
+            = self.get_ptr().get_filtration()
+        return filtration
+
+    def __iter__(self):
+        """Returns an Iterator object for this instance"""
+        return SimplexTreeIterator(self)
 
     def get_skeleton(self, dimension):
         """This function returns the (simplices of the) skeleton of a maximum

--- a/src/python/gudhi/simplex_tree.pyx
+++ b/src/python/gudhi/simplex_tree.pyx
@@ -16,24 +16,22 @@ __copyright__ = "Copyright (C) 2016 Inria"
 __license__ = "MIT"
 
 cdef class SimplexTreeIterator:
-    cdef intptr_t _sti;
     cdef SimplexTree _st;
+    cdef int _key; #index of current iterator object in C++ array
 
     cdef do_init(self):
-        self._st.get_ptr().initialize_filtration()
-        self._sti = self._st.get_ptr().get_filtration_iterator()
+        self._key = self._st.get_ptr().init_or_stop_iteration(-1)
 
     """Iterator class for SimplexTree"""
     def __init__(self, st):
         self._st = st
-        self.do_init()
+        self.do_init() #called indirectly because __init__ cannot be cdef
 
     def __next__(self):
         """Returns the next simplex with its filtration value"""
         cdef pair[vector[int], double] simplex \
-            = self._st.get_ptr().get_next_in_filtration(self._sti)
+            = self._st.get_ptr().get_next_in_filtration(self._key)
         if len(simplex.first) == 0:
-            self._st.get_ptr().end_filtration_iteration(self._sti)
             raise StopIteration
         return simplex
 

--- a/src/python/include/Simplex_tree_interface.h
+++ b/src/python/include/Simplex_tree_interface.h
@@ -82,23 +82,15 @@ class Simplex_tree_interface : public Simplex_tree<SimplexTreeOptions> {
     Base::initialize_filtration();
   }
 
-  std::pair<std::vector<int>, double> get_next_in_filtration() {
-    static Simplex_tree_complex_simplex_iterator<Base>* sti = nullptr;
-    if (sti == nullptr) {
-      Base::initialize_filtration(); //TODO: this allocates the full simplex
-      sti = new Simplex_tree_complex_simplex_iterator<Base>(this);
-    }
-    if (*sti == Simplex_tree_complex_simplex_iterator<Base>()) {
-      delete sti;
-      sti = nullptr;
+  std::pair<std::vector<int>, double> get_next_in_filtration(
+    Simplex_tree_complex_simplex_iterator<Base>& sti)
+  {
+    if (sti == Simplex_tree_complex_simplex_iterator<Base>())
       return std::make_pair<Simplex, double>(std::vector<int>(), 0.0);
-    }
-    auto res = *(*sti);
-    (*sti)++;
+    auto res = *(sti++);
     Simplex simplex;
-    for (auto vertex : Base::simplex_vertex_range(res)) {
+    for (auto vertex : Base::simplex_vertex_range(res))
       simplex.insert(simplex.begin(), vertex);
-    }
     return std::make_pair<Simplex, double>(std::move(simplex), res.get_ptr()->first);
   }
 

--- a/src/python/include/Simplex_tree_interface.h
+++ b/src/python/include/Simplex_tree_interface.h
@@ -82,6 +82,20 @@ class Simplex_tree_interface : public Simplex_tree<SimplexTreeOptions> {
     Base::initialize_filtration();
   }
 
+  std::pair<std::vector<int>, double> get_next_in_filtration() {
+    static Simplex_tree_complex_simplex_iterator<Base>* sti = nullptr;
+    if (sti == nullptr)
+      sti = new Simplex_tree_complex_simplex_iterator<Base>(this);
+    auto res = (*sti)->get_ptr();
+    (*sti)++;
+    if (*(*sti) == Base::null_simplex())
+      return nullptr; //TODO: return "None"
+    std::vector<int> v(5, 3);
+    return std::make_pair<Simplex, double>(std::move(v), res->first);
+    // TODO: process res->second to use next line
+    //return std::make_pair<Simplex, double>(res->second, res->first);
+  }
+
   Filtered_simplices get_filtration() {
     Base::initialize_filtration();
     Filtered_simplices filtrations;

--- a/src/python/include/Simplex_tree_interface.h
+++ b/src/python/include/Simplex_tree_interface.h
@@ -88,18 +88,17 @@ class Simplex_tree_interface : public Simplex_tree<SimplexTreeOptions> {
       Base::initialize_filtration(); //TODO: this allocates the full simplex
       sti = new Simplex_tree_complex_simplex_iterator<Base>(this);
     }
+    if (*sti == Simplex_tree_complex_simplex_iterator<Base>()) {
+      delete sti;
+      sti = nullptr;
+      return std::make_pair<Simplex, double>(std::vector<int>(), 0.0);
+    }
     auto res = *(*sti);
     (*sti)++;
     Simplex simplex;
     for (auto vertex : Base::simplex_vertex_range(res)) {
       simplex.insert(simplex.begin(), vertex);
     }
-    // TODO: how to know if end() is reached?
-//    if (&res == sti->end()) {
-//      delete sti;
-//      sti = nullptr;
-//      return std::make_pair<Simplex, double>(std::vector<int>(), 0.0);
-//    }
     return std::make_pair<Simplex, double>(std::move(simplex), res.get_ptr()->first);
   }
 

--- a/src/python/include/Simplex_tree_interface.h
+++ b/src/python/include/Simplex_tree_interface.h
@@ -101,6 +101,7 @@ class Simplex_tree_interface : public Simplex_tree<SimplexTreeOptions> {
       key = 0;
       while (used_keys.count(key))
         key++;
+      used_keys.insert(key);
     }
     return key;
   }

--- a/src/python/include/Simplex_tree_interface.h
+++ b/src/python/include/Simplex_tree_interface.h
@@ -15,6 +15,7 @@
 #include <gudhi/distance_functions.h>
 #include <gudhi/Simplex_tree.h>
 #include <gudhi/Points_off_io.h>
+#include <gudhi/Simplex_tree/Simplex_tree_iterators.h>
 
 #include "Persistent_cohomology_interface.h"
 
@@ -82,9 +83,13 @@ class Simplex_tree_interface : public Simplex_tree<SimplexTreeOptions> {
     Base::initialize_filtration();
   }
 
-  std::pair<std::vector<int>, double> get_next_in_filtration(
-    Simplex_tree_complex_simplex_iterator<Base>& sti)
-  {
+  intptr_t get_filtration_iterator() {
+    auto psti = new Simplex_tree_complex_simplex_iterator<Base>(this);
+    return reinterpret_cast<intptr_t>(psti);
+  }
+
+  std::pair<std::vector<int>, double> get_next_in_filtration(intptr_t psti) {
+    auto sti = *(reinterpret_cast<Simplex_tree_complex_simplex_iterator<Base>*>(psti));
     if (sti == Simplex_tree_complex_simplex_iterator<Base>())
       return std::make_pair<Simplex, double>(std::vector<int>(), 0.0);
     auto res = *(sti++);
@@ -92,6 +97,10 @@ class Simplex_tree_interface : public Simplex_tree<SimplexTreeOptions> {
     for (auto vertex : Base::simplex_vertex_range(res))
       simplex.insert(simplex.begin(), vertex);
     return std::make_pair<Simplex, double>(std::move(simplex), res.get_ptr()->first);
+  }
+
+  void end_filtration_iteration(intptr_t psti) {
+    delete (reinterpret_cast<Simplex_tree_complex_simplex_iterator<Base>*>(psti));
   }
 
   Filtered_simplices get_filtration() {

--- a/src/python/include/Simplex_tree_interface.h
+++ b/src/python/include/Simplex_tree_interface.h
@@ -88,23 +88,19 @@ class Simplex_tree_interface : public Simplex_tree<SimplexTreeOptions> {
       Base::initialize_filtration(); //TODO: this allocates the full simplex
       sti = new Simplex_tree_complex_simplex_iterator<Base>(this);
     }
-    auto res = (*sti)->get_ptr();
+    auto res = *(*sti);
     (*sti)++;
-    if (*(*sti) == Base::null_simplex()) {
-      delete sti;
-      sti = nullptr;
-      return std::make_pair<Simplex, double>(std::vector<int>(), 0.0);
-    }
-    auto key = res->second.key(); //TODO: seems to contain junk value
-    //return std::make_pair<Simplex, double>(std::vector<int>(5,3), res->first);
-    auto sh = this->simplex(key); //This probably causes a segfault
-    //std::cout << "DEBUG: " << key << std::endl;
     Simplex simplex;
-    for (auto vertex : Base::simplex_vertex_range(sh)) {
-      //std::cout << vertex << std::endl;
+    for (auto vertex : Base::simplex_vertex_range(res)) {
       simplex.insert(simplex.begin(), vertex);
     }
-    return std::make_pair<Simplex, double>(std::move(simplex), res->first);
+    // TODO: how to know if end() is reached?
+//    if (&res == sti->end()) {
+//      delete sti;
+//      sti = nullptr;
+//      return std::make_pair<Simplex, double>(std::vector<int>(), 0.0);
+//    }
+    return std::make_pair<Simplex, double>(std::move(simplex), res.get_ptr()->first);
   }
 
   Filtered_simplices get_filtration() {


### PR DESCRIPTION
Attempt to fix the issue #2 

NOTE: get_filtration() and the introduced method get_unprocessed_filtration() return the same thing:

> f = st.get_filtration()
> g = st.get_unprocessed_filtration()
> f == g
True

So I think get_filtration() could be replaced by the simpler code of the other - temporary, internal - function. The next() method in iterator class could also be simplified (loop "for vertex in filtered_complex[0] ...").