### PR TITLE
Global improvement of rendering with Python tools

### DIFF
--- a/src/python/doc/persistence_graphical_tools_sum.inc
+++ b/src/python/doc/persistence_graphical_tools_sum.inc
@@ -3,10 +3,10 @@
 
    +-----------------------------------------------------------------+-----------------------------------------------------------------------+-----------------------------------------------+
    | .. figure::                                                     | These graphical tools comes on top of persistence results and allows  | :Author: Vincent Rouvreau                     |
-   |      img/graphical_tools_representation.png                     | the user to build easily persistence barcode, diagram or density.     |                                               |
+   |      img/graphical_tools_representation.png                     | the user to display easily persistence barcode, diagram or density.   |                                               |
    |                                                                 |                                                                       | :Introduced in: GUDHI 2.0.0                   |
-   |                                                                 |                                                                       |                                               |
-   |                                                                 |                                                                       | :Copyright: MIT                               |
+   |                                                                 | Note that these functions return the matplotlib axis, allowing        |                                               |
+   |                                                                 | for further modifications (title, aspect, etc.)                       | :Copyright: MIT                               |
    |                                                                 |                                                                       |                                               |
    |                                                                 |                                                                       | :Requires: matplotlib, numpy and scipy        |
    +-----------------------------------------------------------------+-----------------------------------------------------------------------+-----------------------------------------------+

--- a/src/python/doc/persistence_graphical_tools_sum.inc
+++ b/src/python/doc/persistence_graphical_tools_sum.inc
@@ -2,7 +2,7 @@
    :widths: 30 50 20
 
    +-----------------------------------------------------------------+-----------------------------------------------------------------------+-----------------------------------------------+
-   | .. figure::                                                     | These graphical tools comes on top of persistence results and allows  | :Author: Vincent Rouvreau                     |
+   | .. figure::                                                     | These graphical tools comes on top of persistence results and allows  | :Author: Vincent Rouvreau, Theo Lacombe       |
    |      img/graphical_tools_representation.png                     | the user to display easily persistence barcode, diagram or density.   |                                               |
    |                                                                 |                                                                       | :Introduced in: GUDHI 2.0.0                   |
    |                                                                 | Note that these functions return the matplotlib axis, allowing        |                                               |

--- a/src/python/doc/persistence_graphical_tools_user.rst
+++ b/src/python/doc/persistence_graphical_tools_user.rst
@@ -57,6 +57,18 @@ This function can display the persistence result as a diagram:
     ax.set_aspect("equal")  # forces to be square shaped
     plt.show()
 
+Note that (as barcode and density) it can also take a simple `np.array` 
+of shape (N x 2) encoding a persistence diagram (in a given dimension).
+
+.. plot::
+    :include-source:
+    
+    import matplotlib.pyplot as plt
+    import gudhi
+    import numpy as np
+    d = np.array([[0, 1], [1, 2], [1, np.inf]])
+    gudhi.plot_persistence_diagram(d)
+    plt.show()
 
 Persistence density
 -------------------

--- a/src/python/doc/persistence_graphical_tools_user.rst
+++ b/src/python/doc/persistence_graphical_tools_user.rst
@@ -20,7 +20,7 @@ This function can display the persistence result as a barcode:
 .. plot::
    :include-source:
 
-    import matplotlib.pyplot as plot
+    import matplotlib.pyplot as plt
     import gudhi
 
     off_file = gudhi.__root_source_dir__ + '/data/points/tore3D_300.off'
@@ -31,7 +31,7 @@ This function can display the persistence result as a barcode:
     diag = simplex_tree.persistence(min_persistence=0.4)
 
     gudhi.plot_persistence_barcode(diag)
-    plot.show()
+    plt.show()
 
 Show persistence as a diagram
 -----------------------------
@@ -44,15 +44,19 @@ This function can display the persistence result as a diagram:
 .. plot::
    :include-source:
 
-    import matplotlib.pyplot as plot
+    import matplotlib.pyplot as plt
     import gudhi
 
     # rips_on_tore3D_1307.pers obtained from write_persistence_diagram method
     persistence_file=gudhi.__root_source_dir__ + \
         '/data/persistence_diagram/rips_on_tore3D_1307.pers'
-    gudhi.plot_persistence_diagram(persistence_file=persistence_file,
+    ax = gudhi.plot_persistence_diagram(persistence_file=persistence_file,
         legend=True)
-    plot.show()
+    # We can modify the title, aspect, etc.
+    ax.set_title("Persistence diagram of a torus")
+    ax.set_aspect("equal")  # forces to be square shaped
+    plt.show()
+
 
 Persistence density
 -------------------
@@ -65,7 +69,7 @@ If you want more information on a specific dimension, for instance:
 .. plot::
    :include-source:
 
-    import matplotlib.pyplot as plot
+    import matplotlib.pyplot as plt
     import gudhi
     # rips_on_tore3D_1307.pers obtained from write_persistence_diagram method
     persistence_file=gudhi.__root_source_dir__ + \
@@ -75,9 +79,9 @@ If you want more information on a specific dimension, for instance:
         only_this_dim=1)
     pers_diag = [(1, elt) for elt in birth_death]
     # Use subplots to display diagram and density side by side
-    fig, axes = plot.subplots(nrows=1, ncols=2, figsize=(12, 5))
+    fig, axes = plt.subplots(nrows=1, ncols=2, figsize=(12, 5))
     gudhi.plot_persistence_diagram(persistence=pers_diag,
         axes=axes[0])
     gudhi.plot_persistence_density(persistence=pers_diag,
         dimension=1, legend=True, axes=axes[1])
-    plot.show()
+    plt.show()

--- a/src/python/gudhi/persistence_graphical_tools.py
+++ b/src/python/gudhi/persistence_graphical_tools.py
@@ -296,17 +296,6 @@ def plot_persistence_diagram(
         axis_end = max_death + delta / 2
         axis_start = min_birth - delta
 
-        # infinity line and text
-        axes.plot([axis_start, axis_end], [axis_start, axis_end], linewidth=1.0, color="k")
-        axes.plot([axis_start, axis_end], [infinity, infinity], linewidth=1.0, color="k", alpha=alpha)
-        # Infinity label
-        yt = axes.get_yticks()
-        yt = yt[np.where(yt < axis_end)] # to avoid ploting ticklabel higher than infinity
-        yt = np.append(yt, infinity)
-        ytl = ["%.3f" % e for e in yt]  # to avoid float precision error
-        ytl[-1] = r'$+\infty$'
-        axes.set_yticks(yt)
-        axes.set_yticklabels(ytl)
         # bootstrap band
         if band > 0.0:
             x = np.linspace(axis_start, infinity, 1000)
@@ -315,6 +304,7 @@ def plot_persistence_diagram(
         if greyblock:
             axes.add_patch(mpatches.Polygon([[axis_start, axis_start], [axis_end, axis_start], [axis_end, axis_end]], fill=True, color='lightgrey'))
         # Draw points in loop
+        pts_at_infty = False  # Records presence of pts at infty
         for interval in reversed(persistence):
             if float(interval[1][1]) != float("inf"):
                 # Finite death case
@@ -325,10 +315,23 @@ def plot_persistence_diagram(
                     color=colormap[interval[0]],
                 )
             else:
+                pts_at_infty = True
                 # Infinite death case for diagram to be nicer
                 axes.scatter(
                     interval[1][0], infinity, alpha=alpha, color=colormap[interval[0]]
                 )
+        if pts_at_infty:
+            # infinity line and text
+            axes.plot([axis_start, axis_end], [axis_start, axis_end], linewidth=1.0, color="k")
+            axes.plot([axis_start, axis_end], [infinity, infinity], linewidth=1.0, color="k", alpha=alpha)
+            # Infinity label
+            yt = axes.get_yticks()
+            yt = yt[np.where(yt < axis_end)] # to avoid ploting ticklabel higher than infinity
+            yt = np.append(yt, infinity)
+            ytl = ["%.3f" % e for e in yt]  # to avoid float precision error
+            ytl[-1] = r'$+\infty$'
+            axes.set_yticks(yt)
+            axes.set_yticklabels(ytl)
 
         if legend:
             dimensions = list(set(item[0] for item in persistence))

--- a/src/python/gudhi/persistence_graphical_tools.py
+++ b/src/python/gudhi/persistence_graphical_tools.py
@@ -361,7 +361,7 @@ def plot_persistence_density(
     legend=False,
     axes=None,
     fontsize=16,
-    greyblock=True
+    greyblock=False
 ):
     """This function plots the persistence density from persistence
     values list, np.array of shape (N x 2) representing a diagram
@@ -410,7 +410,7 @@ def plot_persistence_density(
     :param fontsize: Fontsize to use in axis.
     :type fontsize: int
     :param greyblock: if we want to plot a grey patch on the lower half plane 
-                         for nicer rendering. Default True.
+                         for nicer rendering. Default False.
     :type greyblock: boolean
     :returns: (`matplotlib.axes.Axes`): The axes on which the plot was drawn.
     """

--- a/src/python/gudhi/persistence_graphical_tools.py
+++ b/src/python/gudhi/persistence_graphical_tools.py
@@ -5,7 +5,6 @@
 # Copyright (C) 2016 Inria
 #
 # Modification(s):
-#   - 2020/02 Theo Lacombe: Added more options for improved rendering and more flexibility.
 #   - YYYY/MM Author: Description of the modification
 
 from os import path
@@ -44,7 +43,6 @@ def __min_birth_max_death(persistence, band=0.0):
         max_death += band
     return (min_birth, max_death)
 
-
 def plot_persistence_barcode(
     persistence=[],
     persistence_file="",
@@ -54,9 +52,7 @@ def plot_persistence_barcode(
     inf_delta=0.1,
     legend=False,
     colormap=None,
-    axes=None,
-    fontsize=16,
-    title="Persistence barcode"
+    axes=None
 ):
     """This function plots the persistence bar code from persistence values list
     or from a :doc:`persistence file <fileformats>`.
@@ -85,18 +81,11 @@ def plot_persistence_barcode(
     :param axes: A matplotlib-like subplot axes. If None, the plot is drawn on
         a new set of axes.
     :type axes: `matplotlib.axes.Axes`
-    :param fontsize: Fontsize to use in axis.
-    :type fontsize: int
-    :param title: title for the plot.
-    :type title: string
     :returns: (`matplotlib.axes.Axes`): The axes on which the plot was drawn.
     """
     try:
         import matplotlib.pyplot as plt
         import matplotlib.patches as mpatches
-        from matplotlib import rc
-        plt.rc('text', usetex=True)
-        plt.rc('font', family='serif')
 
         if persistence_file != "":
             if path.isfile(persistence_file):
@@ -174,7 +163,7 @@ def plot_persistence_barcode(
                 loc="lower right",
             )
 
-        axes.set_title(title)
+        axes.set_title("Persistence barcode")
 
         # Ends plot on infinity value and starts a little bit before min_birth
         axes.axis([axis_start, infinity, 0, ind])
@@ -194,11 +183,7 @@ def plot_persistence_diagram(
     inf_delta=0.1,
     legend=False,
     colormap=None,
-    axes=None,
-    aspect_equal=False,
-    fontsize=16,
-    title="Persistence diagram",
-    greyblock=True
+    axes=None
 ):
     """This function plots the persistence diagram from persistence values
     list or from a :doc:`persistence file <fileformats>`.
@@ -229,23 +214,11 @@ def plot_persistence_diagram(
     :param axes: A matplotlib-like subplot axes. If None, the plot is drawn on
         a new set of axes.
     :type axes: `matplotlib.axes.Axes`
-    :param aspect_equal: if True, force plot to be square shaped.
-    :type aspect_equal: boolean
-    :param fontsize: Fontsize to use in axis.
-    :type fontsize: int
-    :param title: title for the plot.
-    :type title: string
-    :param greyblock: if we want to plot a grey patch on the lower half plane for nicer rendering. Default True.
-    :type greyblock: boolean
     :returns: (`matplotlib.axes.Axes`): The axes on which the plot was drawn.
     """
     try:
         import matplotlib.pyplot as plt
         import matplotlib.patches as mpatches
-        from matplotlib import rc
-        plt.rc('text', usetex=True)
-        plt.rc('font', family='serif')
-
 
         if persistence_file != "":
             if path.isfile(persistence_file):
@@ -283,27 +256,18 @@ def plot_persistence_diagram(
         # Replace infinity values with max_death + delta for diagram to be more
         # readable
         infinity = max_death + delta
-        axis_end = max_death + delta / 2
         axis_start = min_birth - delta
 
         # line display of equation : birth = death
         x = np.linspace(axis_start, infinity, 1000)
         # infinity line and text
-        axes.plot([axis_start, axis_end], [axis_start, axis_end], linewidth=1.0, color="k")
-        axes.plot([axis_start, axis_end], [infinity, infinity], linewidth=1.0, color="k", alpha=alpha)
-        # Infinity label
-        yt = axes.get_yticks()
-        yt = np.append(yt, infinity)
-        ytl = yt.tolist()
-        ytl[-1] = r'$+\infty$'
-        axes.set_yticks(yt)
-        axes.set_yticklabels(ytl)
+        axes.plot(x, x, color="k", linewidth=1.0)
+        axes.plot(x, [infinity] * len(x), linewidth=1.0, color="k", alpha=alpha)
+        axes.text(axis_start, infinity, r"$\infty$", color="k", alpha=alpha)
         # bootstrap band
         if band > 0.0:
             axes.fill_between(x, x, x + band, alpha=alpha, facecolor="red")
-        # lower diag patch
-        if greyblock:
-            axes.add_patch(mpatches.Polygon([[axis_start, axis_start], [axis_end, axis_start], [axis_end, axis_end]], fill=True, color='lightgrey'))
+
         # Draw points in loop
         for interval in reversed(persistence):
             if float(interval[1][1]) != float("inf"):
@@ -329,13 +293,11 @@ def plot_persistence_diagram(
                 ]
             )
 
-        axes.set_xlabel("Birth", fontsize=fontsize)
-        axes.set_ylabel("Death", fontsize=fontsize)
+        axes.set_xlabel("Birth")
+        axes.set_ylabel("Death")
         # Ends plot on infinity value and starts a little bit before min_birth
-        axes.axis([axis_start, axis_end, axis_start, infinity + delta])
-        axes.set_title(title, fontsize=fontsize)  # a different fontsize for the title?
-        if aspect_equal:
-            axes.set_aspect("equal")
+        axes.axis([axis_start, infinity, axis_start, infinity + delta])
+        axes.set_title("Persistence diagram")
         return axes
 
     except ImportError:
@@ -351,11 +313,7 @@ def plot_persistence_density(
     dimension=None,
     cmap=None,
     legend=False,
-    axes=None,
-    aspect_equal=False,
-    fontsize=16,
-    title="Persistence density",
-    greyblock=True
+    axes=None
 ):
     """This function plots the persistence density from persistence
     values list or from a :doc:`persistence file <fileformats>`. Be
@@ -397,25 +355,11 @@ def plot_persistence_density(
     :param axes: A matplotlib-like subplot axes. If None, the plot is drawn on
         a new set of axes.
     :type axes: `matplotlib.axes.Axes`
-    :param aspect_equal: if True, force plot to be square shaped.
-    :type aspect_equal: boolean
-    :param fontsize: Fontsize to use in axis.
-    :type fontsize: int
-    :param title: title for the plot.
-    :type title: string
-    :param greyblock: if we want to plot a grey patch on the lower half plane 
-                         for nicer rendering. Default True.
-    :type greyblock: boolean
     :returns: (`matplotlib.axes.Axes`): The axes on which the plot was drawn.
     """
     try:
         import matplotlib.pyplot as plt
-        import matplotlib.patches as mpatches
         from scipy.stats import kde
-        from matplotlib import rc
-        plt.rc('text', usetex=True)
-        plt.rc('font', family='serif')
-
 
         if persistence_file != "":
             if dimension is None:
@@ -474,18 +418,12 @@ def plot_persistence_density(
         # Make the plot
         img = axes.pcolormesh(xi, yi, zi.reshape(xi.shape), cmap=cmap)
 
-        if greyblock:
-            axes.add_patch(mpatches.Polygon([[birth.min(), birth.min()], [death.max(), birth.min()], [death.max(), death.max()]], fill=True, color='lightgrey'))
-
         if legend:
             plt.colorbar(img, ax=axes)
 
-        axes.set_xlabel("Birth", fontsize=fontsize)
-        axes.set_ylabel("Death", fontsize=fontsize)
-        axes.set_title(title, fontsize=fontsize)
-        if aspect_equal:
-            axes.set_aspect("equal")
-
+        axes.set_xlabel("Birth")
+        axes.set_ylabel("Death")
+        axes.set_title("Persistence density")
         return axes
 
     except ImportError:

--- a/src/python/gudhi/persistence_graphical_tools.py
+++ b/src/python/gudhi/persistence_graphical_tools.py
@@ -74,9 +74,8 @@ def plot_persistence_barcode(
     in a single homology dimension), 
     or from a :doc:`persistence file <fileformats>`.
 
-    :param persistence: Persistence intervals values list grouped by dimension, 
-                        or np.array of shape (N x 2).
-    :type persistence: list of tuples(dimension, tuple(birth, death)).
+    :param persistence: Persistence intervals values list. Can be grouped by dimension or not.
+    :type persistence: an array of (dimension, array of (birth, death)) or an array of (birth, death).
     :param persistence_file: A :doc:`persistence file <fileformats>` style name
         (reset persistence if both are set).
     :type persistence_file: string
@@ -217,9 +216,8 @@ def plot_persistence_diagram(
     list, a np.array of shape (N x 2) representing a diagram in a single
     homology dimension, or from a :doc:`persistence file <fileformats>`.
 
-    :param persistence: Persistence intervals values list grouped by dimension,
-                        or np.array of shape (N x 2).
-    :type persistence: list of tuples(dimension, tuple(birth, death)).
+    :param persistence: Persistence intervals values list. Can be grouped by dimension or not.
+    :type persistence: an array of (dimension, array of (birth, death)) or an array of (birth, death).
     :param persistence_file: A :doc:`persistence file <fileformats>` style name
         (reset persistence if both are set).
     :type persistence_file: string
@@ -373,9 +371,10 @@ def plot_persistence_density(
     up to you to select the required one. This function also does not handle
     degenerate data set (scipy correlation matrix inversion can fail).
 
-    :param persistence: Persistence intervals values list grouped by dimension,
-                        or np.array of shape (N x 2).
-    :type persistence: list of tuples(dimension, tuple(birth, death)).
+    :param persistence: Persistence intervals values list. 
+                        Can be grouped by dimension or not.
+    :type persistence: an array of (dimension, array of (birth, death)) 
+                        or an array of (birth, death).
     :param persistence_file: A :doc:`persistence file <fileformats>`
         style name (reset persistence if both are set).
     :type persistence_file: string

--- a/src/python/gudhi/persistence_graphical_tools.py
+++ b/src/python/gudhi/persistence_graphical_tools.py
@@ -51,7 +51,7 @@ def _array_handler(a):
                 persistence-compatible list (padding with 0), so that the
                 plot can be performed seamlessly.
     '''
-    if isinstance(a, np.ndarray): 
+    if isinstance(a[0][1], np.float64) or isinstance(a[0][1], float):
         return [[0, x] for x in a]
     else:
         return a

--- a/src/python/gudhi/persistence_graphical_tools.py
+++ b/src/python/gudhi/persistence_graphical_tools.py
@@ -5,6 +5,7 @@
 # Copyright (C) 2016 Inria
 #
 # Modification(s):
+#   - 2020/02 Theo Lacombe: Added more options for improved rendering and more flexibility.
 #   - YYYY/MM Author: Description of the modification
 
 from os import path
@@ -43,6 +44,7 @@ def __min_birth_max_death(persistence, band=0.0):
         max_death += band
     return (min_birth, max_death)
 
+
 def plot_persistence_barcode(
     persistence=[],
     persistence_file="",
@@ -52,7 +54,8 @@ def plot_persistence_barcode(
     inf_delta=0.1,
     legend=False,
     colormap=None,
-    axes=None
+    axes=None,
+    fontsize=16,
 ):
     """This function plots the persistence bar code from persistence values list
     or from a :doc:`persistence file <fileformats>`.
@@ -81,11 +84,16 @@ def plot_persistence_barcode(
     :param axes: A matplotlib-like subplot axes. If None, the plot is drawn on
         a new set of axes.
     :type axes: `matplotlib.axes.Axes`
+    :param fontsize: Fontsize to use in axis.
+    :type fontsize: int
     :returns: (`matplotlib.axes.Axes`): The axes on which the plot was drawn.
     """
     try:
         import matplotlib.pyplot as plt
         import matplotlib.patches as mpatches
+        from matplotlib import rc
+        plt.rc('text', usetex=True)
+        plt.rc('font', family='serif')
 
         if persistence_file != "":
             if path.isfile(persistence_file):
@@ -163,7 +171,7 @@ def plot_persistence_barcode(
                 loc="lower right",
             )
 
-        axes.set_title("Persistence barcode")
+        axes.set_title("Persistence barcode", fontsize=fontsize)
 
         # Ends plot on infinity value and starts a little bit before min_birth
         axes.axis([axis_start, infinity, 0, ind])
@@ -183,7 +191,9 @@ def plot_persistence_diagram(
     inf_delta=0.1,
     legend=False,
     colormap=None,
-    axes=None
+    axes=None,
+    fontsize=16,
+    greyblock=True
 ):
     """This function plots the persistence diagram from persistence values
     list or from a :doc:`persistence file <fileformats>`.
@@ -214,11 +224,19 @@ def plot_persistence_diagram(
     :param axes: A matplotlib-like subplot axes. If None, the plot is drawn on
         a new set of axes.
     :type axes: `matplotlib.axes.Axes`
+    :param fontsize: Fontsize to use in axis.
+    :type fontsize: int
+    :param greyblock: if we want to plot a grey patch on the lower half plane for nicer rendering. Default True.
+    :type greyblock: boolean
     :returns: (`matplotlib.axes.Axes`): The axes on which the plot was drawn.
     """
     try:
         import matplotlib.pyplot as plt
         import matplotlib.patches as mpatches
+        from matplotlib import rc
+        plt.rc('text', usetex=True)
+        plt.rc('font', family='serif')
+
 
         if persistence_file != "":
             if path.isfile(persistence_file):
@@ -256,18 +274,27 @@ def plot_persistence_diagram(
         # Replace infinity values with max_death + delta for diagram to be more
         # readable
         infinity = max_death + delta
+        axis_end = max_death + delta / 2
         axis_start = min_birth - delta
 
-        # line display of equation : birth = death
-        x = np.linspace(axis_start, infinity, 1000)
         # infinity line and text
-        axes.plot(x, x, color="k", linewidth=1.0)
-        axes.plot(x, [infinity] * len(x), linewidth=1.0, color="k", alpha=alpha)
-        axes.text(axis_start, infinity, r"$\infty$", color="k", alpha=alpha)
+        axes.plot([axis_start, axis_end], [axis_start, axis_end], linewidth=1.0, color="k")
+        axes.plot([axis_start, axis_end], [infinity, infinity], linewidth=1.0, color="k", alpha=alpha)
+        # Infinity label
+        yt = axes.get_yticks()
+        yt = yt[np.where(yt < axis_end)] # to avoid ploting ticklabel higher than infinity
+        yt = np.append(yt, infinity)
+        ytl = ["%.3f" % e for e in yt]  # to avoid float precision error
+        ytl[-1] = r'$+\infty$'
+        axes.set_yticks(yt)
+        axes.set_yticklabels(ytl)
         # bootstrap band
         if band > 0.0:
+            x = np.linspace(axis_start, infinity, 1000)
             axes.fill_between(x, x, x + band, alpha=alpha, facecolor="red")
-
+        # lower diag patch
+        if greyblock:
+            axes.add_patch(mpatches.Polygon([[axis_start, axis_start], [axis_end, axis_start], [axis_end, axis_end]], fill=True, color='lightgrey'))
         # Draw points in loop
         for interval in reversed(persistence):
             if float(interval[1][1]) != float("inf"):
@@ -293,11 +320,11 @@ def plot_persistence_diagram(
                 ]
             )
 
-        axes.set_xlabel("Birth")
-        axes.set_ylabel("Death")
+        axes.set_xlabel("Birth", fontsize=fontsize)
+        axes.set_ylabel("Death", fontsize=fontsize)
+        axes.set_title("Persistence diagram", fontsize=fontsize)
         # Ends plot on infinity value and starts a little bit before min_birth
-        axes.axis([axis_start, infinity, axis_start, infinity + delta])
-        axes.set_title("Persistence diagram")
+        axes.axis([axis_start, axis_end, axis_start, infinity + delta/2])
         return axes
 
     except ImportError:
@@ -313,7 +340,9 @@ def plot_persistence_density(
     dimension=None,
     cmap=None,
     legend=False,
-    axes=None
+    axes=None,
+    fontsize=16,
+    greyblock=True
 ):
     """This function plots the persistence density from persistence
     values list or from a :doc:`persistence file <fileformats>`. Be
@@ -355,11 +384,21 @@ def plot_persistence_density(
     :param axes: A matplotlib-like subplot axes. If None, the plot is drawn on
         a new set of axes.
     :type axes: `matplotlib.axes.Axes`
+    :param fontsize: Fontsize to use in axis.
+    :type fontsize: int
+    :param greyblock: if we want to plot a grey patch on the lower half plane 
+                         for nicer rendering. Default True.
+    :type greyblock: boolean
     :returns: (`matplotlib.axes.Axes`): The axes on which the plot was drawn.
     """
     try:
         import matplotlib.pyplot as plt
+        import matplotlib.patches as mpatches
         from scipy.stats import kde
+        from matplotlib import rc
+        plt.rc('text', usetex=True)
+        plt.rc('font', family='serif')
+
 
         if persistence_file != "":
             if dimension is None:
@@ -418,12 +457,16 @@ def plot_persistence_density(
         # Make the plot
         img = axes.pcolormesh(xi, yi, zi.reshape(xi.shape), cmap=cmap)
 
+        if greyblock:
+            axes.add_patch(mpatches.Polygon([[birth.min(), birth.min()], [death.max(), birth.min()], [death.max(), death.max()]], fill=True, color='lightgrey'))
+
         if legend:
             plt.colorbar(img, ax=axes)
 
-        axes.set_xlabel("Birth")
-        axes.set_ylabel("Death")
-        axes.set_title("Persistence density")
+        axes.set_xlabel("Birth", fontsize=fontsize)
+        axes.set_ylabel("Death", fontsize=fontsize)
+        axes.set_title("Persistence density", fontsize=fontsize)
+
         return axes
 
     except ImportError:

--- a/src/python/gudhi/persistence_graphical_tools.py
+++ b/src/python/gudhi/persistence_graphical_tools.py
@@ -15,7 +15,7 @@ import numpy as np
 from gudhi.reader_utils import read_persistence_intervals_in_dimension
 from gudhi.reader_utils import read_persistence_intervals_grouped_by_dimension
 
-__author__ = "Vincent Rouvreau, Bertrand Michel"
+__author__ = "Vincent Rouvreau, Bertrand Michel, Theo Lacombe"
 __copyright__ = "Copyright (C) 2016 Inria"
 __license__ = "MIT"
 
@@ -46,6 +46,11 @@ def __min_birth_max_death(persistence, band=0.0):
 
 
 def _array_handler(a):
+    '''
+    :param a: if array, assumes it is a (n x 2) np.array and return a
+                persistence-compatible list (padding with 0), so that the
+                plot can be performed seamlessly.
+    '''
     if isinstance(a, np.ndarray): 
         return [[0, x] for x in a]
     else:
@@ -65,9 +70,12 @@ def plot_persistence_barcode(
     fontsize=16,
 ):
     """This function plots the persistence bar code from persistence values list
+    , a np.array of shape (N x 2) (representing a diagram 
+    in a single homology dimension), 
     or from a :doc:`persistence file <fileformats>`.
 
-    :param persistence: Persistence intervals values list grouped by dimension.
+    :param persistence: Persistence intervals values list grouped by dimension, 
+                        or np.array of shape (N x 2).
     :type persistence: list of tuples(dimension, tuple(birth, death)).
     :param persistence_file: A :doc:`persistence file <fileformats>` style name
         (reset persistence if both are set).
@@ -206,9 +214,11 @@ def plot_persistence_diagram(
     greyblock=True
 ):
     """This function plots the persistence diagram from persistence values
-    list or from a :doc:`persistence file <fileformats>`.
+    list, a np.array of shape (N x 2) representing a diagram in a single
+    homology dimension, or from a :doc:`persistence file <fileformats>`.
 
-    :param persistence: Persistence intervals values list grouped by dimension.
+    :param persistence: Persistence intervals values list grouped by dimension,
+                        or np.array of shape (N x 2).
     :type persistence: list of tuples(dimension, tuple(birth, death)).
     :param persistence_file: A :doc:`persistence file <fileformats>` style name
         (reset persistence if both are set).
@@ -356,12 +366,15 @@ def plot_persistence_density(
     greyblock=True
 ):
     """This function plots the persistence density from persistence
-    values list or from a :doc:`persistence file <fileformats>`. Be
+    values list, np.array of shape (N x 2) representing a diagram
+    in a single homology dimension,
+    or from a :doc:`persistence file <fileformats>`. Be
     aware that this function does not distinguish the dimension, it is
     up to you to select the required one. This function also does not handle
     degenerate data set (scipy correlation matrix inversion can fail).
 
-    :param persistence: Persistence intervals values list grouped by dimension.
+    :param persistence: Persistence intervals values list grouped by dimension,
+                        or np.array of shape (N x 2).
     :type persistence: list of tuples(dimension, tuple(birth, death)).
     :param persistence_file: A :doc:`persistence file <fileformats>`
         style name (reset persistence if both are set).

--- a/src/python/gudhi/persistence_graphical_tools.py
+++ b/src/python/gudhi/persistence_graphical_tools.py
@@ -45,6 +45,13 @@ def __min_birth_max_death(persistence, band=0.0):
     return (min_birth, max_death)
 
 
+def _array_handler(a):
+    if isinstance(a, np.ndarray): 
+        return [[0, x] for x in a]
+    else:
+        return a
+
+
 def plot_persistence_barcode(
     persistence=[],
     persistence_file="",
@@ -94,6 +101,9 @@ def plot_persistence_barcode(
         from matplotlib import rc
         plt.rc('text', usetex=True)
         plt.rc('font', family='serif')
+
+
+        persistence = _array_handler(persistence)
 
         if persistence_file != "":
             if path.isfile(persistence_file):
@@ -237,6 +247,7 @@ def plot_persistence_diagram(
         plt.rc('text', usetex=True)
         plt.rc('font', family='serif')
 
+        persistence = _array_handler(persistence)
 
         if persistence_file != "":
             if path.isfile(persistence_file):
@@ -399,6 +410,7 @@ def plot_persistence_density(
         plt.rc('text', usetex=True)
         plt.rc('font', family='serif')
 
+        persistence = _array_handler(persistence)
 
         if persistence_file != "":
             if dimension is None:

--- a/src/python/gudhi/persistence_graphical_tools.py
+++ b/src/python/gudhi/persistence_graphical_tools.py
@@ -5,6 +5,7 @@
 # Copyright (C) 2016 Inria
 #
 # Modification(s):
+#   - 2020/02 Theo Lacombe: Added more options for improved rendering and more flexibility.
 #   - YYYY/MM Author: Description of the modification
 
 from os import path
@@ -43,6 +44,7 @@ def __min_birth_max_death(persistence, band=0.0):
         max_death += band
     return (min_birth, max_death)
 
+
 def plot_persistence_barcode(
     persistence=[],
     persistence_file="",
@@ -52,7 +54,9 @@ def plot_persistence_barcode(
     inf_delta=0.1,
     legend=False,
     colormap=None,
-    axes=None
+    axes=None,
+    fontsize=16,
+    title="Persistence barcode"
 ):
     """This function plots the persistence bar code from persistence values list
     or from a :doc:`persistence file <fileformats>`.
@@ -81,11 +85,18 @@ def plot_persistence_barcode(
     :param axes: A matplotlib-like subplot axes. If None, the plot is drawn on
         a new set of axes.
     :type axes: `matplotlib.axes.Axes`
+    :param fontsize: Fontsize to use in axis.
+    :type fontsize: int
+    :param title: title for the plot.
+    :type title: string
     :returns: (`matplotlib.axes.Axes`): The axes on which the plot was drawn.
     """
     try:
         import matplotlib.pyplot as plt
         import matplotlib.patches as mpatches
+        from matplotlib import rc
+        plt.rc('text', usetex=True)
+        plt.rc('font', family='serif')
 
         if persistence_file != "":
             if path.isfile(persistence_file):
@@ -163,7 +174,7 @@ def plot_persistence_barcode(
                 loc="lower right",
             )
 
-        axes.set_title("Persistence barcode")
+        axes.set_title(title)
 
         # Ends plot on infinity value and starts a little bit before min_birth
         axes.axis([axis_start, infinity, 0, ind])
@@ -183,7 +194,11 @@ def plot_persistence_diagram(
     inf_delta=0.1,
     legend=False,
     colormap=None,
-    axes=None
+    axes=None,
+    aspect_equal=False,
+    fontsize=16,
+    title="Persistence diagram",
+    greyblock=True
 ):
     """This function plots the persistence diagram from persistence values
     list or from a :doc:`persistence file <fileformats>`.
@@ -214,11 +229,23 @@ def plot_persistence_diagram(
     :param axes: A matplotlib-like subplot axes. If None, the plot is drawn on
         a new set of axes.
     :type axes: `matplotlib.axes.Axes`
+    :param aspect_equal: if True, force plot to be square shaped.
+    :type aspect_equal: boolean
+    :param fontsize: Fontsize to use in axis.
+    :type fontsize: int
+    :param title: title for the plot.
+    :type title: string
+    :param greyblock: if we want to plot a grey patch on the lower half plane for nicer rendering. Default True.
+    :type greyblock: boolean
     :returns: (`matplotlib.axes.Axes`): The axes on which the plot was drawn.
     """
     try:
         import matplotlib.pyplot as plt
         import matplotlib.patches as mpatches
+        from matplotlib import rc
+        plt.rc('text', usetex=True)
+        plt.rc('font', family='serif')
+
 
         if persistence_file != "":
             if path.isfile(persistence_file):
@@ -256,18 +283,27 @@ def plot_persistence_diagram(
         # Replace infinity values with max_death + delta for diagram to be more
         # readable
         infinity = max_death + delta
+        axis_end = max_death + delta / 2
         axis_start = min_birth - delta
 
         # line display of equation : birth = death
         x = np.linspace(axis_start, infinity, 1000)
         # infinity line and text
-        axes.plot(x, x, color="k", linewidth=1.0)
-        axes.plot(x, [infinity] * len(x), linewidth=1.0, color="k", alpha=alpha)
-        axes.text(axis_start, infinity, r"$\infty$", color="k", alpha=alpha)
+        axes.plot([axis_start, axis_end], [axis_start, axis_end], linewidth=1.0, color="k")
+        axes.plot([axis_start, axis_end], [infinity, infinity], linewidth=1.0, color="k", alpha=alpha)
+        # Infinity label
+        yt = axes.get_yticks()
+        yt = np.append(yt, infinity)
+        ytl = yt.tolist()
+        ytl[-1] = r'$+\infty$'
+        axes.set_yticks(yt)
+        axes.set_yticklabels(ytl)
         # bootstrap band
         if band > 0.0:
             axes.fill_between(x, x, x + band, alpha=alpha, facecolor="red")
-
+        # lower diag patch
+        if greyblock:
+            axes.add_patch(mpatches.Polygon([[axis_start, axis_start], [axis_end, axis_start], [axis_end, axis_end]], fill=True, color='lightgrey'))
         # Draw points in loop
         for interval in reversed(persistence):
             if float(interval[1][1]) != float("inf"):
@@ -293,11 +329,13 @@ def plot_persistence_diagram(
                 ]
             )
 
-        axes.set_xlabel("Birth")
-        axes.set_ylabel("Death")
+        axes.set_xlabel("Birth", fontsize=fontsize)
+        axes.set_ylabel("Death", fontsize=fontsize)
         # Ends plot on infinity value and starts a little bit before min_birth
-        axes.axis([axis_start, infinity, axis_start, infinity + delta])
-        axes.set_title("Persistence diagram")
+        axes.axis([axis_start, axis_end, axis_start, infinity + delta])
+        axes.set_title(title, fontsize=fontsize)  # a different fontsize for the title?
+        if aspect_equal:
+            axes.set_aspect("equal")
         return axes
 
     except ImportError:
@@ -313,7 +351,11 @@ def plot_persistence_density(
     dimension=None,
     cmap=None,
     legend=False,
-    axes=None
+    axes=None,
+    aspect_equal=False,
+    fontsize=16,
+    title="Persistence density",
+    greyblock=True
 ):
     """This function plots the persistence density from persistence
     values list or from a :doc:`persistence file <fileformats>`. Be
@@ -355,11 +397,25 @@ def plot_persistence_density(
     :param axes: A matplotlib-like subplot axes. If None, the plot is drawn on
         a new set of axes.
     :type axes: `matplotlib.axes.Axes`
+    :param aspect_equal: if True, force plot to be square shaped.
+    :type aspect_equal: boolean
+    :param fontsize: Fontsize to use in axis.
+    :type fontsize: int
+    :param title: title for the plot.
+    :type title: string
+    :param greyblock: if we want to plot a grey patch on the lower half plane 
+                         for nicer rendering. Default True.
+    :type greyblock: boolean
     :returns: (`matplotlib.axes.Axes`): The axes on which the plot was drawn.
     """
     try:
         import matplotlib.pyplot as plt
+        import matplotlib.patches as mpatches
         from scipy.stats import kde
+        from matplotlib import rc
+        plt.rc('text', usetex=True)
+        plt.rc('font', family='serif')
+
 
         if persistence_file != "":
             if dimension is None:
@@ -418,12 +474,18 @@ def plot_persistence_density(
         # Make the plot
         img = axes.pcolormesh(xi, yi, zi.reshape(xi.shape), cmap=cmap)
 
+        if greyblock:
+            axes.add_patch(mpatches.Polygon([[birth.min(), birth.min()], [death.max(), birth.min()], [death.max(), death.max()]], fill=True, color='lightgrey'))
+
         if legend:
             plt.colorbar(img, ax=axes)
 
-        axes.set_xlabel("Birth")
-        axes.set_ylabel("Death")
-        axes.set_title("Persistence density")
+        axes.set_xlabel("Birth", fontsize=fontsize)
+        axes.set_ylabel("Death", fontsize=fontsize)
+        axes.set_title(title, fontsize=fontsize)
+        if aspect_equal:
+            axes.set_aspect("equal")
+
         return axes
 
     except ImportError:


### PR DESCRIPTION
Did some (hopefully) nice improvements on persistence diagrams/barcode/density plot rendering. Main changes:

- Added option for fontsize (crucial when it comes to produce plot for a paper).
- Added option to change the title (but set the default titles to previous ones).
- Used Latex font as default
- Added a (optional) lightgrey block on the lower half plane. I find the rendering quite nice and it seems commonly used in TDA litterature. 
- Added option to set plot aspects to "equal" for dgm and density.
- [plot dgm] Turned the $\infty$ text into a "true" `axis.yticklabel`, improving readability. 
- [dgm and density] Modified the line draw methods (why did it plot (x, x) for 1000 values of x instead of just a line between (min, min) and (max, max) ?). It doesn't change the rendering but might (slightly) improve the running time.

What could be also done:

- [x] Provide an option to plot diagrams that comes from a different format, such as (N x 2) numpy arrays, as Python implementations in `representations` are mostly using this format if I am correct. [EDIT] Did a quick but hopefully useful change to handle (N x 2) numpy arrays as input for the plot functions. [EDIT VR] Fix #27 
- [x] Add more flexibility features (removing xticklabels, etc.). [EDIT] We actually removed these as the functions return axis ==> the user can do these modifications by him/herself.
- [x] Remove the +\infty line if there is no point at infty.