### PR TITLE
Build with conda as pip with brew fails

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,10 +10,10 @@ jobs:
       matrix:
         Python36:
           python.version: '3.6'
-        Python37:
-          python.version: '3.7'
-        Python38:
-          python.version: '3.8'
+        #Python37:
+        #  python.version: '3.7'
+        #Python38:
+        #  python.version: '3.8'
 
     steps:
     - bash: echo "##vso[task.prependpath]$CONDA/bin"
@@ -26,11 +26,12 @@ jobs:
         source activate gudhi_build_env
         sudo conda install --yes --quiet --name gudhi_build_env python=$PYTHON_VERSION
         sudo conda install --yes -c conda-forge doxygen eigen boost-cpp=1.70.0 cgal-cpp>=5.0
-        git submodule update --init
         python -m pip install --user -r .github/build-requirements.txt
         python -m pip install --user -r .github/test-requirements.txt
       displayName: 'Install build dependencies'
     - bash: |
+        source activate gudhi_build_env
+        git submodule update --init
         mkdir build
         cd build
         cmake -DCMAKE_BUILD_TYPE:STRING=$(CMakeBuildType) -DWITH_GUDHI_TEST=ON -DWITH_GUDHI_UTILITIES=ON -DWITH_GUDHI_PYTHON=ON -DPython_ADDITIONAL_VERSIONS=3 ..

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,6 +10,7 @@ jobs:
       matrix:
         Python36:
           python.version: '3.6'
+          CMakeBuildType: Release
         #Python37:
         #  python.version: '3.7'
         #Python38:
@@ -25,6 +26,7 @@ jobs:
     - bash: |
         source activate gudhi_build_env
         sudo conda install --yes --quiet --name gudhi_build_env python=$PYTHON_VERSION
+        sudo conda update --yes --quiet -n base -c defaults conda
         sudo conda install --yes -c conda-forge doxygen eigen boost-cpp=1.70.0 cgal-cpp>=5.0
         python -m pip install --user -r .github/build-requirements.txt
         python -m pip install --user -r .github/test-requirements.txt

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,7 +19,7 @@ jobs:
     - bash: echo "##vso[task.prependpath]$CONDA/bin"
       displayName: Add conda to PATH
   
-    - bash: conda create --yes --quiet --name gudhi_build_env
+    - bash: sudo conda create --yes --quiet --name gudhi_build_env
       displayName: Create Anaconda environment
   
     - bash: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,35 +4,36 @@ jobs:
     displayName: "Build and test"
     timeoutInMinutes: 0
     cancelTimeoutInMinutes: 60
-  
+    pool:
+      vmImage: macOS-10.14
     strategy:
       matrix:
-        macOSrelease:
-          imageName: 'macos-10.14'
-          CMakeBuildType: Release
-          customInstallation: 'brew update && brew install graphviz doxygen boost eigen gmp mpfr tbb cgal'
+        Python36:
+          python.version: '3.6'
+        Python37:
+          python.version: '3.7'
+        Python38:
+          python.version: '3.8'
 
-    pool:
-      vmImage: $(imageName)
-  
     steps:
-    - task: UsePythonVersion@0
-      inputs:
-        versionSpec: '3.7'
-        architecture: 'x64'
+    - bash: echo "##vso[task.prependpath]$CONDA/bin"
+      displayName: Add conda to PATH
   
-    - script: |
-        $(customInstallation)
+    - bash: conda create --yes --quiet --name gudhi_build_env
+      displayName: Create Anaconda environment
+  
+    - bash: |
+        source activate gudhi_build_env
+        conda install --yes --quiet --name gudhi_build_env python=$PYTHON_VERSION
         git submodule update --init
-        python -m pip install --upgrade pip
         python -m pip install --user -r .github/build-requirements.txt
         python -m pip install --user -r .github/test-requirements.txt
       displayName: 'Install build dependencies'
-    - script: |
+    - bash: |
         mkdir build
         cd build
         cmake -DCMAKE_BUILD_TYPE:STRING=$(CMakeBuildType) -DWITH_GUDHI_TEST=ON -DWITH_GUDHI_UTILITIES=ON -DWITH_GUDHI_PYTHON=ON -DPython_ADDITIONAL_VERSIONS=3 ..
         make
         make doxygen
-        ctest -j 8 --output-on-failure -E sphinx # remove sphinx build as it fails
+        ctest -j 8 --output-on-failure # -E sphinx remove sphinx build as it fails
       displayName: 'Build, test and documentation generation'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -25,6 +25,7 @@ jobs:
     - bash: |
         source activate gudhi_build_env
         sudo conda install --yes --quiet --name gudhi_build_env python=$PYTHON_VERSION
+        sudo conda install --yes -c conda-forge doxygen eigen boost-cpp=1.70.0 cgal-cpp>=5.0
         git submodule update --init
         python -m pip install --user -r .github/build-requirements.txt
         python -m pip install --user -r .github/test-requirements.txt

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,7 +24,7 @@ jobs:
   
     - bash: |
         source activate gudhi_build_env
-        conda install --yes --quiet --name gudhi_build_env python=$PYTHON_VERSION
+        sudo conda install --yes --quiet --name gudhi_build_env python=$PYTHON_VERSION
         git submodule update --init
         python -m pip install --user -r .github/build-requirements.txt
         python -m pip install --user -r .github/test-requirements.txt

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,16 +6,10 @@ jobs:
     cancelTimeoutInMinutes: 60
     pool:
       vmImage: macOS-10.14
-    strategy:
-      matrix:
-        Python36:
-          python.version: '3.6'
-          CMakeBuildType: Release
-          customInstallation: 'brew update && brew install graphviz doxygen boost eigen gmp mpfr tbb cgal'
-        #Python37:
-        #  python.version: '3.7'
-        #Python38:
-        #  python.version: '3.8'
+    variables:
+      pythonVersion: '3.6'
+      cmakeBuildType: Release
+      customInstallation: 'brew update && brew install graphviz doxygen boost eigen gmp mpfr tbb cgal'
 
     steps:
     - bash: echo "##vso[task.prependpath]$CONDA/bin"
@@ -26,7 +20,7 @@ jobs:
   
     - bash: |
         source activate gudhi_build_env
-        sudo conda install --yes --quiet --name gudhi_build_env python=$PYTHON_VERSION
+        sudo conda install --yes --quiet --name gudhi_build_env python=$(pythonVersion)
         python -m pip install --user -r .github/build-requirements.txt
         python -m pip install --user -r .github/test-requirements.txt
         $(customInstallation)
@@ -36,8 +30,8 @@ jobs:
         git submodule update --init
         mkdir build
         cd build
-        cmake -DCMAKE_BUILD_TYPE:STRING=$(CMakeBuildType) -DWITH_GUDHI_TEST=ON -DWITH_GUDHI_UTILITIES=ON -DWITH_GUDHI_PYTHON=ON -DPython_ADDITIONAL_VERSIONS=3 ..
-        make
+        cmake -DCMAKE_BUILD_TYPE:STRING=$(cmakeBuildType) -DWITH_GUDHI_TEST=ON -DWITH_GUDHI_UTILITIES=ON -DWITH_GUDHI_PYTHON=ON -DPython_ADDITIONAL_VERSIONS=3 ..
+        make -j 4
         make doxygen
-        ctest -j 8 --output-on-failure # -E sphinx remove sphinx build as it fails
+        ctest -j 4 --output-on-failure -E sphinx # remove sphinx build as it fails
       displayName: 'Build, test and documentation generation'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,6 +11,7 @@ jobs:
         Python36:
           python.version: '3.6'
           CMakeBuildType: Release
+          customInstallation: 'brew update && brew install graphviz doxygen boost eigen gmp mpfr tbb cgal'
         #Python37:
         #  python.version: '3.7'
         #Python38:
@@ -26,10 +27,9 @@ jobs:
     - bash: |
         source activate gudhi_build_env
         sudo conda install --yes --quiet --name gudhi_build_env python=$PYTHON_VERSION
-        sudo conda update --yes --quiet -n base -c defaults conda
-        sudo conda install --yes -c conda-forge doxygen eigen boost-cpp=1.70.0 cgal-cpp>=5.0
         python -m pip install --user -r .github/build-requirements.txt
         python -m pip install --user -r .github/test-requirements.txt
+        $(customInstallation)
       displayName: 'Install build dependencies'
     - bash: |
         source activate gudhi_build_env


### PR DESCRIPTION
I tried to install eigen, cgal and boost with conda but it fails at link with boost-test (cf. this [build log](https://dev.azure.com/GUDHI/gudhi-devel/_build/results?buildId=213&view=logs&jobId=d7d66435-5ae4-561a-5876-2cd4e19b3ce2&j=d7d66435-5ae4-561a-5876-2cd4e19b3ce2&t=ce6ffbeb-bfe2-5291-5596-9f8fd91bb86e).
This PR is just a work around that uses python and pip from a conda installation.