### PR TITLE
Avoid brew install cgal issue

### DIFF
--- a/.github/workflows/pip-packaging-osx.yml
+++ b/.github/workflows/pip-packaging-osx.yml
@@ -22,7 +22,8 @@ jobs:
           architecture: x64
       - name: Install dependencies
         run: |
-          brew update && brew install boost eigen gmp mpfr cgal
+          brew update || true
+          brew install boost eigen gmp mpfr cgal || true
           python -m pip install --user -r .github/build-requirements.txt
           python -m pip install --user twine delocate
       - name: Build python wheel

--- a/CMakeGUDHIVersion.txt
+++ b/CMakeGUDHIVersion.txt
@@ -2,7 +2,7 @@
 set (GUDHI_MAJOR_VERSION 3)
 set (GUDHI_MINOR_VERSION 3)
 # GUDHI_PATCH_VERSION can be 'ZaN' for Alpha release, 'ZbN' for Beta release, 'ZrcN' for release candidate or 'Z' for a final release.
-set (GUDHI_PATCH_VERSION 0rc1)
+set (GUDHI_PATCH_VERSION 0rc2)
 set(GUDHI_VERSION ${GUDHI_MAJOR_VERSION}.${GUDHI_MINOR_VERSION}.${GUDHI_PATCH_VERSION})
 
 message(STATUS "GUDHI version : ${GUDHI_VERSION}")

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,7 +9,6 @@ jobs:
     variables:
       pythonVersion: '3.6'
       cmakeBuildType: Release
-      customInstallation: 'brew update && brew install graphviz doxygen boost eigen gmp mpfr tbb cgal'
 
     steps:
     - bash: echo "##vso[task.prependpath]$CONDA/bin"
@@ -23,7 +22,8 @@ jobs:
         sudo conda install --yes --quiet --name gudhi_build_env python=$(pythonVersion)
         python -m pip install --user -r .github/build-requirements.txt
         python -m pip install --user -r .github/test-requirements.txt
-        $(customInstallation)
+        brew update || true
+        brew install graphviz doxygen boost eigen gmp mpfr tbb cgal || true
       displayName: 'Install build dependencies'
     - bash: |
         source activate gudhi_build_env

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,7 +5,7 @@ jobs:
     timeoutInMinutes: 0
     cancelTimeoutInMinutes: 60
     pool:
-      vmImage: macOS-10.14
+      vmImage: macOS-10.15
     variables:
       pythonVersion: '3.6'
       cmakeBuildType: Release


### PR DESCRIPTION
Avoid [brew install cgal issue](https://github.com/Homebrew/homebrew-core/issues/59131) on github actions macosx-latest (10.15) and azure macosx-10.14