### PR TITLE
Bottleneck cython interface

### DIFF
--- a/src/python/gudhi/alpha_complex.pyx
+++ b/src/python/gudhi/alpha_complex.pyx
@@ -27,11 +27,11 @@ __license__ = "GPL v3"
 
 cdef extern from "Alpha_complex_interface.h" namespace "Gudhi":
     cdef cppclass Alpha_complex_interface "Gudhi::alpha_complex::Alpha_complex_interface":
-        Alpha_complex_interface(vector[vector[double]] points) except +
+        Alpha_complex_interface(vector[vector[double]] points) nogil except +
         # bool from_file is a workaround for cython to find the correct signature
-        Alpha_complex_interface(string off_file, bool from_file) except +
-        vector[double] get_point(int vertex) except +
-        void create_simplex_tree(Simplex_tree_interface_full_featured* simplex_tree, double max_alpha_square) except +
+        Alpha_complex_interface(string off_file, bool from_file) nogil except +
+        vector[double] get_point(int vertex) nogil except +
+        void create_simplex_tree(Simplex_tree_interface_full_featured* simplex_tree, double max_alpha_square) nogil except +
 
 # AlphaComplex python interface
 cdef class AlphaComplex:
@@ -70,6 +70,7 @@ cdef class AlphaComplex:
 
     # The real cython constructor
     def __cinit__(self, points = None, off_file = ''):
+        cdef vector[vector[double]] pts
         if off_file:
             if os.path.isfile(off_file):
                 self.thisptr = new Alpha_complex_interface(
@@ -80,7 +81,9 @@ cdef class AlphaComplex:
             if points is None:
                 # Empty Alpha construction
                 points=[]
-            self.thisptr = new Alpha_complex_interface(points)
+            pts = points
+            with nogil:
+                self.thisptr = new Alpha_complex_interface(pts)
                 
 
     def __dealloc__(self):
@@ -113,6 +116,8 @@ cdef class AlphaComplex:
         :rtype: SimplexTree
         """
         stree = SimplexTree()
+        cdef double mas = max_alpha_square
         cdef intptr_t stree_int_ptr=stree.thisptr
-        self.thisptr.create_simplex_tree(<Simplex_tree_interface_full_featured*>stree_int_ptr, max_alpha_square)
+        with nogil:
+            self.thisptr.create_simplex_tree(<Simplex_tree_interface_full_featured*>stree_int_ptr, mas)
         return stree

--- a/src/python/gudhi/bottleneck.pyx
+++ b/src/python/gudhi/bottleneck.pyx
@@ -17,8 +17,8 @@ __copyright__ = "Copyright (C) 2016 Inria"
 __license__ = "GPL v3"
 
 cdef extern from "Bottleneck_distance_interface.h" namespace "Gudhi::persistence_diagram":
-    double bottleneck(vector[pair[double, double]], vector[pair[double, double]], double)
-    double bottleneck(vector[pair[double, double]], vector[pair[double, double]])
+    double bottleneck(vector[pair[double, double]], vector[pair[double, double]], double) nogil
+    double bottleneck(vector[pair[double, double]], vector[pair[double, double]]) nogil
 
 def bottleneck_distance(diagram_1, diagram_2, e=None):
     """This function returns the point corresponding to a given vertex.
@@ -40,9 +40,17 @@ def bottleneck_distance(diagram_1, diagram_2, e=None):
     :rtype: float
     :returns: the bottleneck distance.
     """
+    cdef vector[pair[double, double]] dgm1 = diagram_1
+    cdef vector[pair[double, double]] dgm2 = diagram_2
+    cdef double eps
+    cdef double ret
     if e is None:
-        # Default value is the smallest double value (not 0, 0 is for exact version)
-        return bottleneck(diagram_1, diagram_2)
+        with nogil:
+            # Default value is the smallest double value (not 0, 0 is for exact version)
+            ret = bottleneck(dgm1, dgm2)
     else:
-        # Can be 0 for exact version
-        return bottleneck(diagram_1, diagram_2, e)
+        eps = e
+        with nogil:
+            # Can be 0 for exact version
+            ret = bottleneck(dgm1, dgm2, eps)
+    return ret

--- a/src/python/gudhi/bottleneck.pyx
+++ b/src/python/gudhi/bottleneck.pyx
@@ -42,8 +42,8 @@ def bottleneck_distance(diagram_1, diagram_2, e=None):
     :rtype: float
     :returns: the bottleneck distance.
     """
-    diagram_1 = np.asarray(diagram_1, dtype=np.float64)
-    diagram_2 = np.asarray(diagram_2, dtype=np.float64)
+    diagram_1 = np.ascontiguousarray(diagram_1, dtype=np.float64)
+    diagram_2 = np.ascontiguousarray(diagram_2, dtype=np.float64)
     if diagram_1.size == 0:
         diagram_1, diagram_2 = diagram_2, diagram_1
     if diagram_1.size == 0:

--- a/src/python/gudhi/rips_complex.pyx
+++ b/src/python/gudhi/rips_complex.pyx
@@ -23,12 +23,12 @@ __license__ = "MIT"
 
 cdef extern from "Rips_complex_interface.h" namespace "Gudhi":
     cdef cppclass Rips_complex_interface "Gudhi::rips_complex::Rips_complex_interface":
-        Rips_complex_interface()
-        void init_points(vector[vector[double]] values, double threshold)
-        void init_matrix(vector[vector[double]] values, double threshold)
-        void init_points_sparse(vector[vector[double]] values, double threshold, double sparse)
-        void init_matrix_sparse(vector[vector[double]] values, double threshold, double sparse)
-        void create_simplex_tree(Simplex_tree_interface_full_featured* simplex_tree, int dim_max) except +
+        Rips_complex_interface() nogil
+        void init_points(vector[vector[double]] values, double threshold) nogil
+        void init_matrix(vector[vector[double]] values, double threshold) nogil
+        void init_points_sparse(vector[vector[double]] values, double threshold, double sparse) nogil
+        void init_matrix_sparse(vector[vector[double]] values, double threshold, double sparse) nogil
+        void create_simplex_tree(Simplex_tree_interface_full_featured* simplex_tree, int dim_max) nogil except +
 
 # RipsComplex python interface
 cdef class RipsComplex:
@@ -97,6 +97,7 @@ cdef class RipsComplex:
         """
         stree = SimplexTree()
         cdef intptr_t stree_int_ptr=stree.thisptr
-        self.thisref.create_simplex_tree(<Simplex_tree_interface_full_featured*>stree_int_ptr,
-            max_dimension)
+        cdef int maxdim = max_dimension
+        with nogil:
+            self.thisref.create_simplex_tree(<Simplex_tree_interface_full_featured*>stree_int_ptr, maxdim)
         return stree

--- a/src/python/gudhi/simplex_tree.pxd
+++ b/src/python/gudhi/simplex_tree.pxd
@@ -25,57 +25,56 @@ cdef extern from "Simplex_tree_interface.h" namespace "Gudhi":
         pass
 
     cdef cppclass Simplex_tree_simplices_iterator "Gudhi::Simplex_tree_interface<Gudhi::Simplex_tree_options_full_featured>::Complex_simplex_iterator":
-        Simplex_tree_simplices_iterator()
-        Simplex_tree_simplex_handle& operator*()
-        Simplex_tree_simplices_iterator operator++()
-        bint operator!=(Simplex_tree_simplices_iterator)
+        Simplex_tree_simplices_iterator() nogil
+        Simplex_tree_simplex_handle& operator*() nogil
+        Simplex_tree_simplices_iterator operator++() nogil
+        bint operator!=(Simplex_tree_simplices_iterator) nogil
 
     cdef cppclass Simplex_tree_skeleton_iterator "Gudhi::Simplex_tree_interface<Gudhi::Simplex_tree_options_full_featured>::Skeleton_simplex_iterator":
-        Simplex_tree_skeleton_iterator()
-        Simplex_tree_simplex_handle& operator*()
-        Simplex_tree_skeleton_iterator operator++()
-        bint operator!=(Simplex_tree_skeleton_iterator)
+        Simplex_tree_skeleton_iterator() nogil
+        Simplex_tree_simplex_handle& operator*() nogil
+        Simplex_tree_skeleton_iterator operator++() nogil
+        bint operator!=(Simplex_tree_skeleton_iterator) nogil
 
 
     cdef cppclass Simplex_tree_interface_full_featured "Gudhi::Simplex_tree_interface<Gudhi::Simplex_tree_options_full_featured>":
-        Simplex_tree()
-        double simplex_filtration(vector[int] simplex)
-        void assign_simplex_filtration(vector[int] simplex, double filtration)
-        void initialize_filtration()
-        int num_vertices()
-        int num_simplices()
-        void set_dimension(int dimension)
-        int dimension()
-        int upper_bound_dimension()
-        bool find_simplex(vector[int] simplex)
-        bool insert(vector[int] simplex, double filtration)
-        vector[pair[vector[int], double]] get_star(vector[int] simplex)
-        vector[pair[vector[int], double]] get_cofaces(vector[int] simplex,
-                                                          int dimension)
-        void expansion(int max_dim) except +
-        void remove_maximal_simplex(vector[int] simplex)
-        bool prune_above_filtration(double filtration)
-        bool make_filtration_non_decreasing()
-        void compute_extended_filtration()
-        vector[vector[pair[int, pair[double, double]]]] compute_extended_persistence_subdiagrams(vector[pair[int, pair[double, double]]] dgm, double min_persistence)
+        Simplex_tree() nogil
+        double simplex_filtration(vector[int] simplex) nogil
+        void assign_simplex_filtration(vector[int] simplex, double filtration) nogil
+        void initialize_filtration() nogil
+        int num_vertices() nogil
+        int num_simplices() nogil
+        void set_dimension(int dimension) nogil
+        int dimension() nogil
+        int upper_bound_dimension() nogil
+        bool find_simplex(vector[int] simplex) nogil
+        bool insert(vector[int] simplex, double filtration) nogil
+        vector[pair[vector[int], double]] get_star(vector[int] simplex) nogil
+        vector[pair[vector[int], double]] get_cofaces(vector[int] simplex, int dimension) nogil
+        void expansion(int max_dim) nogil except +
+        void remove_maximal_simplex(vector[int] simplex) nogil
+        bool prune_above_filtration(double filtration) nogil
+        bool make_filtration_non_decreasing() nogil
+        void compute_extended_filtration() nogil
+        vector[vector[pair[int, pair[double, double]]]] compute_extended_persistence_subdiagrams(vector[pair[int, pair[double, double]]] dgm, double min_persistence) nogil
         # Iterators over Simplex tree
-        pair[vector[int], double] get_simplex_and_filtration(Simplex_tree_simplex_handle f_simplex)
-        Simplex_tree_simplices_iterator get_simplices_iterator_begin()
-        Simplex_tree_simplices_iterator get_simplices_iterator_end()
-        vector[Simplex_tree_simplex_handle].const_iterator get_filtration_iterator_begin()
-        vector[Simplex_tree_simplex_handle].const_iterator get_filtration_iterator_end()
-        Simplex_tree_skeleton_iterator get_skeleton_iterator_begin(int dimension)
-        Simplex_tree_skeleton_iterator get_skeleton_iterator_end(int dimension)
+        pair[vector[int], double] get_simplex_and_filtration(Simplex_tree_simplex_handle f_simplex) nogil
+        Simplex_tree_simplices_iterator get_simplices_iterator_begin() nogil
+        Simplex_tree_simplices_iterator get_simplices_iterator_end() nogil
+        vector[Simplex_tree_simplex_handle].const_iterator get_filtration_iterator_begin() nogil
+        vector[Simplex_tree_simplex_handle].const_iterator get_filtration_iterator_end() nogil
+        Simplex_tree_skeleton_iterator get_skeleton_iterator_begin(int dimension) nogil
+        Simplex_tree_skeleton_iterator get_skeleton_iterator_end(int dimension) nogil
 
 cdef extern from "Persistent_cohomology_interface.h" namespace "Gudhi":
     cdef cppclass Simplex_tree_persistence_interface "Gudhi::Persistent_cohomology_interface<Gudhi::Simplex_tree<Gudhi::Simplex_tree_options_full_featured>>":
-        Simplex_tree_persistence_interface(Simplex_tree_interface_full_featured * st, bool persistence_dim_max)
-        void compute_persistence(int homology_coeff_field, double min_persistence)
-        vector[pair[int, pair[double, double]]] get_persistence()
-        vector[int] betti_numbers()
-        vector[int] persistent_betti_numbers(double from_value, double to_value)
-        vector[pair[double,double]] intervals_in_dimension(int dimension)
-        void write_output_diagram(string diagram_file_name) except +
-        vector[pair[vector[int], vector[int]]] persistence_pairs()
-        pair[vector[vector[int]], vector[vector[int]]] lower_star_generators()
-        pair[vector[vector[int]], vector[vector[int]]] flag_generators()
+        Simplex_tree_persistence_interface(Simplex_tree_interface_full_featured * st, bool persistence_dim_max) nogil
+        void compute_persistence(int homology_coeff_field, double min_persistence) nogil
+        vector[pair[int, pair[double, double]]] get_persistence() nogil
+        vector[int] betti_numbers() nogil
+        vector[int] persistent_betti_numbers(double from_value, double to_value) nogil
+        vector[pair[double,double]] intervals_in_dimension(int dimension) nogil
+        void write_output_diagram(string diagram_file_name) nogil except +
+        vector[pair[vector[int], vector[int]]] persistence_pairs() nogil
+        pair[vector[vector[int]], vector[vector[int]]] lower_star_generators() nogil
+        pair[vector[vector[int]], vector[vector[int]]] flag_generators() nogil

--- a/src/python/gudhi/simplex_tree.pyx
+++ b/src/python/gudhi/simplex_tree.pyx
@@ -33,7 +33,7 @@ cdef class SimplexTree:
     cdef public intptr_t thisptr
 
     # Get the pointer casted as it should be
-    cdef Simplex_tree_interface_full_featured* get_ptr(self):
+    cdef Simplex_tree_interface_full_featured* get_ptr(self) nogil:
         return <Simplex_tree_interface_full_featured*>(self.thisptr)
 
     cdef Simplex_tree_persistence_interface * pcohptr
@@ -343,7 +343,9 @@ cdef class SimplexTree:
         :param max_dim: The maximal dimension.
         :type max_dim: int.
         """
-        self.get_ptr().expansion(max_dim)
+        cdef int maxdim = max_dim
+        with nogil:
+            self.get_ptr().expansion(maxdim)
 
     def make_filtration_non_decreasing(self):
         """This function ensures that each simplex has a higher filtration
@@ -449,8 +451,12 @@ cdef class SimplexTree:
         """
         if self.pcohptr != NULL:
             del self.pcohptr
-        self.pcohptr = new Simplex_tree_persistence_interface(self.get_ptr(), persistence_dim_max)
-        self.pcohptr.compute_persistence(homology_coeff_field, min_persistence)
+        cdef bool pdm = persistence_dim_max
+        cdef int coef = homology_coeff_field
+        cdef double minp = min_persistence
+        with nogil:
+            self.pcohptr = new Simplex_tree_persistence_interface(self.get_ptr(), pdm)
+            self.pcohptr.compute_persistence(coef, minp)
 
     def betti_numbers(self):
         """This function returns the Betti numbers of the simplicial complex.

--- a/src/python/include/Bottleneck_distance_interface.h
+++ b/src/python/include/Bottleneck_distance_interface.h
@@ -13,6 +13,8 @@
 
 #include <gudhi/Bottleneck.h>
 
+#include <boost/range/iterator_range.hpp>
+
 #include <iostream>
 #include <vector>
 #include <utility>  // for std::pair
@@ -22,14 +24,22 @@ namespace Gudhi {
 namespace persistence_diagram {
 
   // bottleneck_distance function renamed for the python function can be called bottleneck_dstance
-  double bottleneck(const std::vector<std::pair<double, double>>& diag1,
-                    const std::vector<std::pair<double, double>>& diag2,
-                    double e) {
+  static double bottleneck(void* data1, std::ptrdiff_t n1,
+                           void* data2, std::ptrdiff_t n2,
+                           double e) {
+    auto p1 = static_cast<std::pair<double, double>*>(data1);
+    auto p2 = static_cast<std::pair<double, double>*>(data2);
+    auto diag1 = boost::make_iterator_range(p1, p1 + n1);
+    auto diag2 = boost::make_iterator_range(p2, p2 + n2);
     return bottleneck_distance(diag1, diag2, e);
   }
 
-  double bottleneck(const std::vector<std::pair<double, double>>& diag1,
-                    const std::vector<std::pair<double, double>>& diag2) {
+  static double bottleneck(void* data1, std::ptrdiff_t n1,
+                           void* data2, std::ptrdiff_t n2) {
+    auto p1 = static_cast<std::pair<double, double>*>(data1);
+    auto p2 = static_cast<std::pair<double, double>*>(data2);
+    auto diag1 = boost::make_iterator_range(p1, p1 + n1);
+    auto diag2 = boost::make_iterator_range(p2, p2 + n2);
     return bottleneck_distance(diag1, diag2);
   }
 


### PR DESCRIPTION
This comes on top of #304 and rewrites the cython interface of bottleneck to avoid copying vectors. We could avoid a copy in even more cases, accepting any numpy array and passing strides to C++, but then we might as well share the code with hera's interface.