### PR TITLE
Add scikit-learn as a third party library in installation

### DIFF
--- a/src/python/doc/installation.rst
+++ b/src/python/doc/installation.rst
@@ -257,6 +257,13 @@ The :doc:`Wasserstein distance </wasserstein_distance_user>`
 module requires `POT <https://pot.readthedocs.io/>`_, a library that provides
 several solvers for optimization problems related to Optimal Transport.
 
+Scikit-learn
+============
+
+The :doc:`persistence representations </representations>` module require
+`scikit-learn <https://scikit-learn.org/>`_, a Python-based ecosystem of
+open-source software for machine learning.
+
 SciPy
 =====
 


### PR DESCRIPTION
Add scikit-learn as a third party library as it is required by persistence representations