### PR TITLE
A proposal for simplex_tree reset_filtration (python & C++)

### DIFF
--- a/src/Simplex_tree/include/gudhi/Simplex_tree.h
+++ b/src/Simplex_tree/include/gudhi/Simplex_tree.h
@@ -1668,8 +1668,8 @@ class Simplex_tree {
   }
 
  public:
-  /** \brief This function resets filtration value from a given dimension. Resets all the Simplex_tree when
-   * `min_dim = 0`.
+  /** \brief This function resets the filtration value of all the simplices of dimension at least min_dim. Resets all
+   * the Simplex_tree when `min_dim = 0`.
    * `reset_filtration` may break the filtration property with `min_dim > 0`, and it is the user's responsibility to
    * make it a valid filtration (using a large enough `filt_value`, or calling `make_filtration_non_decreasing`
    * afterwards for instance).

--- a/src/Simplex_tree/include/gudhi/Simplex_tree.h
+++ b/src/Simplex_tree/include/gudhi/Simplex_tree.h
@@ -1670,10 +1670,13 @@ class Simplex_tree {
  public:
   /** \brief This function resets filtration value from a given dimension. Resets all the Simplex_tree when
    * `min_dim = 0`.
+   * `reset_filtration` may break the filtration property with `min_dim > 0`, and it is the user's responsibility to
+   * make it a valid filtration (using a large enough `filt_value`, or calling `make_filtration_non_decreasing`
+   * afterwards for instance).
    * @param[in] filt_value The new filtration value.
-   * @param[in] min_dim The minimal dimension.
+   * @param[in] min_dim The minimal dimension. Default value is 0.
    */
-  void reset_filtration(Filtration_value filt_value, int min_dim) {
+  void reset_filtration(Filtration_value filt_value, int min_dim = 0) {
     for (auto& simplex : root_.members()) {
       if (min_dim <= 0) {
         simplex.second.assign_filtration(filt_value);
@@ -1689,7 +1692,7 @@ class Simplex_tree {
   /** \brief Recursively resets filtration value from a given dimension.
    * @param[in] sib Siblings to be parsed.
    * @param[in] filt_value The new filtration value.
-   * @param[in] min_dim The maximal dimension.
+   * @param[in] min_dim The minimal dimension.
    */
   void rec_reset_filtration(Siblings * sib, Filtration_value filt_value, int min_dim) {
     for (auto sh = sib->members().begin(); sh != sib->members().end(); ++sh) {

--- a/src/Simplex_tree/include/gudhi/Simplex_tree.h
+++ b/src/Simplex_tree/include/gudhi/Simplex_tree.h
@@ -1677,14 +1677,7 @@ class Simplex_tree {
    * @param[in] min_dim The minimal dimension. Default value is 0.
    */
   void reset_filtration(Filtration_value filt_value, int min_dim = 0) {
-    for (auto& simplex : root_.members()) {
-      if (min_dim <= 0) {
-        simplex.second.assign_filtration(filt_value);
-      }
-      if (has_children(&simplex)) {
-        rec_reset_filtration(simplex.second.children(), filt_value, min_dim - 1);
-      }
-    }
+    rec_reset_filtration(&root_, filt_value, min_dim);
     clear_filtration(); // Drop the cache.
   }
 

--- a/src/Simplex_tree/include/gudhi/Simplex_tree.h
+++ b/src/Simplex_tree/include/gudhi/Simplex_tree.h
@@ -1682,25 +1682,25 @@ class Simplex_tree {
         simplex.second.assign_filtration(filt_value);
       }
       if (has_children(&simplex)) {
-        rec_reset_filtration(simplex.second.children(), filt_value, min_dim);
+        rec_reset_filtration(simplex.second.children(), filt_value, min_dim - 1);
       }
     }
     clear_filtration(); // Drop the cache.
   }
 
  private:
-  /** \brief Recursively resets filtration value from a given dimension.
+  /** \brief Recursively resets filtration value when minimal depth <= 0.
    * @param[in] sib Siblings to be parsed.
    * @param[in] filt_value The new filtration value.
-   * @param[in] min_dim The minimal dimension.
+   * @param[in] min_depth The minimal depth.
    */
-  void rec_reset_filtration(Siblings * sib, Filtration_value filt_value, int min_dim) {
+  void rec_reset_filtration(Siblings * sib, Filtration_value filt_value, int min_depth) {
     for (auto sh = sib->members().begin(); sh != sib->members().end(); ++sh) {
-      if (min_dim <= dimension(sh)) {
+      if (min_depth <= 0) {
         sh->second.assign_filtration(filt_value);
       }
       if (has_children(sh)) {
-        rec_reset_filtration(sh->second.children(), filt_value, min_dim);
+        rec_reset_filtration(sh->second.children(), filt_value, min_depth - 1);
       }
     }
   }

--- a/src/Simplex_tree/include/gudhi/Simplex_tree.h
+++ b/src/Simplex_tree/include/gudhi/Simplex_tree.h
@@ -1668,31 +1668,36 @@ class Simplex_tree {
   }
 
  public:
-  /** \brief This function resets filtration value until a given dimension.
+  /** \brief This function resets filtration value from a given dimension. Resets all the Simplex_tree when
+   * `min_dim = 0`.
    * @param[in] filt_value The new filtration value.
-   * @param[in] max_dim The maximal dimension.
+   * @param[in] min_dim The minimal dimension.
    */
-  void reset_filtration(Filtration_value filt_value, int max_dim) {
+  void reset_filtration(Filtration_value filt_value, int min_dim) {
     for (auto& simplex : root_.members()) {
-      simplex.second.assign_filtration(filt_value);
-      if (has_children(&simplex) && max_dim > 0) {
-        rec_reset_filtration(simplex.second.children(), filt_value, (max_dim - 1));
+      if (min_dim <= 0) {
+        simplex.second.assign_filtration(filt_value);
+      }
+      if (has_children(&simplex)) {
+        rec_reset_filtration(simplex.second.children(), filt_value, min_dim);
       }
     }
     clear_filtration(); // Drop the cache.
   }
 
  private:
-  /** \brief Recursively resets filtration value until a given dimension.
+  /** \brief Recursively resets filtration value from a given dimension.
    * @param[in] sib Siblings to be parsed.
    * @param[in] filt_value The new filtration value.
-   * @param[in] max_dim The maximal dimension.
+   * @param[in] min_dim The maximal dimension.
    */
-  void rec_reset_filtration(Siblings * sib, Filtration_value filt_value, int max_dim) {
-    for (auto& simplex : sib->members()) {
-      simplex.second.assign_filtration(filt_value);
-      if (has_children(&simplex) && max_dim > 0) {
-        rec_reset_filtration(simplex.second.children(), filt_value, (max_dim - 1));
+  void rec_reset_filtration(Siblings * sib, Filtration_value filt_value, int min_dim) {
+    for (auto sh = sib->members().begin(); sh != sib->members().end(); ++sh) {
+      if (min_dim <= dimension(sh)) {
+        sh->second.assign_filtration(filt_value);
+      }
+      if (has_children(sh)) {
+        rec_reset_filtration(sh->second.children(), filt_value, min_dim);
       }
     }
   }

--- a/src/Simplex_tree/include/gudhi/Simplex_tree.h
+++ b/src/Simplex_tree/include/gudhi/Simplex_tree.h
@@ -1667,6 +1667,36 @@ class Simplex_tree {
     return sh; // None of its faces has the same filtration.
   }
 
+ public:
+  /** \brief This function resets filtration value until a given dimension.
+   * @param[in] filt_value The new filtration value.
+   * @param[in] max_dim The maximal dimension.
+   */
+  void reset_filtration(Filtration_value filt_value, int max_dim) {
+    for (auto& simplex : root_.members()) {
+      simplex.second.assign_filtration(filt_value);
+      if (has_children(&simplex) && max_dim > 0) {
+        rec_reset_filtration(simplex.second.children(), filt_value, (max_dim - 1));
+      }
+    }
+    clear_filtration(); // Drop the cache.
+  }
+
+ private:
+  /** \brief Recursively resets filtration value until a given dimension.
+   * @param[in] sib Siblings to be parsed.
+   * @param[in] filt_value The new filtration value.
+   * @param[in] max_dim The maximal dimension.
+   */
+  void rec_reset_filtration(Siblings * sib, Filtration_value filt_value, int max_dim) {
+    for (auto& simplex : sib->members()) {
+      simplex.second.assign_filtration(filt_value);
+      if (has_children(&simplex) && max_dim > 0) {
+        rec_reset_filtration(simplex.second.children(), filt_value, (max_dim - 1));
+      }
+    }
+  }
+
  private:
   Vertex_handle null_vertex_;
   /** \brief Total number of simplices in the complex, without the empty simplex.*/

--- a/src/Simplex_tree/test/simplex_tree_unit_test.cpp
+++ b/src/Simplex_tree/test/simplex_tree_unit_test.cpp
@@ -965,21 +965,25 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(simplex_tree_reset_filtration, typeST, list_of_tes
     for (auto vertex : st.simplex_vertex_range(f_simplex)) {
       std::clog << vertex << ",";
     }
-    std::clog << ") - filtration =" << st.filtration(f_simplex) << std::endl;
+    std::clog << ") - filtration = " << st.filtration(f_simplex);
+    std::clog << " - dimension = " << st.dimension(f_simplex) << std::endl;
+    // Guaranteed by construction
     BOOST_CHECK(st.filtration(f_simplex) >= 2.);
   }
 
   // dimension until 5 even if simplex tree is of dimension 3 to test the limits
-  for(int dimension = 0; dimension < 6; dimension ++) {
+  for(int dimension = 5; dimension >= 0; dimension --) {
+    std::clog << "### reset_filtration - dimension = " << dimension << "\n";
     st.reset_filtration(0., dimension);
     for (auto f_simplex : st.skeleton_simplex_range(3)) {
       std::clog << "vertex = (";
       for (auto vertex : st.simplex_vertex_range(f_simplex)) {
         std::clog << vertex << ",";
       }
-      std::clog << ") - filtration =" << st.filtration(f_simplex) << std::endl;
-      if (st.dimension(f_simplex) > dimension)
-        BOOST_CHECK(st.filtration(f_simplex) >= 1.);
+      std::clog << ") - filtration = " << st.filtration(f_simplex);
+      std::clog << " - dimension = " << st.dimension(f_simplex) << std::endl;
+      if (st.dimension(f_simplex) < dimension)
+        BOOST_CHECK(st.filtration(f_simplex) >= 2.);
       else
         BOOST_CHECK(st.filtration(f_simplex) == 0.);
     }

--- a/src/Simplex_tree/test/simplex_tree_unit_test.cpp
+++ b/src/Simplex_tree/test/simplex_tree_unit_test.cpp
@@ -940,3 +940,50 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(generators, typeST, list_of_tested_variants) {
     BOOST_CHECK(st.edge_with_same_filtration(st.find({1,5}))==st.find({1,5}));
   }
 }
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(simplex_tree_reset_filtration, typeST, list_of_tested_variants) {
+  std::clog << "********************************************************************" << std::endl;
+  std::clog << "TEST RESET FILTRATION" << std::endl;
+  typeST st;
+
+  st.insert_simplex_and_subfaces({2, 1, 0}, 3.);
+  st.insert_simplex_and_subfaces({3, 0}, 2.);
+  st.insert_simplex_and_subfaces({3, 4, 5}, 3.);
+  st.insert_simplex_and_subfaces({0, 1, 6, 7}, 4.);
+
+  /* Inserted simplex:        */
+  /*    1   6                 */
+  /*    o---o                 */
+  /*   /X\7/                  */
+  /*  o---o---o---o           */
+  /*  2   0   3\X/4           */
+  /*            o             */
+  /*            5             */
+
+  for (auto f_simplex : st.skeleton_simplex_range(3)) {
+    std::clog << "vertex = (";
+    for (auto vertex : st.simplex_vertex_range(f_simplex)) {
+      std::clog << vertex << ",";
+    }
+    std::clog << ") - filtration =" << st.filtration(f_simplex) << std::endl;
+    BOOST_CHECK(st.filtration(f_simplex) >= 2.);
+  }
+
+  // dimension until 5 even if simplex tree is of dimension 3 to test the limits
+  for(int dimension = 0; dimension < 6; dimension ++) {
+    st.reset_filtration(0., dimension);
+    for (auto f_simplex : st.skeleton_simplex_range(3)) {
+      std::clog << "vertex = (";
+      for (auto vertex : st.simplex_vertex_range(f_simplex)) {
+        std::clog << vertex << ",";
+      }
+      std::clog << ") - filtration =" << st.filtration(f_simplex) << std::endl;
+      if (st.dimension(f_simplex) > dimension)
+        BOOST_CHECK(st.filtration(f_simplex) >= 1.);
+      else
+        BOOST_CHECK(st.filtration(f_simplex) == 0.);
+    }
+  }
+
+}
+

--- a/src/python/gudhi/simplex_tree.pxd
+++ b/src/python/gudhi/simplex_tree.pxd
@@ -57,6 +57,7 @@ cdef extern from "Simplex_tree_interface.h" namespace "Gudhi":
         bool make_filtration_non_decreasing() nogil
         void compute_extended_filtration() nogil
         vector[vector[pair[int, pair[double, double]]]] compute_extended_persistence_subdiagrams(vector[pair[int, pair[double, double]]] dgm, double min_persistence) nogil
+        void reset_filtration(double filtration, int dimension) nogil
         # Iterators over Simplex tree
         pair[vector[int], double] get_simplex_and_filtration(Simplex_tree_simplex_handle f_simplex) nogil
         Simplex_tree_simplices_iterator get_simplices_iterator_begin() nogil

--- a/src/python/gudhi/simplex_tree.pyx
+++ b/src/python/gudhi/simplex_tree.pyx
@@ -328,7 +328,7 @@ cdef class SimplexTree:
         return self.get_ptr().prune_above_filtration(filtration)
 
     def expansion(self, max_dim):
-        """Expands the Simplex_tree containing only its one skeleton
+        """Expands the simplex tree containing only its one skeleton
         until dimension max_dim.
 
         The expanded simplicial complex until dimension :math:`d`
@@ -338,7 +338,7 @@ cdef class SimplexTree:
         The filtration value assigned to a simplex is the maximal filtration
         value of one of its edges.
 
-        The Simplex_tree must contain no simplex of dimension bigger than
+        The simplex tree must contain no simplex of dimension bigger than
         1 when calling the method.
 
         :param max_dim: The maximal dimension.
@@ -358,15 +358,16 @@ cdef class SimplexTree:
         """
         return self.get_ptr().make_filtration_non_decreasing()
 
-    def reset_filtration(self, filtration, max_dim):
-        """This function resets filtration value until a given dimension.
+    def reset_filtration(self, filtration, min_dim):
+        """This function resets filtration value from a given dimension.
+        Resets all the simplex tree when `min_dim = 0`.
 
         :param filtration: New threshold value.
         :type filtration: float.
-        :param max_dim: The maximal dimension.
+        :param max_dim: The minimal dimension.
         :type max_dim: int.
         """
-        self.get_ptr().reset_filtration(filtration, max_dim)
+        self.get_ptr().reset_filtration(filtration, min_dim)
 
     def extend_filtration(self):
         """ Extend filtration for computing extended persistence. This function only uses the 
@@ -376,14 +377,14 @@ cdef class SimplexTree:
         .. note::
 
             Note that after calling this function, the filtration 
-            values are actually modified within the Simplex_tree. 
+            values are actually modified within the simplex tree. 
             The function :func:`extended_persistence`
             retrieves the original values.
 
         .. note::
 
             Note that this code creates an extra vertex internally, so you should make sure that
-            the Simplex_tree does not contain a vertex with the largest possible value (i.e., 4294967295). 
+            the simplex tree does not contain a vertex with the largest possible value (i.e., 4294967295). 
         """
         self.get_ptr().compute_extended_filtration()
 

--- a/src/python/gudhi/simplex_tree.pyx
+++ b/src/python/gudhi/simplex_tree.pyx
@@ -358,6 +358,16 @@ cdef class SimplexTree:
         """
         return self.get_ptr().make_filtration_non_decreasing()
 
+    def reset_filtration(self, filtration, max_dim):
+        """This function resets filtration value until a given dimension.
+
+        :param filtration: New threshold value.
+        :type filtration: float.
+        :param max_dim: The maximal dimension.
+        :type max_dim: int.
+        """
+        self.get_ptr().reset_filtration(filtration, max_dim)
+
     def extend_filtration(self):
         """ Extend filtration for computing extended persistence. This function only uses the 
         filtration values at the 0-dimensional simplices, and computes the extended persistence 

--- a/src/python/gudhi/simplex_tree.pyx
+++ b/src/python/gudhi/simplex_tree.pyx
@@ -358,14 +358,17 @@ cdef class SimplexTree:
         """
         return self.get_ptr().make_filtration_non_decreasing()
 
-    def reset_filtration(self, filtration, min_dim):
-        """This function resets filtration value from a given dimension.
-        Resets all the simplex tree when `min_dim = 0`.
+    def reset_filtration(self, filtration, min_dim = 0):
+        """This function resets filtration value from a given dimension. Resets all the simplex tree when
+        `min_dim = 0`.
+        `reset_filtration` may break the filtration property with `min_dim > 0`, and it is the user's responsibility to
+        make it a valid filtration (using a large enough `filt_value`, or calling `make_filtration_non_decreasing`
+        afterwards for instance).
 
         :param filtration: New threshold value.
         :type filtration: float.
-        :param max_dim: The minimal dimension.
-        :type max_dim: int.
+        :param min_dim: The minimal dimension. Default value is 0.
+        :type min_dim: int.
         """
         self.get_ptr().reset_filtration(filtration, min_dim)
 

--- a/src/python/gudhi/simplex_tree.pyx
+++ b/src/python/gudhi/simplex_tree.pyx
@@ -359,8 +359,8 @@ cdef class SimplexTree:
         return self.get_ptr().make_filtration_non_decreasing()
 
     def reset_filtration(self, filtration, min_dim = 0):
-        """This function resets filtration value from a given dimension. Resets all the simplex tree when
-        `min_dim = 0`.
+        """This function resets the filtration value of all the simplices of dimension at least min_dim. Resets all the
+        simplex tree when `min_dim = 0`.
         `reset_filtration` may break the filtration property with `min_dim > 0`, and it is the user's responsibility to
         make it a valid filtration (using a large enough `filt_value`, or calling `make_filtration_non_decreasing`
         afterwards for instance).

--- a/src/python/test/test_simplex_tree.py
+++ b/src/python/test/test_simplex_tree.py
@@ -340,3 +340,25 @@ def test_simplices_iterator():
         assert st.find(simplex[0]) == True
         print("filtration is: ", simplex[1])
         assert st.filtration(simplex[0]) == simplex[1]
+
+def test_reset_filtration():
+    st = SimplexTree()
+    
+    assert st.insert([0, 1, 2], 3.) == True
+    assert st.insert([0, 3], 2.) == True
+    assert st.insert([3, 4, 5], 3.) == True
+    assert st.insert([0, 1, 6, 7], 4.) == True
+
+    for simplex in st.get_simplices():
+        assert st.filtration(simplex[0]) >= 0.
+    
+    # dimension until 5 even if simplex tree is of dimension 3 to test the limits
+    for dimension in range(0, 6):
+        st.reset_filtration(0., dimension)
+        for simplex in st.get_skeleton(3):
+            print(simplex)
+            if len(simplex[0]) > (dimension + 1):
+                assert st.filtration(simplex[0]) >= 1.
+            else:
+                assert st.filtration(simplex[0]) == 0.
+

--- a/src/python/test/test_simplex_tree.py
+++ b/src/python/test/test_simplex_tree.py
@@ -367,15 +367,16 @@ def test_reset_filtration():
     assert st.insert([3, 4, 5], 3.) == True
     assert st.insert([0, 1, 6, 7], 4.) == True
 
+    # Guaranteed by construction
     for simplex in st.get_simplices():
-        assert st.filtration(simplex[0]) >= 0.
+        assert st.filtration(simplex[0]) >= 2.
     
     # dimension until 5 even if simplex tree is of dimension 3 to test the limits
-    for dimension in range(0, 6):
+    for dimension in range(5, -1, -1):
         st.reset_filtration(0., dimension)
         for simplex in st.get_skeleton(3):
             print(simplex)
-            if len(simplex[0]) > (dimension + 1):
-                assert st.filtration(simplex[0]) >= 1.
+            if len(simplex[0]) < (dimension) + 1:
+                assert st.filtration(simplex[0]) >= 2.
             else:
                 assert st.filtration(simplex[0]) == 0.


### PR DESCRIPTION
Maybe useless as we can now use the default_filtration_value to set to NaN an alpha complex.
This is a fix proposal for #73 
Does it worth it to set default values ? `min_dim` could be 0 and `filt_value` could be NaN by default .