### PR TITLE
Fix TBB Warning: tbb/task_scheduler_init.h is deprecated.

### DIFF
--- a/src/Persistent_cohomology/example/rips_persistence_via_boundary_matrix.cpp
+++ b/src/Persistent_cohomology/example/rips_persistence_via_boundary_matrix.cpp
@@ -17,10 +17,6 @@
 
 #include <boost/program_options.hpp>
 
-#ifdef GUDHI_USE_TBB
-#include <tbb/task_scheduler_init.h>
-#endif
-
 #include <string>
 #include <vector>
 
@@ -67,11 +63,6 @@ int main(int argc, char * argv[]) {
   std::clog << "The complex contains " << st.num_simplices() << " simplices \n";
   std::clog << "   and has dimension " << st.dimension() << " \n";
 
-#ifdef GUDHI_USE_TBB
-  // Unnecessary, but clarifies which operations are parallel.
-  tbb::task_scheduler_init ts;
-#endif
-
   // Sort the simplices in the order of the filtration
   st.initialize_filtration();
   int count = 0;
@@ -80,10 +71,6 @@ int main(int argc, char * argv[]) {
 
   // Convert to a more convenient representation.
   Gudhi::Hasse_complex<> hcpx(st);
-
-#ifdef GUDHI_USE_TBB
-  ts.terminate();
-#endif
 
   // Free some space.
   delete &st;


### PR DESCRIPTION
Fix #266 

It seems the only place this needs to be fixed as explained on [tbb deprecated page](https://www.threadingbuildingblocks.org/docs/help/reference/appendices/deprecated_features/redundant/task_scheduler_init_cls.html).

In `src/cmake/modules/FindTBB.cmake`, FindTBB can continue to find `tbb/task_scheduler_init.h` as this file will still exist.

In `src/Tangential_complex/benchmark/benchmark_tc.cpp`, we can continue to set the number of threads as explained in tbb documentation.