### PR TITLE
Pip build on ci

### DIFF
--- a/.github/workflows/pip-build-linux.yml
+++ b/.github/workflows/pip-build-linux.yml
@@ -1,0 +1,45 @@
+name: pip build linux
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    name: build pip wheels
+    runs-on: ubuntu-latest
+    container: gudhi/pip_for_gudhi
+    steps:
+      - uses: actions/checkout@v1
+        with:
+          submodules: true
+      - name: Build wheels for Python 3.5
+        run: |
+          mkdir build_35
+          cd build_35
+          cmake -DCMAKE_BUILD_TYPE=Release -DPYTHON_EXECUTABLE=$PYTHON35/bin/python ..
+          cd src/python
+          $PYTHON35/bin/python setup.py bdist_wheel
+          auditwheel repair dist/*.whl
+      - name: Build wheels for Python 3.6
+        run: |
+          mkdir build_36
+          cd build_36
+          cmake -DCMAKE_BUILD_TYPE=Release -DPYTHON_EXECUTABLE=$PYTHON36/bin/python ..
+          cd src/python
+          $PYTHON36/bin/python setup.py bdist_wheel
+          auditwheel repair dist/*.whl
+      - name: Build wheels for Python 3.7
+        run: |
+          mkdir build_37
+          cd build_37
+          cmake -DCMAKE_BUILD_TYPE=Release -DPYTHON_EXECUTABLE=$PYTHON37/bin/python ..
+          cd src/python
+          $PYTHON37/bin/python setup.py bdist_wheel
+          auditwheel repair dist/*.whl
+      - name: Build wheels for Python 3.8
+        run: |
+          mkdir build_38
+          cd build_38
+          cmake -DCMAKE_BUILD_TYPE=Release -DPYTHON_EXECUTABLE=$PYTHON38/bin/python ..
+          cd src/python
+          $PYTHON38/bin/python setup.py bdist_wheel
+          auditwheel repair dist/*.whl

--- a/.github/workflows/pip-build-linux.yml
+++ b/.github/workflows/pip-build-linux.yml
@@ -11,30 +11,6 @@ jobs:
       - uses: actions/checkout@v1
         with:
           submodules: true
-      - name: Build wheels for Python 3.5
-        run: |
-          mkdir build_35
-          cd build_35
-          cmake -DCMAKE_BUILD_TYPE=Release -DPYTHON_EXECUTABLE=$PYTHON35/bin/python ..
-          cd src/python
-          $PYTHON35/bin/python setup.py bdist_wheel
-          auditwheel repair dist/*.whl
-      - name: Build wheels for Python 3.6
-        run: |
-          mkdir build_36
-          cd build_36
-          cmake -DCMAKE_BUILD_TYPE=Release -DPYTHON_EXECUTABLE=$PYTHON36/bin/python ..
-          cd src/python
-          $PYTHON36/bin/python setup.py bdist_wheel
-          auditwheel repair dist/*.whl
-      - name: Build wheels for Python 3.7
-        run: |
-          mkdir build_37
-          cd build_37
-          cmake -DCMAKE_BUILD_TYPE=Release -DPYTHON_EXECUTABLE=$PYTHON37/bin/python ..
-          cd src/python
-          $PYTHON37/bin/python setup.py bdist_wheel
-          auditwheel repair dist/*.whl
       - name: Build wheels for Python 3.8
         run: |
           mkdir build_38

--- a/.github/workflows/pip-build-osx.yml
+++ b/.github/workflows/pip-build-osx.yml
@@ -1,0 +1,34 @@
+name: pip build osx
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: macos-latest
+    strategy:
+      max-parallel: 4
+      matrix:
+        python-version: ['3.5', '3.6', '3.7', '3.8']
+    name: Build wheels for Python ${{ matrix.python-version }}
+    steps:
+      - uses: actions/checkout@v1
+        with:
+          submodules: true
+      - uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python-version }}
+          architecture: x64
+      - name: Install dependencies
+        run: |
+          brew update || true
+          brew install boost eigen gmp mpfr cgal || true
+          python -m pip install --user -r .github/build-requirements.txt
+          python -m pip install --user twine delocate
+      - name: Build python wheel
+        run: |
+          python --version
+          mkdir build
+          cd build
+          cmake -DCMAKE_BUILD_TYPE=Release -DPython_ADDITIONAL_VERSIONS=3 ..
+          cd src/python
+          python setup.py bdist_wheel

--- a/.github/workflows/pip-build-osx.yml
+++ b/.github/workflows/pip-build-osx.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ['3.5', '3.6', '3.7', '3.8']
+        python-version: ['3.8']
     name: Build wheels for Python ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/pip-build-windows.yml
+++ b/.github/workflows/pip-build-windows.yml
@@ -1,0 +1,42 @@
+name: pip build windows
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: windows-latest
+    strategy:
+      max-parallel: 4
+      matrix:
+        python-version: ['3.5', '3.6', '3.7', '3.8']
+    name: Build wheels for Python ${{ matrix.python-version }}
+    steps:
+      - uses: actions/checkout@v1
+        with:
+          submodules: true
+      - uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python-version }}
+          architecture: x64
+      - name: Patch
+        run: |
+          (new-object System.Net.WebClient).DownloadFile('https://github.com/microsoft/vcpkg/files/4978792/vcpkg_fixup_pkgconfig.cmake.txt','c:\vcpkg\scripts\cmake\vcpkg_fixup_pkgconfig.cmake')
+          (new-object System.Net.WebClient).DownloadFile('https://github.com/microsoft/vcpkg/files/4978796/vcpkg_acquire_msys.cmake.txt','c:\vcpkg\scripts\cmake\vcpkg_acquire_msys.cmake')
+        shell: powershell
+      - name: Install dependencies
+        run: |
+          vcpkg update
+          vcpkg upgrade --no-dry-run
+          vcpkg install boost-graph boost-serialization boost-date-time boost-system boost-filesystem boost-units boost-thread boost-program-options eigen3 mpfr mpir cgal --triplet x64-windows
+          python -m pip install --user -r .github/build-requirements.txt
+          python -m pip install --user twine
+          python -m pip list
+      - name: Build python wheel
+        run: |
+          mkdir build
+          cd build
+          cmake -DCMAKE_BUILD_TYPE=Release -DGMP_INCLUDE_DIR="c:/vcpkg/installed/x64-windows/include" -DGMP_LIBRARIES="c:/vcpkg/installed/x64-windows/lib/mpir.lib" -DGMP_LIBRARIES_DIR="c:/vcpkg/installed/x64-windows/lib" -DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake -DVCPKG_TARGET_TRIPLET=x64-windows -DPython_ADDITIONAL_VERSIONS=3 ..
+          cd src/python
+          cp c:/vcpkg/installed/x64-windows/bin/mpfr.dll gudhi/
+          cp c:/vcpkg/installed/x64-windows/bin/mpir.dll gudhi/
+          python setup.py bdist_wheel

--- a/.github/workflows/pip-build-windows.yml
+++ b/.github/workflows/pip-build-windows.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ['3.5', '3.6', '3.7', '3.8']
+        python-version: ['3.8']
     name: Build wheels for Python ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@v1


### PR DESCRIPTION
By building pip package on CI, we could see errors sooner, but it is adding 9 builds to the CI.
Maybe I could limit to only one build on Windows and OSx.