### PR TITLE
Improve local bibliographies in python

### DIFF
--- a/src/python/doc/alpha_complex_user.rst
+++ b/src/python/doc/alpha_complex_user.rst
@@ -209,4 +209,3 @@ CGAL citations
 .. bibliography:: ../../biblio/how_to_cite_cgal.bib
    :filter: docname in docnames
    :style: unsrt
-   :labelprefix: A

--- a/src/python/doc/alpha_complex_user.rst
+++ b/src/python/doc/alpha_complex_user.rst
@@ -207,5 +207,5 @@ CGAL citations
 ==============
 
 .. bibliography:: ../../biblio/how_to_cite_cgal.bib
-   :filter: docnames
+   :filter: docname in docnames
    :style: unsrt

--- a/src/python/doc/alpha_complex_user.rst
+++ b/src/python/doc/alpha_complex_user.rst
@@ -204,7 +204,7 @@ the program output is:
    [3, 6] -> 30.25
 
 CGAL citations
-==============
+--------------
 
 .. bibliography:: ../../biblio/how_to_cite_cgal.bib
    :filter: docname in docnames

--- a/src/python/doc/alpha_complex_user.rst
+++ b/src/python/doc/alpha_complex_user.rst
@@ -209,3 +209,4 @@ CGAL citations
 .. bibliography:: ../../biblio/how_to_cite_cgal.bib
    :filter: docname in docnames
    :style: unsrt
+   :labelprefix: A

--- a/src/python/doc/bottleneck_distance_user.rst
+++ b/src/python/doc/bottleneck_distance_user.rst
@@ -67,7 +67,7 @@ The output is:
     Bottleneck distance value = 0.75
 
 Bibliography
-============
+------------
 
 .. bibliography:: ../../biblio/bibliography.bib
    :filter: docname in docnames

--- a/src/python/doc/bottleneck_distance_user.rst
+++ b/src/python/doc/bottleneck_distance_user.rst
@@ -65,3 +65,10 @@ The output is:
 
     Bottleneck distance approximation = 0.81
     Bottleneck distance value = 0.75
+
+Bibliography
+============
+
+.. bibliography:: ../../biblio/bibliography.bib
+   :filter: docname in docnames
+   :style: unsrt

--- a/src/python/doc/bottleneck_distance_user.rst
+++ b/src/python/doc/bottleneck_distance_user.rst
@@ -72,4 +72,3 @@ Bibliography
 .. bibliography:: ../../biblio/bibliography.bib
    :filter: docname in docnames
    :style: unsrt
-   :labelprefix: B

--- a/src/python/doc/bottleneck_distance_user.rst
+++ b/src/python/doc/bottleneck_distance_user.rst
@@ -72,3 +72,4 @@ Bibliography
 .. bibliography:: ../../biblio/bibliography.bib
    :filter: docname in docnames
    :style: unsrt
+   :labelprefix: B

--- a/src/python/doc/cubical_complex_user.rst
+++ b/src/python/doc/cubical_complex_user.rst
@@ -165,4 +165,3 @@ Bibliography
 .. bibliography:: ../../biblio/bibliography.bib
    :filter: docname in docnames
    :style: unsrt
-   :labelprefix: CC

--- a/src/python/doc/cubical_complex_user.rst
+++ b/src/python/doc/cubical_complex_user.rst
@@ -163,5 +163,5 @@ Bibliography
 ============
 
 .. bibliography:: ../../biblio/bibliography.bib
-   :filter: docnames
+   :filter: docname in docnames
    :style: unsrt

--- a/src/python/doc/cubical_complex_user.rst
+++ b/src/python/doc/cubical_complex_user.rst
@@ -160,7 +160,7 @@ Examples.
 End user programs are available in python/example/ folder.
 
 Bibliography
-============
+------------
 
 .. bibliography:: ../../biblio/bibliography.bib
    :filter: docname in docnames

--- a/src/python/doc/cubical_complex_user.rst
+++ b/src/python/doc/cubical_complex_user.rst
@@ -165,3 +165,4 @@ Bibliography
 .. bibliography:: ../../biblio/bibliography.bib
    :filter: docname in docnames
    :style: unsrt
+   :labelprefix: CC

--- a/src/python/doc/index.rst
+++ b/src/python/doc/index.rst
@@ -92,3 +92,4 @@ Bibliography
 .. bibliography:: ../../biblio/bibliography.bib
    :filter: docname in docnames
    :style: unsrt
+   :labelprefix: I

--- a/src/python/doc/index.rst
+++ b/src/python/doc/index.rst
@@ -92,4 +92,3 @@ Bibliography
 .. bibliography:: ../../biblio/bibliography.bib
    :filter: docname in docnames
    :style: unsrt
-   :labelprefix: I

--- a/src/python/doc/index.rst
+++ b/src/python/doc/index.rst
@@ -90,5 +90,5 @@ Bibliography
 ************
 
 .. bibliography:: ../../biblio/bibliography.bib
-   :filter: docnames
+   :filter: docname in docnames
    :style: unsrt

--- a/src/python/doc/nerve_gic_complex_ref.rst
+++ b/src/python/doc/nerve_gic_complex_ref.rst
@@ -12,3 +12,10 @@ Cover complexes reference manual
    :show-inheritance:
 
    .. automethod:: gudhi.CoverComplex.__init__
+
+Bibliography
+------------
+
+.. bibliography:: ../../biblio/bibliography.bib
+   :filter: docname in docnames
+   :style: unsrt

--- a/src/python/doc/nerve_gic_complex_user.rst
+++ b/src/python/doc/nerve_gic_complex_user.rst
@@ -313,3 +313,10 @@ the program outputs again SC.dot which gives the following visualization after u
     :alt: Visualization with neato
 
     Visualization with neato
+
+Bibliography
+============
+
+.. bibliography:: ../../biblio/bibliography.bib
+   :filter: docname in docnames
+   :style: unsrt

--- a/src/python/doc/nerve_gic_complex_user.rst
+++ b/src/python/doc/nerve_gic_complex_user.rst
@@ -320,3 +320,4 @@ Bibliography
 .. bibliography:: ../../biblio/bibliography.bib
    :filter: docname in docnames
    :style: unsrt
+   :labelprefix: N

--- a/src/python/doc/nerve_gic_complex_user.rst
+++ b/src/python/doc/nerve_gic_complex_user.rst
@@ -315,7 +315,7 @@ the program outputs again SC.dot which gives the following visualization after u
     Visualization with neato
 
 Bibliography
-============
+------------
 
 .. bibliography:: ../../biblio/bibliography.bib
    :filter: docname in docnames

--- a/src/python/doc/nerve_gic_complex_user.rst
+++ b/src/python/doc/nerve_gic_complex_user.rst
@@ -320,4 +320,3 @@ Bibliography
 .. bibliography:: ../../biblio/bibliography.bib
    :filter: docname in docnames
    :style: unsrt
-   :labelprefix: N

--- a/src/python/doc/persistent_cohomology_user.rst
+++ b/src/python/doc/persistent_cohomology_user.rst
@@ -118,3 +118,4 @@ Bibliography
 .. bibliography:: ../../biblio/bibliography.bib
    :filter: docname in docnames
    :style: unsrt
+   :labelprefix: PC

--- a/src/python/doc/persistent_cohomology_user.rst
+++ b/src/python/doc/persistent_cohomology_user.rst
@@ -118,4 +118,3 @@ Bibliography
 .. bibliography:: ../../biblio/bibliography.bib
    :filter: docname in docnames
    :style: unsrt
-   :labelprefix: PC

--- a/src/python/doc/persistent_cohomology_user.rst
+++ b/src/python/doc/persistent_cohomology_user.rst
@@ -116,5 +116,5 @@ Bibliography
 ============
 
 .. bibliography:: ../../biblio/bibliography.bib
-   :filter: docnames
+   :filter: docname in docnames
    :style: unsrt

--- a/src/python/doc/persistent_cohomology_user.rst
+++ b/src/python/doc/persistent_cohomology_user.rst
@@ -113,7 +113,7 @@ We provide several example files: run these examples with -h for details on thei
     * :download:`tangential_complex_plain_homology_from_off_file_example.py <../example/tangential_complex_plain_homology_from_off_file_example.py>`
 
 Bibliography
-============
+------------
 
 .. bibliography:: ../../biblio/bibliography.bib
    :filter: docname in docnames

--- a/src/python/doc/rips_complex_user.rst
+++ b/src/python/doc/rips_complex_user.rst
@@ -354,4 +354,3 @@ Bibliography
 .. bibliography:: ../../biblio/bibliography.bib
    :filter: docname in docnames
    :style: unsrt
-   :labelprefix: R

--- a/src/python/doc/rips_complex_user.rst
+++ b/src/python/doc/rips_complex_user.rst
@@ -347,3 +347,10 @@ until dimension 1 - one skeleton graph in other words), the output is:
     points in the persistence diagram will be under the diagonal, and
     bottleneck distance and persistence graphical tool will not work properly,
     this is a known issue.
+
+Bibliography
+============
+
+.. bibliography:: ../../biblio/bibliography.bib
+   :filter: docname in docnames
+   :style: unsrt

--- a/src/python/doc/rips_complex_user.rst
+++ b/src/python/doc/rips_complex_user.rst
@@ -349,7 +349,7 @@ until dimension 1 - one skeleton graph in other words), the output is:
     this is a known issue.
 
 Bibliography
-============
+------------
 
 .. bibliography:: ../../biblio/bibliography.bib
    :filter: docname in docnames

--- a/src/python/doc/rips_complex_user.rst
+++ b/src/python/doc/rips_complex_user.rst
@@ -354,3 +354,4 @@ Bibliography
 .. bibliography:: ../../biblio/bibliography.bib
    :filter: docname in docnames
    :style: unsrt
+   :labelprefix: R

--- a/src/python/doc/simplex_tree_user.rst
+++ b/src/python/doc/simplex_tree_user.rst
@@ -73,4 +73,3 @@ Bibliography
 .. bibliography:: ../../biblio/bibliography.bib
    :filter: docname in docnames
    :style: unsrt
-   :labelprefix: ST

--- a/src/python/doc/simplex_tree_user.rst
+++ b/src/python/doc/simplex_tree_user.rst
@@ -68,7 +68,7 @@ The output is:
     ([2], 4.0)
 
 Bibliography
-============
+------------
 
 .. bibliography:: ../../biblio/bibliography.bib
    :filter: docname in docnames

--- a/src/python/doc/simplex_tree_user.rst
+++ b/src/python/doc/simplex_tree_user.rst
@@ -73,3 +73,4 @@ Bibliography
 .. bibliography:: ../../biblio/bibliography.bib
    :filter: docname in docnames
    :style: unsrt
+   :labelprefix: ST

--- a/src/python/doc/simplex_tree_user.rst
+++ b/src/python/doc/simplex_tree_user.rst
@@ -66,3 +66,10 @@ The output is:
     ([1, 2], 4.0)
     ([1], 0.0)
     ([2], 4.0)
+
+Bibliography
+============
+
+.. bibliography:: ../../biblio/bibliography.bib
+   :filter: docname in docnames
+   :style: unsrt

--- a/src/python/doc/tangential_complex_user.rst
+++ b/src/python/doc/tangential_complex_user.rst
@@ -202,3 +202,4 @@ Bibliography
 .. bibliography:: ../../biblio/bibliography.bib
    :filter: docname in docnames
    :style: unsrt
+   :labelprefix: TA

--- a/src/python/doc/tangential_complex_user.rst
+++ b/src/python/doc/tangential_complex_user.rst
@@ -202,4 +202,3 @@ Bibliography
 .. bibliography:: ../../biblio/bibliography.bib
    :filter: docname in docnames
    :style: unsrt
-   :labelprefix: TA

--- a/src/python/doc/tangential_complex_user.rst
+++ b/src/python/doc/tangential_complex_user.rst
@@ -197,7 +197,7 @@ The output is:
 
 
 Bibliography
-============
+------------
 
 .. bibliography:: ../../biblio/bibliography.bib
    :filter: docname in docnames

--- a/src/python/doc/tangential_complex_user.rst
+++ b/src/python/doc/tangential_complex_user.rst
@@ -200,5 +200,5 @@ Bibliography
 ============
 
 .. bibliography:: ../../biblio/bibliography.bib
-   :filter: docnames
+   :filter: docname in docnames
    :style: unsrt

--- a/src/python/doc/wasserstein_distance_user.rst
+++ b/src/python/doc/wasserstein_distance_user.rst
@@ -84,3 +84,10 @@ The output is:
     point 1 in dgm1 is matched to point 2 in dgm2
     point 2 in dgm1 is matched to the diagonal
     point 1 in dgm2 is matched to the diagonal
+
+Bibliography
+============
+
+.. bibliography:: ../../biblio/bibliography.bib
+   :filter: docname in docnames
+   :style: unsrt

--- a/src/python/doc/wasserstein_distance_user.rst
+++ b/src/python/doc/wasserstein_distance_user.rst
@@ -91,4 +91,3 @@ Bibliography
 .. bibliography:: ../../biblio/bibliography.bib
    :filter: docname in docnames
    :style: unsrt
-   :labelprefix: WA

--- a/src/python/doc/wasserstein_distance_user.rst
+++ b/src/python/doc/wasserstein_distance_user.rst
@@ -86,7 +86,7 @@ The output is:
     point 1 in dgm2 is matched to the diagonal
 
 Bibliography
-============
+------------
 
 .. bibliography:: ../../biblio/bibliography.bib
    :filter: docname in docnames

--- a/src/python/doc/wasserstein_distance_user.rst
+++ b/src/python/doc/wasserstein_distance_user.rst
@@ -91,3 +91,4 @@ Bibliography
 .. bibliography:: ../../biblio/bibliography.bib
    :filter: docname in docnames
    :style: unsrt
+   :labelprefix: WA

--- a/src/python/doc/witness_complex_user.rst
+++ b/src/python/doc/witness_complex_user.rst
@@ -133,4 +133,3 @@ Bibliography
 .. bibliography:: ../../biblio/bibliography.bib
    :filter: docname in docnames
    :style: unsrt
-   :labelprefix: WI

--- a/src/python/doc/witness_complex_user.rst
+++ b/src/python/doc/witness_complex_user.rst
@@ -131,5 +131,5 @@ Bibliography
 ============
 
 .. bibliography:: ../../biblio/bibliography.bib
-   :filter: docnames
+   :filter: docname in docnames
    :style: unsrt

--- a/src/python/doc/witness_complex_user.rst
+++ b/src/python/doc/witness_complex_user.rst
@@ -128,7 +128,7 @@ Here is an example of constructing a strong witness complex filtration and compu
 * :download:`euclidean_strong_witness_complex_diagram_persistence_from_off_file_example.py <../example/euclidean_strong_witness_complex_diagram_persistence_from_off_file_example.py>`
 
 Bibliography
-============
+------------
 
 .. bibliography:: ../../biblio/bibliography.bib
    :filter: docname in docnames

--- a/src/python/doc/witness_complex_user.rst
+++ b/src/python/doc/witness_complex_user.rst
@@ -133,3 +133,4 @@ Bibliography
 .. bibliography:: ../../biblio/bibliography.bib
    :filter: docname in docnames
    :style: unsrt
+   :labelprefix: WI


### PR DESCRIPTION
I also experimented with changes that remove most warnings, but didn't like the results.
I still get some weirdness, for instance in Wasserstein both references appear as [2], but the links work properly...
Helps with #270.