### PR TITLE
More DOI in the biblio

### DIFF
--- a/biblio/bibliography.bib
+++ b/biblio/bibliography.bib
@@ -13,7 +13,9 @@ pages = {1--39},
 publisher = {JMLR.org},
 title = {{Statistical analysis and parameter selection for Mapper}},
 volume = {19},
-year = {2018}
+year = {2018},
+url = {http://jmlr.org/papers/v19/17-291.html},
+doi = {10.5555/3291125.3291137}
 }
 
 @inproceedings{Dey13,
@@ -22,6 +24,7 @@ year = {2018}
  booktitle = {Proceedings of the Twenty-ninth Annual Symposium on Computational Geometry},
  year = {2013},
  pages = {107--116},
+ doi = {10.1145/2462356.2462387}
 }
 
 @article{Carriere16,
@@ -832,6 +835,7 @@ book{hatcher2002algebraic,
   number    = {4},
   year      = {2010},
   pages     = {367-405},
+  doi       = {10.1007/s10208-010-9066-0},
   ee        = {http://dx.doi.org/10.1007/s10208-010-9066-0},
   bibsource = {DBLP, http://dblp.uni-trier.de}
 }
@@ -927,6 +931,7 @@ language={English}
   booktitle = {Symposium on Computational Geometry},
   year      = {2014},
   pages     = {345},
+  doi       = {10.1145/2582112.2582165},
   ee        = {http://doi.acm.org/10.1145/2582112.2582165},
   bibsource = {DBLP, http://dblp.uni-trier.de}
 }
@@ -1241,6 +1246,7 @@ year = "2011"
   title={Fr{\'e}chet means for distributions of persistence diagrams},
   author={Turner, Katharine and Mileyko, Yuriy and Mukherjee, Sayan and Harer, John},
   journal={Discrete \& Computational Geometry},
+  doi={10.1007/s00454-014-9604-7},
   volume={52},
   number={1},
   pages={44--70},

--- a/src/Persistent_cohomology/doc/Intro_persistent_cohomology.h
+++ b/src/Persistent_cohomology/doc/Intro_persistent_cohomology.h
@@ -21,7 +21,7 @@ namespace persistent_cohomology {
   \author    Clément Maria
 
   Computation of persistent cohomology using the algorithm of 
-  \cite DBLP:journals/dcg/SilvaMV11 and \cite DBLP:journals/corr/abs-1208-5018 
+  \cite DBLP:journals/dcg/SilvaMV11 and \cite DBLP:conf/compgeom/DeyFW14
   and the Compressed Annotation Matrix 
   implementation of \cite DBLP:conf/esa/BoissonnatDM13 
        

--- a/src/common/doc/main_page.md
+++ b/src/common/doc/main_page.md
@@ -312,7 +312,7 @@
     theory is essentially composed of three elements: topological spaces, their homology groups and an evolution
     scheme.
     Computation of persistent cohomology using the algorithm of \cite DBLP:journals/dcg/SilvaMV11 and
-    \cite DBLP:journals/corr/abs-1208-5018 and the Compressed Annotation Matrix implementation of
+    \cite DBLP:conf/compgeom/DeyFW14 and the Compressed Annotation Matrix implementation of
     \cite DBLP:conf/esa/BoissonnatDM13 .
     </td>
     <td width="15%">

--- a/src/python/doc/persistent_cohomology_sum.inc
+++ b/src/python/doc/persistent_cohomology_sum.inc
@@ -12,7 +12,7 @@
    |                                                                 |                                                                       |                                               |
    |                                                                 | Computation of persistent cohomology using the algorithm of           |                                               |
    |                                                                 | :cite:`DBLP:journals/dcg/SilvaMV11` and                               |                                               |
-   |                                                                 | :cite:`DBLP:journals/corr/abs-1208-5018` and the Compressed           |                                               |
+   |                                                                 | :cite:`DBLP:conf/compgeom/DeyFW14` and the Compressed                 |                                               |
    |                                                                 | Annotation Matrix implementation of                                   |                                               |
    |                                                                 | :cite:`DBLP:conf/esa/BoissonnatDM13`.                                 |                                               |
    |                                                                 |                                                                       |                                               |

--- a/src/python/doc/persistent_cohomology_user.rst
+++ b/src/python/doc/persistent_cohomology_user.rst
@@ -21,7 +21,7 @@ Definition
 
 
 Computation of persistent cohomology using the algorithm of :cite:`DBLP:journals/dcg/SilvaMV11` and
-:cite:`DBLP:journals/corr/abs-1208-5018` and the Compressed Annotation Matrix implementation of
+:cite:`DBLP:conf/compgeom/DeyFW14` and the Compressed Annotation Matrix implementation of
 :cite:`DBLP:conf/esa/BoissonnatDM13`.
      
 The theory of homology consists in attaching to a topological space a sequence of (homology) groups, capturing global


### PR DESCRIPTION
and update references from a preprint to the published version.

More entries in the bibliography could use a URL and/or DOI, I just added a few and quickly got bored.

The style we use for doxygen does not use the DOI at all, even when there is no other URL, while the one for sphinx shows both DOI and URL, even when the URL starts with `http://dx.doi.org/`, neither is optimal.