### PR TITLE
Add 3 pip runtime dependencies

### DIFF
--- a/.github/test-requirements.txt
+++ b/.github/test-requirements.txt
@@ -7,3 +7,6 @@ scipy
 scikit-learn
 POT
 tensorflow
+torch
+pykeops
+hnswlib


### PR DESCRIPTION
I am using those for nearest neighbors in a branch I'll submit soon.
I am not sure how well things that use CUDA on my computer will work on CI...
Do we want to limit the number of pip packages we install, or is it fine to keep adding more?