### PR TITLE
Add mechanism to deactivate LaTeX matplotlib rendering

### DIFF
--- a/src/python/doc/installation.rst
+++ b/src/python/doc/installation.rst
@@ -323,6 +323,35 @@ The following examples require the `Matplotlib <http://matplotlib.org>`_:
     * :download:`euclidean_strong_witness_complex_diagram_persistence_from_off_file_example.py <../example/euclidean_strong_witness_complex_diagram_persistence_from_off_file_example.py>`
     * :download:`euclidean_witness_complex_diagram_persistence_from_off_file_example.py <../example/euclidean_witness_complex_diagram_persistence_from_off_file_example.py>`
 
+LaTeX
+~~~~~
+
+If a sufficiently complete LaTeX toolchain is available (including dvipng and ghostscript), the LaTeX option of
+matplotlib is enabled for prettier captions (cf.
+`matplotlib text rendering with LaTeX <https://matplotlib.org/3.3.0/tutorials/text/usetex.html>`_).
+It also requires `type1cm` LaTeX package (not detected by matplotlib).
+
+If you are facing issues with LaTeX rendering, like this one:
+
+.. code-block:: none
+
+    Traceback (most recent call last):
+      File "/usr/lib/python3/dist-packages/matplotlib/texmanager.py", line 302, in _run_checked_subprocess
+        report = subprocess.check_output(command,
+    ...
+    ! LaTeX Error: File `type1cm.sty' not found.
+    ...
+
+This is because the LaTeX package is not installed on your system. On Ubuntu systems you can install texlive-full
+(for all LaTeX packages), or more specific packages like texlive-latex-extra, cm-super.
+
+You can still deactivate LaTeX rendering by saying:
+
+.. code-block:: python
+
+    import gudhi
+    gudhi.persistence_graphical_tools._gudhi_matplotlib_use_tex=False
+
 PyKeOps
 -------
 

--- a/src/python/doc/persistence_graphical_tools_user.rst
+++ b/src/python/doc/persistence_graphical_tools_user.rst
@@ -94,25 +94,8 @@ If you want more information on a specific dimension, for instance:
 LaTeX support
 -------------
 
-By default, persistence graphical tools are using LaTeX support for matplotlib if available (cf.
-`matplotlib text rendering with LaTeX <https://matplotlib.org/3.3.0/tutorials/text/usetex.html>`_).
-It also requires `type1cm` LaTeX package (not detected by matplotlib).
-
-If you are facing issues with LaTeX rendering, like this one:
-
-.. code-block:: none
-
-    Traceback (most recent call last):
-      File "/usr/lib/python3/dist-packages/matplotlib/texmanager.py", line 302, in _run_checked_subprocess
-        report = subprocess.check_output(command,
-    ...
-    ! LaTeX Error: File `type1cm.sty' not found.
-    ...
-
-This is because the LaTeX package is not installed on your system. On Ubuntu systems you can install texlive-full
-(for all LaTeX packages), or more specific packages like texlive-latex-extra, cm-super.
-
-You can still deactivate LaTeX rendering by saying:
+If you are facing issues with `LaTeX <installation.html#latex>`_ rendering, you can still deactivate LaTeX rendering by
+saying:
 
 .. code-block:: python
 

--- a/src/python/doc/persistence_graphical_tools_user.rst
+++ b/src/python/doc/persistence_graphical_tools_user.rst
@@ -90,3 +90,17 @@ If you want more information on a specific dimension, for instance:
     gudhi.plot_persistence_density(persistence=pers_diag,
         dimension=1, legend=True, axes=axes[1])
     plt.show()
+
+LaTeX support
+-------------
+
+By default, persistence graphical tools are using LaTeX support for matplotlib if available (cf.
+`matplotlib text rendering with LaTeX <https://matplotlib.org/3.3.0/tutorials/text/usetex.html>`_).
+It also requires `type1cm` LaTeX package (not detected by matplotlib).
+
+If you are facing issues with LaTeX rendering, you can still deactivate LaTeX rendering by saying:
+
+.. code-block:: python
+
+    import gudhi
+    gudhi.persistence_graphical_tools._gudhi_matplotlib_use_tex=False

--- a/src/python/doc/persistence_graphical_tools_user.rst
+++ b/src/python/doc/persistence_graphical_tools_user.rst
@@ -98,7 +98,21 @@ By default, persistence graphical tools are using LaTeX support for matplotlib i
 `matplotlib text rendering with LaTeX <https://matplotlib.org/3.3.0/tutorials/text/usetex.html>`_).
 It also requires `type1cm` LaTeX package (not detected by matplotlib).
 
-If you are facing issues with LaTeX rendering, you can still deactivate LaTeX rendering by saying:
+If you are facing issues with LaTeX rendering, like this one:
+
+.. code-block:: none
+
+    Traceback (most recent call last):
+      File "/usr/lib/python3/dist-packages/matplotlib/texmanager.py", line 302, in _run_checked_subprocess
+        report = subprocess.check_output(command,
+    ...
+    ! LaTeX Error: File `type1cm.sty' not found.
+    ...
+
+This is because the LaTeX package is not installed on your system. On Ubuntu systems you can install texlive-full
+(for all LaTeX packages), or more specific packages like texlive-latex-extra, cm-super.
+
+You can still deactivate LaTeX rendering by saying:
 
 .. code-block:: python
 

--- a/src/python/gudhi/persistence_graphical_tools.py
+++ b/src/python/gudhi/persistence_graphical_tools.py
@@ -11,6 +11,7 @@
 from os import path
 from math import isfinite
 import numpy as np
+from functools import lru_cache
 
 from gudhi.reader_utils import read_persistence_intervals_in_dimension
 from gudhi.reader_utils import read_persistence_intervals_grouped_by_dimension
@@ -57,6 +58,7 @@ def _array_handler(a):
     else:
         return a
 
+@lru_cache(maxsize=1)
 def _matplotlib_can_use_tex():
     """This function returns True if matplotlib can deal with LaTeX, False otherwise.
     The returned value is cached.

--- a/src/python/gudhi/persistence_graphical_tools.py
+++ b/src/python/gudhi/persistence_graphical_tools.py
@@ -11,7 +11,6 @@
 from os import path
 from math import isfinite
 import numpy as np
-from functools import lru_cache
 
 from gudhi.reader_utils import read_persistence_intervals_in_dimension
 from gudhi.reader_utils import read_persistence_intervals_grouped_by_dimension
@@ -20,20 +19,7 @@ __author__ = "Vincent Rouvreau, Bertrand Michel, Theo Lacombe"
 __copyright__ = "Copyright (C) 2016 Inria"
 __license__ = "MIT"
 
-@lru_cache(maxsize=1)
-def _matplotlib_can_use_tex():
-    """This function returns True if matplotlib can deal with LaTeX, False otherwise.
-    The returned value is cached.
-    """
-    try:
-        from matplotlib import checkdep_usetex
-        return checkdep_usetex(True)
-    except ImportError:
-        print("This function is not available, you may be missing matplotlib.")
-
-
-_gudhi_matplotlib_use_tex = _matplotlib_can_use_tex()
-
+_gudhi_matplotlib_use_tex = True
 
 def __min_birth_max_death(persistence, band=0.0):
     """This function returns (min_birth, max_death) from the persistence.
@@ -70,6 +56,16 @@ def _array_handler(a):
         return [[0, x] for x in a]
     else:
         return a
+
+def _matplotlib_can_use_tex():
+    """This function returns True if matplotlib can deal with LaTeX, False otherwise.
+    The returned value is cached.
+    """
+    try:
+        from matplotlib import checkdep_usetex
+        return checkdep_usetex(True)
+    except ImportError:
+        print("This function is not available, you may be missing matplotlib.")
 
 
 def plot_persistence_barcode(
@@ -121,7 +117,7 @@ def plot_persistence_barcode(
         import matplotlib.pyplot as plt
         import matplotlib.patches as mpatches
         from matplotlib import rc
-        if _gudhi_matplotlib_use_tex:
+        if _gudhi_matplotlib_use_tex and _matplotlib_can_use_tex():
             plt.rc('text', usetex=True)
             plt.rc('font', family='serif')
         else:
@@ -270,7 +266,7 @@ def plot_persistence_diagram(
         import matplotlib.pyplot as plt
         import matplotlib.patches as mpatches
         from matplotlib import rc
-        if _gudhi_matplotlib_use_tex:
+        if _gudhi_matplotlib_use_tex and _matplotlib_can_use_tex():
             plt.rc('text', usetex=True)
             plt.rc('font', family='serif')
         else:
@@ -446,7 +442,7 @@ def plot_persistence_density(
         import matplotlib.patches as mpatches
         from scipy.stats import kde
         from matplotlib import rc
-        if _gudhi_matplotlib_use_tex:
+        if _gudhi_matplotlib_use_tex and _matplotlib_can_use_tex():
             plt.rc('text', usetex=True)
             plt.rc('font', family='serif')
         else:

--- a/src/python/gudhi/persistence_graphical_tools.py
+++ b/src/python/gudhi/persistence_graphical_tools.py
@@ -20,6 +20,20 @@ __author__ = "Vincent Rouvreau, Bertrand Michel, Theo Lacombe"
 __copyright__ = "Copyright (C) 2016 Inria"
 __license__ = "MIT"
 
+@lru_cache(maxsize=1)
+def _matplotlib_can_use_tex():
+    """This function returns True if matplotlib can deal with LaTeX, False otherwise.
+    The returned value is cached.
+    """
+    try:
+        from matplotlib import checkdep_usetex
+        return checkdep_usetex(True)
+    except ImportError:
+        print("This function is not available, you may be missing matplotlib.")
+
+
+_gudhi_matplotlib_use_tex = _matplotlib_can_use_tex()
+
 
 def __min_birth_max_death(persistence, band=0.0):
     """This function returns (min_birth, max_death) from the persistence.
@@ -56,17 +70,6 @@ def _array_handler(a):
         return [[0, x] for x in a]
     else:
         return a
-
-@lru_cache(maxsize=1)
-def _matplotlib_can_use_tex():
-    """This function returns True if matplotlib can deal with LaTeX, False otherwise.
-    The returned value is cached.
-    """
-    try:
-        from matplotlib import checkdep_usetex
-        return checkdep_usetex(True)
-    except ImportError:
-        print("This function is not available, you may be missing matplotlib.")
 
 
 def plot_persistence_barcode(
@@ -117,10 +120,13 @@ def plot_persistence_barcode(
     try:
         import matplotlib.pyplot as plt
         import matplotlib.patches as mpatches
-        if _matplotlib_can_use_tex():
-            from matplotlib import rc
+        from matplotlib import rc
+        if _gudhi_matplotlib_use_tex:
             plt.rc('text', usetex=True)
             plt.rc('font', family='serif')
+        else:
+            plt.rc('text', usetex=False)
+            plt.rc('font', family='DejaVu Sans')
 
         if persistence_file != "":
             if path.isfile(persistence_file):
@@ -263,10 +269,13 @@ def plot_persistence_diagram(
     try:
         import matplotlib.pyplot as plt
         import matplotlib.patches as mpatches
-        if _matplotlib_can_use_tex():
-            from matplotlib import rc
+        from matplotlib import rc
+        if _gudhi_matplotlib_use_tex:
             plt.rc('text', usetex=True)
             plt.rc('font', family='serif')
+        else:
+            plt.rc('text', usetex=False)
+            plt.rc('font', family='DejaVu Sans')
 
         if persistence_file != "":
             if path.isfile(persistence_file):
@@ -436,10 +445,13 @@ def plot_persistence_density(
         import matplotlib.pyplot as plt
         import matplotlib.patches as mpatches
         from scipy.stats import kde
-        if _matplotlib_can_use_tex():
-            from matplotlib import rc
+        from matplotlib import rc
+        if _gudhi_matplotlib_use_tex:
             plt.rc('text', usetex=True)
             plt.rc('font', family='serif')
+        else:
+            plt.rc('text', usetex=False)
+            plt.rc('font', family='DejaVu Sans')
 
         if persistence_file != "":
             if dimension is None:


### PR DESCRIPTION
As #351 is partially fixed, add and document mechanism to deactivate LaTeX matplotlib rendering