### PR TITLE
Entropic regularization for wasserstein distances

### DIFF
--- a/src/python/doc/wasserstein_distance_user.rst
+++ b/src/python/doc/wasserstein_distance_user.rst
@@ -153,6 +153,28 @@ Morozov, and Arnur Nigmetov.
 
 .. autofunction:: gudhi.hera.wasserstein_distance
 
+This example computes the 1-Wasserstein distance with infinity-norm as ground metric
+between 2 persistence diagrams with Euclidean ground metric.
+Note that persistence diagrams must be submitted as (n x 2) numpy arrays and can contain inf values.
+
+.. testcode::
+
+    import gudhi.hera
+    import numpy as np
+
+    dgm1 = np.array([[2.7, 3.7],[9.6, 14.],[34.2, 34.974], [1, np.inf]])
+    dgm2 = np.array([[2.8, 4.45],[9.5, 14.1], [2, np.inf]])
+
+    message = "Wasserstein distance value (hera) = " + '%.2f' % gudhi.hera.wasserstein_distance(dgm1, dgm2, order=1., internal_p=2.)
+    print(message)
+
+The output is:
+
+.. testoutput::
+
+    Wasserstein distance value (hera) = 2.45
+
+
 
 Barycenters
 -----------

--- a/src/python/doc/wasserstein_distance_user.rst
+++ b/src/python/doc/wasserstein_distance_user.rst
@@ -100,6 +100,57 @@ The output is:
     point 2 in dgm1 is matched to the diagonal
     point 1 in dgm2 is matched to the diagonal
 
+
+Entropic regularization
+***********************
+
+When using the Optimal Transport based version of wasserstein distances, 
+we also allow for the use of entropic regularization of optimal transport distance via the parameter ``reg``.
+If ``reg > 0``, we solve 
+:math:`\argmin_P \sum P_{ij} M_{ij} + reg * h(P)`
+under marginal constraints on :math:`P` , which can be understood as a generalized matching between the diagrams.
+:math:`P_{ij}` denotes the quantity of mass from the :math:`i`-th points in the first diagram that is
+transported to the :math:`j`-th point in the second diagram. Last row and column of :math:`P` denotes the diagonal
+by convention.
+Here :math:`M` is a matrix encoding the pairwises distances between the points of the two diagrams along with
+distances from points to the diagonal, and :math:`h(P) = \sum P_{ij} \log(P_{ij})` is the entropic regularization term.
+
+If ``matching=True``, we return both the estimated transport cost :math:`sum P_{ij} C_{ij}` and the computed :math:`P`, 
+otherwise we simply return the estimated transport cost.
+
+The closer ``reg`` is to 0, the closer the transport cost will be from the exact distance between the diagrams.
+The larger the regularization parameter, the faster the computation.
+Note however that taking too low values for ``reg`` can run into numerical issues.
+
+.. testcode::
+
+    import gudhi.wasserstein
+    import numpy as np
+
+    # regularization parameter
+    reg = 0.1
+
+    dgm1 = np.array([[2.7, 3.7], [4., 4.1]])
+    dgm2 = np.array([[2.8, 4.45]])
+    cost, P = gudhi.wasserstein.wasserstein_distance(dgm1, dgm2, matching=True, order=1, internal_p=2, reg=reg)
+
+    message_cost = "Regularized Wasserstein distance value = %.2f" %cost
+    print(message_cost)
+    print("Mass located in the first point of dgm1 transported to the first point of dgm2:")
+    print("%.3f" %P[0,0]) 
+    print("Mass located in the first point of dgm1 transported to the diagonal:")
+    print("%.3f" %P[0,1]) 
+
+
+.. testoutput::
+
+   Regularized Wasserstein distance value = 0.83
+   Mass located in the first point of dgm1 transported to the first point of dgm2:
+   0.995
+   Mass located in the first point of dgm1 transported to the diagonal:
+   0.004
+
+
 Barycenters
 -----------
 

--- a/src/python/doc/wasserstein_distance_user.rst
+++ b/src/python/doc/wasserstein_distance_user.rst
@@ -107,7 +107,7 @@ Entropic regularization
 When using the Optimal Transport based version of wasserstein distances, 
 we also allow for the use of entropic regularization of optimal transport distance via the parameter ``reg``.
 If ``reg > 0``, we solve 
-:math:`\argmin_P \sum P_{ij} M_{ij} + reg * h(P)`
+:math:`\min_P \sum P_{ij} M_{ij} + reg * h(P)`
 under marginal constraints on :math:`P` , which can be understood as a generalized matching between the diagrams.
 :math:`P_{ij}` denotes the quantity of mass from the :math:`i`-th points in the first diagram that is
 transported to the :math:`j`-th point in the second diagram. Last row and column of :math:`P` denotes the diagonal
@@ -115,7 +115,7 @@ by convention.
 Here :math:`M` is a matrix encoding the pairwises distances between the points of the two diagrams along with
 distances from points to the diagonal, and :math:`h(P) = \sum P_{ij} \log(P_{ij})` is the entropic regularization term.
 
-If ``matching=True``, we return both the estimated transport cost :math:`sum P_{ij} C_{ij}` and the computed :math:`P`, 
+If ``matching=True``, we return both the estimated transport cost :math:`\sum P_{ij} C_{ij}` and the computed :math:`P`, 
 otherwise we simply return the estimated transport cost.
 
 The closer ``reg`` is to 0, the closer the transport cost will be from the exact distance between the diagrams.
@@ -139,7 +139,7 @@ Note however that taking too low values for ``reg`` can run into numerical issue
     print("Mass located in the first point of dgm1 transported to the first point of dgm2:")
     print("%.3f" %P[0,0]) 
     print("Mass located in the first point of dgm1 transported to the diagonal:")
-    print("%.3f" %P[0,1]) 
+    print("%.3f" %P[0,-1]) 
 
 
 .. testoutput::

--- a/src/python/doc/wasserstein_distance_user.rst
+++ b/src/python/doc/wasserstein_distance_user.rst
@@ -148,7 +148,7 @@ Note however that taking too low values for ``reg`` can run into numerical issue
    Mass located in the first point of dgm1 transported to the first point of dgm2:
    0.995
    Mass located in the first point of dgm1 transported to the diagonal:
-   0.004
+   0.005
 
 
 Barycenters

--- a/src/python/doc/wasserstein_distance_user.rst
+++ b/src/python/doc/wasserstein_distance_user.rst
@@ -112,6 +112,8 @@ The larger the regularization parameter, the faster the computation.
 Note however that taking too low values for ``reg`` can run into numerical issues.
 
 This optimization problem is solved using the Python Optimal Transport library and relies on the Sinkhorn algorithm.
+
+
 .. testcode::
 
     import gudhi.wasserstein

--- a/src/python/doc/wasserstein_distance_user.rst
+++ b/src/python/doc/wasserstein_distance_user.rst
@@ -29,17 +29,6 @@ Diagrams via Optimal Transport" :cite:`10.5555/3327546.3327645`.
 
 .. autofunction:: gudhi.wasserstein.wasserstein_distance
 
-Hera
-****
-
-This other implementation comes from `Hera
-<https://bitbucket.org/grey_narn/hera/src/master/>`_ (BSD-3-Clause) which is
-based on "Geometry Helps to Compare Persistence Diagrams"
-:cite:`Kerber:2017:GHC:3047249.3064175` by Michael Kerber, Dmitriy
-Morozov, and Arnur Nigmetov.
-
-.. autofunction:: gudhi.hera.wasserstein_distance
-
 Basic example
 *************
 
@@ -106,7 +95,7 @@ Entropic regularization
 
 When using the Optimal Transport based version of wasserstein distances, 
 we also allow for the use of entropic regularization of optimal transport distance via the parameter ``reg``.
-If ``reg > 0``, we solve 
+If ``reg > 0``, we solve
 :math:`\min_P \sum P_{ij} M_{ij} + reg * h(P)`
 under marginal constraints on :math:`P` , which can be understood as a generalized matching between the diagrams.
 :math:`P_{ij}` denotes the quantity of mass from the :math:`i`-th points in the first diagram that is
@@ -122,6 +111,7 @@ The closer ``reg`` is to 0, the closer the transport cost will be from the exact
 The larger the regularization parameter, the faster the computation.
 Note however that taking too low values for ``reg`` can run into numerical issues.
 
+This optimization problem is solved using the Python Optimal Transport library and relies on the Sinkhorn algorithm.
 .. testcode::
 
     import gudhi.wasserstein
@@ -149,6 +139,19 @@ Note however that taking too low values for ``reg`` can run into numerical issue
    0.995
    Mass located in the first point of dgm1 transported to the diagonal:
    0.005
+
+
+Hera
+****
+
+We provide an alternative implementation to estimate Wasserstein distance between persistence diagrams.
+This one comes from `Hera
+<https://bitbucket.org/grey_narn/hera/src/master/>`_ (BSD-3-Clause) which is
+based on "Geometry Helps to Compare Persistence Diagrams"
+:cite:`Kerber:2017:GHC:3047249.3064175` by Michael Kerber, Dmitriy
+Morozov, and Arnur Nigmetov.
+
+.. autofunction:: gudhi.hera.wasserstein_distance
 
 
 Barycenters

--- a/src/python/doc/wasserstein_distance_user.rst
+++ b/src/python/doc/wasserstein_distance_user.rst
@@ -131,6 +131,7 @@ This optimization problem is solved using the Python Optimal Transport library a
     print("Mass located in the first point of dgm1 transported to the diagonal:")
     print("%.3f" %P[0,-1]) 
 
+The output is
 
 .. testoutput::
 

--- a/src/python/gudhi/wasserstein/__init__.py
+++ b/src/python/gudhi/wasserstein/__init__.py
@@ -1,1 +1,6 @@
+__copyright__ = "Copyright (C) 2019 Inria"
+__license__ = "MIT"
+__author__ = "Theo Lacombe"
+
+
 from .wasserstein import wasserstein_distance

--- a/src/python/gudhi/wasserstein/wasserstein.py
+++ b/src/python/gudhi/wasserstein/wasserstein.py
@@ -99,13 +99,13 @@ def wasserstein_distance(X, Y, matching=False, order=2., internal_p=2., reg=0., 
     :param order: exponent for Wasserstein; Default value is 2.
     :param internal_p: Ground metric on the (upper-half) plane (i.e. norm L^p in R^2);
                        Default value is 2 (Euclidean norm).
-    :param reg: entropic regularization paramter. If 0. (default), exact distance is computed. Beware that low
-                values of ``reg`` might lead to numerical instability.
-                Note that using ``reg>0`` is incompatible with ``enable_autodiff=True`` for now.
-                Using ``reg>0`` with ``matching=True`` returns a transport plan, that is a (n+1)x(m+1) matrix.
+    :param reg: entropic regularization parameter. If 0. (default), exact distance is computed. Beware that low
+                values of `reg` might lead to numerical instability.
+                Note that using `reg>0` is incompatible with `enable_autodiff=True` for now.
+                Using `reg>0` with `matching=True` returns a transport plan, that is a (n+1)x(m+1) matrix.
     :param enable_autodiff: If X and Y are torch.tensor, tensorflow.Tensor or jax.numpy.ndarray, make the computation
         transparent to automatic differentiation. This requires the package EagerPy and is currently incompatible
-        with `matching=True`.
+        with `matching=True` or `reg > 0`.
 
         .. note:: This considers the function defined on the coordinates of the off-diagonal points of X and Y
             and lets the various frameworks compute its gradient. It never pulls new points from the diagonal.

--- a/src/python/gudhi/wasserstein/wasserstein.py
+++ b/src/python/gudhi/wasserstein/wasserstein.py
@@ -173,7 +173,7 @@ def wasserstein_distance(X, Y, matching=False, order=2., internal_p=2., reg=0., 
         return ep.concatenate(dists).norms.lp(order).raw
         # We can also concatenate the 3 vectors to compute just one norm.
 
-    # Comptuation of the otcost using the ot.emd2 library, and matching/transport plan using ot.emd.
+    # Computation of the otcost using the ot.emd2 library, and matching/transport plan using ot.emd.
     # Note: it is the Wasserstein distance to the power q.
     # The default numItermax=100000 is not sufficient for some examples with 5000 points, what is a good value?
     if reg == 0.:
@@ -190,19 +190,19 @@ def wasserstein_distance(X, Y, matching=False, order=2., internal_p=2., reg=0., 
             ot_cost = ot.emd2(a, b, M, numItermax=2000000)
 
     elif reg > 0:
-        np.seterr(divide='raise')  # For a better handling of numerical issues due to reg being too low
-        try:
-            if matching:
-                P = ot.sinkhorn(a=a, b=b, M=M, reg=reg)
-                ot_cost = np.sum(np.multiply(P, M))
-                return ot_cost ** (1./order), P
-            else:
-                ot_cost = ot.sinkhorn2(a, b, M, reg=reg)[0]
-                return ot_cost ** (1. / order)
-        except FloatingPointError:
-            raise FloatingPointError('Error when computing regularized wasserstein distance (Sinkhorn loop).' \
-                                     'This is probably due to reg being too low. Try' \
-                                     'to increase reg or set it to 0 for exact computation')
+        with np.errstate(divide='raise'):  # For a better handling of numerical issues due to reg being too low
+            try:
+                if matching:
+                    P = ot.sinkhorn(a=a, b=b, M=M, reg=reg)
+                    ot_cost = np.sum(np.multiply(P, M))
+                    return ot_cost ** (1./order), P
+                else:
+                    ot_cost = ot.sinkhorn2(a, b, M, reg=reg)[0]
+                    return ot_cost ** (1. / order)
+            except FloatingPointError:
+                raise FloatingPointError('Error when computing regularized wasserstein distance (Sinkhorn loop).'
+                                         'This is probably due to reg being too low. Try'
+                                         'to increase reg or set it to 0 for exact computation')
     else:
         raise ValueError('Negative value for reg')
         # It seems ot.sinkhorn2 returns something when reg<0, which is reasonnable but probably unexpected

--- a/src/python/test/test_wasserstein_distance.py
+++ b/src/python/test/test_wasserstein_distance.py
@@ -18,11 +18,13 @@ __author__ = "Theo Lacombe"
 __copyright__ = "Copyright (C) 2019 Inria"
 __license__ = "MIT"
 
+
 def test_proj_on_diag():
     dgm = np.array([[1., 1.], [1., 2.], [3., 5.]])
     assert np.array_equal(_proj_on_diag(dgm), [[1., 1.], [1.5, 1.5], [4., 4.]])
     empty = np.empty((0, 2))
     assert np.array_equal(_proj_on_diag(empty), empty)
+
 
 def _basic_wasserstein(wasserstein_distance, delta, test_infinity=True, test_matching=True):
     diag1 = np.array([[2.7, 3.7], [9.6, 14.0], [34.2, 34.974]])
@@ -77,6 +79,23 @@ def _basic_wasserstein(wasserstein_distance, delta, test_infinity=True, test_mat
         assert np.array_equal(match , [[0, -1], [1, -1]])
         match = wasserstein_distance(diag1, diag2, matching=True, internal_p=2., order=2.)[1]
         assert np.array_equal(match, [[0, 0], [1, 1], [2, -1]])
+
+    if test_entropy:
+        assert wasserstein_distance(diag1, diag2, internal_p=2., order=2., reg=1) == approx(1.2251725975696444)
+        with pytest.raises(FloatingPointError):
+            wasserstein_distance(diag1, diag2, internal_p=2., order=2., reg=1E-20)
+        res1 = wasserstein_distance(diag1, diag3, internal_p=2., order=2.)
+        res2 = wasserstein_distance(diag1, diag3, internal_p=2., order=2., reg=0)
+        assert res1 == res2  # these two should be very much the same.
+        with pytest.raises(ValueError):
+            wasserstein_distance(diag1, diag2, reg=-1)
+
+        cost_res, P_res = 3.4637979748620684, np.array([[0.46505399, 0.0042368 , 0.53070921],
+                                                        [0.03878662, 0.47330083, 0.48791255],
+                                                        [0.49615939, 0.52246237, 0.98137825]])
+        cost, P = wasserstein_distance(diag3, diag4, internal_p=2., order=2., reg = 10, matching=True)
+        assert cost == approx(cost_res)
+        assert np.linalg.norm(P - P_res) < 1E-5
 
 
 

--- a/src/python/test/test_wasserstein_distance.py
+++ b/src/python/test/test_wasserstein_distance.py
@@ -26,7 +26,7 @@ def test_proj_on_diag():
     assert np.array_equal(_proj_on_diag(empty), empty)
 
 
-def _basic_wasserstein(wasserstein_distance, delta, test_infinity=True, test_matching=True):
+def _basic_wasserstein(wasserstein_distance, delta, test_infinity=True, test_matching=True, test_entropy=True):
     diag1 = np.array([[2.7, 3.7], [9.6, 14.0], [34.2, 34.974]])
     diag2 = np.array([[2.8, 4.45], [9.5, 14.1]])
     diag3 = np.array([[0, 2], [4, 6]])
@@ -110,7 +110,7 @@ def pot_wrap(**extra):
     return fun
 
 def test_wasserstein_distance_pot():
-    _basic_wasserstein(pot, 1e-15, test_infinity=False, test_matching=True)
+    _basic_wasserstein(pot, 1e-15, test_infinity=False, test_matching=True, test_entropy=True)
     _basic_wasserstein(pot_wrap(enable_autodiff=True), 1e-15, test_infinity=False, test_matching=False)
 
 def test_wasserstein_distance_hera():

--- a/src/python/test/test_wasserstein_distance.py
+++ b/src/python/test/test_wasserstein_distance.py
@@ -26,7 +26,7 @@ def test_proj_on_diag():
     assert np.array_equal(_proj_on_diag(empty), empty)
 
 
-def _basic_wasserstein(wasserstein_distance, delta, test_infinity=True, test_matching=True, test_entropy=True):
+def _basic_wasserstein(wasserstein_distance, delta, test_infinity, test_matching, test_entropy):
     diag1 = np.array([[2.7, 3.7], [9.6, 14.0], [34.2, 34.974]])
     diag2 = np.array([[2.8, 4.45], [9.5, 14.1]])
     diag3 = np.array([[0, 2], [4, 6]])
@@ -81,7 +81,7 @@ def _basic_wasserstein(wasserstein_distance, delta, test_infinity=True, test_mat
         assert np.array_equal(match, [[0, 0], [1, 1], [2, -1]])
 
     if test_entropy:
-        assert wasserstein_distance(diag1, diag2, internal_p=2., order=2., reg=1) == approx(1.2251725975696444)
+        assert wasserstein_distance(diag1, diag2, internal_p=2., order=2., reg=1) == approx(1.2251655537043005)
         with pytest.raises(FloatingPointError):
             wasserstein_distance(diag1, diag2, internal_p=2., order=2., reg=1E-20)
         res1 = wasserstein_distance(diag1, diag3, internal_p=2., order=2.)
@@ -90,7 +90,7 @@ def _basic_wasserstein(wasserstein_distance, delta, test_infinity=True, test_mat
         with pytest.raises(ValueError):
             wasserstein_distance(diag1, diag2, reg=-1)
 
-        cost_res, P_res = 3.4637979748620684, np.array([[0.46505399, 0.0042368 , 0.53070921],
+        cost_res, P_res = 3.4637979754199804, np.array([[0.46505399, 0.0042368 , 0.53070921],
                                                         [0.03878662, 0.47330083, 0.48791255],
                                                         [0.49615939, 0.52246237, 0.98137825]])
         cost, P = wasserstein_distance(diag3, diag4, internal_p=2., order=2., reg = 10, matching=True)
@@ -111,11 +111,12 @@ def pot_wrap(**extra):
 
 def test_wasserstein_distance_pot():
     _basic_wasserstein(pot, 1e-15, test_infinity=False, test_matching=True, test_entropy=True)
-    _basic_wasserstein(pot_wrap(enable_autodiff=True), 1e-15, test_infinity=False, test_matching=False)
+    _basic_wasserstein(pot_wrap(enable_autodiff=True), 1e-15, test_infinity=False, test_matching=False,
+                       test_entropy=False)
 
 def test_wasserstein_distance_hera():
-    _basic_wasserstein(hera_wrap(delta=1e-12), 1e-12, test_matching=False)
-    _basic_wasserstein(hera_wrap(delta=.1), .1, test_matching=False)
+    _basic_wasserstein(hera_wrap(delta=1e-12), 1e-12, test_infinity=True, test_matching=False, test_entropy=False)
+    _basic_wasserstein(hera_wrap(delta=.1), .1, test_infinity=True, test_matching=False, test_entropy=False)
 
 def test_wasserstein_distance_grad():
     import torch

--- a/src/python/test/test_wasserstein_distance.py
+++ b/src/python/test/test_wasserstein_distance.py
@@ -92,7 +92,7 @@ def _basic_wasserstein(wasserstein_distance, delta, test_infinity, test_matching
 
         cost_res, P_res = 3.4637979754199804, np.array([[0.46505399, 0.0042368 , 0.53070921],
                                                         [0.03878662, 0.47330083, 0.48791255],
-                                                        [0.49615939, 0.52246237, 0.98137825]])
+                                                        [0.49615939, 0.52246237, 0.98137824]])
         cost, P = wasserstein_distance(diag3, diag4, internal_p=2., order=2., reg = 10, matching=True)
         assert cost == approx(cost_res)
         assert np.linalg.norm(P - P_res) < 1E-5


### PR DESCRIPTION
Added an option to use `ot.sinkhorn` instead of `ot.emd` when computing the Wasserstein distance between persistence diagrams. 

Tried to manage as well as possible the numerical issues that could be induced by used a too small value for `reg`.