### PR TITLE
Support e=None for bottleneck_distance

### DIFF
--- a/src/python/gudhi/bottleneck.cc
+++ b/src/python/gudhi/bottleneck.cc
@@ -46,7 +46,7 @@ PYBIND11_MODULE(bottleneck, m) {
         bits of the mantissa may be wrong). This version of the algorithm takes
         advantage of the limited precision of `double` and is usually a lot
         faster to compute, whatever the value of `e`.
-        Thus, by default, `e` is the smallest positive double.
+        Thus, by default (`e=None`), `e` is the smallest positive double.
     :type e: float
     :rtype: float
     :returns: the bottleneck distance.


### PR DESCRIPTION
An alternative would be to change BottleneckDistance so it doesn't use None.
Fix #341.
I will add a test that relies on e=None as part of #338 (or a small tweak afterwards, if it gets in first).