### PR TITLE
Alpha complex 3d does not require eigen

### DIFF
--- a/src/Alpha_complex/example/CMakeLists.txt
+++ b/src/Alpha_complex/example/CMakeLists.txt
@@ -25,7 +25,7 @@ if (NOT CGAL_WITH_EIGEN3_VERSION VERSION_LESS 4.11.0)
   add_test(NAME Alpha_complex_example_fast_from_off_32 COMMAND $<TARGET_FILE:Alpha_complex_example_fast_from_off>
       "${CMAKE_SOURCE_DIR}/data/points/alphacomplexdoc.off" "32.0" "${CMAKE_CURRENT_BINARY_DIR}/fastalphaoffreader_result_32.txt")
 
-if (DIFF_PATH)
+  if (DIFF_PATH)
     # Do not forget to copy test results files in current binary dir
     file(COPY "alphaoffreader_for_doc_32.txt" DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/)
     file(COPY "alphaoffreader_for_doc_60.txt" DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/)
@@ -43,8 +43,10 @@ if (DIFF_PATH)
     add_test(Alpha_complex_example_fast_from_off_32_diff_files ${DIFF_PATH}
         ${CMAKE_CURRENT_BINARY_DIR}/fastalphaoffreader_result_32.txt ${CMAKE_CURRENT_BINARY_DIR}/alphaoffreader_for_doc_32.txt)
     set_tests_properties(Alpha_complex_example_fast_from_off_32_diff_files PROPERTIES DEPENDS Alpha_complex_example_fast_from_off_32) 
-endif()
+  endif()
+ endif(NOT CGAL_WITH_EIGEN3_VERSION VERSION_LESS 4.11.0)
 
+if (NOT CGAL_VERSION VERSION_LESS 4.11.0)
   add_executable ( Alpha_complex_example_weighted_3d_from_points Weighted_alpha_complex_3d_from_points.cpp )
   target_link_libraries(Alpha_complex_example_weighted_3d_from_points  ${CGAL_LIBRARY})
   if (TBB_FOUND)
@@ -61,4 +63,4 @@ endif()
   add_test(NAME Alpha_complex_example_3d_from_points
           COMMAND $<TARGET_FILE:Alpha_complex_example_3d_from_points>)
 
-endif(NOT CGAL_WITH_EIGEN3_VERSION VERSION_LESS 4.11.0)
+endif(NOT CGAL_VERSION VERSION_LESS 4.11.0)

--- a/src/Alpha_complex/include/gudhi/Alpha_complex_3d.h
+++ b/src/Alpha_complex/include/gudhi/Alpha_complex_3d.h
@@ -56,10 +56,6 @@
 # error Alpha_complex_3d is only available for CGAL >= 4.11
 #endif
 
-#if !EIGEN_VERSION_AT_LEAST(3,1,0)
-# error Alpha_complex_3d is only available for Eigen3 >= 3.1.0 installed with CGAL
-#endif
-
 namespace Gudhi {
 
 namespace alpha_complex {

--- a/src/Alpha_complex/include/gudhi/Alpha_complex_3d.h
+++ b/src/Alpha_complex/include/gudhi/Alpha_complex_3d.h
@@ -38,8 +38,6 @@
 #include <CGAL/iterator.h>
 #include <CGAL/version.h>  // for CGAL_VERSION_NR
 
-#include <Eigen/src/Core/util/Macros.h>  // for EIGEN_VERSION_AT_LEAST
-
 #include <boost/container/static_vector.hpp>
 
 #include <iostream>

--- a/src/Alpha_complex/test/CMakeLists.txt
+++ b/src/Alpha_complex/test/CMakeLists.txt
@@ -18,6 +18,10 @@ if (NOT CGAL_WITH_EIGEN3_VERSION VERSION_LESS 4.11.0)
   gudhi_add_boost_test(Alpha_complex_test_unit)
   gudhi_add_boost_test(Delaunay_complex_test_unit)
 
+endif (NOT CGAL_WITH_EIGEN3_VERSION VERSION_LESS 4.11.0)
+
+if (NOT CGAL_VERSION VERSION_LESS 4.11.0)
+
   add_executable ( Alpha_complex_3d_test_unit Alpha_complex_3d_unit_test.cpp )
   target_link_libraries(Alpha_complex_3d_test_unit ${CGAL_LIBRARY})
   add_executable ( Weighted_alpha_complex_3d_test_unit Weighted_alpha_complex_3d_unit_test.cpp )
@@ -38,4 +42,4 @@ if (NOT CGAL_WITH_EIGEN3_VERSION VERSION_LESS 4.11.0)
   gudhi_add_boost_test(Periodic_alpha_complex_3d_test_unit)
   gudhi_add_boost_test(Weighted_periodic_alpha_complex_3d_test_unit)
 
-endif (NOT CGAL_WITH_EIGEN3_VERSION VERSION_LESS 4.11.0)
+endif (NOT CGAL_VERSION VERSION_LESS 4.11.0)

--- a/src/Alpha_complex/utilities/CMakeLists.txt
+++ b/src/Alpha_complex/utilities/CMakeLists.txt
@@ -27,7 +27,9 @@ if (NOT CGAL_WITH_EIGEN3_VERSION VERSION_LESS 4.11.0)
   endif()
   
   install(TARGETS alpha_complex_persistence DESTINATION bin)
+endif (NOT CGAL_WITH_EIGEN3_VERSION VERSION_LESS 4.11.0)
 
+if (NOT CGAL_VERSION VERSION_LESS 4.11.0)
   add_executable(alpha_complex_3d_persistence alpha_complex_3d_persistence.cpp)
   target_link_libraries(alpha_complex_3d_persistence ${CGAL_LIBRARY} Boost::program_options)
   if (TBB_FOUND)
@@ -75,4 +77,4 @@ if (NOT CGAL_WITH_EIGEN3_VERSION VERSION_LESS 4.11.0)
 
   install(TARGETS alpha_complex_3d_persistence DESTINATION bin)
 
-endif (NOT CGAL_WITH_EIGEN3_VERSION VERSION_LESS 4.11.0)
+endif (NOT CGAL_VERSION VERSION_LESS 4.11.0)

--- a/src/Collapse/example/CMakeLists.txt
+++ b/src/Collapse/example/CMakeLists.txt
@@ -1,23 +1,28 @@
 project(Edge_collapse_examples)
 
-# Point cloud
-add_executable ( Edge_collapse_example_basic edge_collapse_basic_example.cpp )
 
-if (TBB_FOUND)
-  target_link_libraries(Edge_collapse_example_basic ${TBB_LIBRARIES})
+if (NOT EIGEN3_VERSION VERSION_LESS 3.1.0)
+
+  # Point cloud
+  add_executable ( Edge_collapse_example_basic edge_collapse_basic_example.cpp )
+  
+  if (TBB_FOUND)
+    target_link_libraries(Edge_collapse_example_basic ${TBB_LIBRARIES})
+  endif()
+  
+  add_test(NAME Edge_collapse_example_basic COMMAND $<TARGET_FILE:Edge_collapse_example_basic>)
+  
+  # Point cloud
+  add_executable ( Edge_collapse_conserve_persistence edge_collapse_conserve_persistence.cpp )
+  
+  if (TBB_FOUND)
+    target_link_libraries(Edge_collapse_conserve_persistence ${TBB_LIBRARIES})
+  endif()
+  
+  add_test(NAME Edge_collapse_conserve_persistence_1 COMMAND $<TARGET_FILE:Edge_collapse_conserve_persistence>
+           "${CMAKE_SOURCE_DIR}/data/points/tore3D_300.off" "0.2")
+  
+  add_test(NAME Edge_collapse_conserve_persistence_2 COMMAND $<TARGET_FILE:Edge_collapse_conserve_persistence>
+           "${CMAKE_SOURCE_DIR}/data/points/tore3D_300.off" "1.8")
+
 endif()
-
-add_test(NAME Edge_collapse_example_basic COMMAND $<TARGET_FILE:Edge_collapse_example_basic>)
-
-# Point cloud
-add_executable ( Edge_collapse_conserve_persistence edge_collapse_conserve_persistence.cpp )
-
-if (TBB_FOUND)
-  target_link_libraries(Edge_collapse_conserve_persistence ${TBB_LIBRARIES})
-endif()
-
-add_test(NAME Edge_collapse_conserve_persistence_1 COMMAND $<TARGET_FILE:Edge_collapse_conserve_persistence>
-         "${CMAKE_SOURCE_DIR}/data/points/tore3D_300.off" "0.2")
-
-add_test(NAME Edge_collapse_conserve_persistence_2 COMMAND $<TARGET_FILE:Edge_collapse_conserve_persistence>
-         "${CMAKE_SOURCE_DIR}/data/points/tore3D_300.off" "1.8")

--- a/src/Collapse/include/gudhi/Flag_complex_edge_collapser.h
+++ b/src/Collapse/include/gudhi/Flag_complex_edge_collapser.h
@@ -18,6 +18,7 @@
 #include <boost/iterator/iterator_facade.hpp>
 
 #include <Eigen/Sparse>
+#include <Eigen/src/Core/util/Macros.h>  // for EIGEN_VERSION_AT_LEAST
 
 #ifdef GUDHI_USE_TBB
 #include <tbb/parallel_sort.h>
@@ -33,6 +34,11 @@
 #include <algorithm>  // for std::includes
 #include <iterator>  // for std::inserter
 #include <type_traits>  // for std::decay
+
+// Make compilation fail - required for external projects - https://github.com/GUDHI/gudhi-devel/issues/10
+#if !EIGEN_VERSION_AT_LEAST(3,1,0)
+# error Alpha_complex is only available for Eigen3 >= 3.1.0 installed with CGAL
+#endif
 
 namespace Gudhi {
 

--- a/src/Collapse/include/gudhi/Flag_complex_edge_collapser.h
+++ b/src/Collapse/include/gudhi/Flag_complex_edge_collapser.h
@@ -37,7 +37,7 @@
 
 // Make compilation fail - required for external projects - https://github.com/GUDHI/gudhi-devel/issues/10
 #if !EIGEN_VERSION_AT_LEAST(3,1,0)
-# error Alpha_complex is only available for Eigen3 >= 3.1.0 installed with CGAL
+# error Edge Collapse is only available for Eigen3 >= 3.1.0
 #endif
 
 namespace Gudhi {

--- a/src/Collapse/test/CMakeLists.txt
+++ b/src/Collapse/test/CMakeLists.txt
@@ -1,9 +1,13 @@
 project(Collapse_tests)
 
-include(GUDHI_boost_test)
+if (NOT EIGEN3_VERSION VERSION_LESS 3.1.0)
 
-add_executable ( Collapse_test_unit collapse_unit_test.cpp )
-if (TBB_FOUND)
-  target_link_libraries(Collapse_test_unit ${TBB_LIBRARIES})
+  include(GUDHI_boost_test)
+  
+  add_executable ( Collapse_test_unit collapse_unit_test.cpp )
+  if (TBB_FOUND)
+    target_link_libraries(Collapse_test_unit ${TBB_LIBRARIES})
+  endif()
+  gudhi_add_boost_test(Collapse_test_unit)
+
 endif()
-gudhi_add_boost_test(Collapse_test_unit)

--- a/src/Collapse/utilities/CMakeLists.txt
+++ b/src/Collapse/utilities/CMakeLists.txt
@@ -1,33 +1,37 @@
 project(Collapse_utilities)
 
-# From a point cloud
-add_executable ( point_cloud_edge_collapse_rips_persistence point_cloud_edge_collapse_rips_persistence.cpp )
-target_link_libraries(point_cloud_edge_collapse_rips_persistence Boost::program_options)
+if (NOT EIGEN3_VERSION VERSION_LESS 3.1.0)
 
-if (TBB_FOUND)
-  target_link_libraries(point_cloud_edge_collapse_rips_persistence ${TBB_LIBRARIES})
-endif()
-add_test(NAME Edge_collapse_utilities_point_cloud_rips_persistence COMMAND $<TARGET_FILE:point_cloud_edge_collapse_rips_persistence>
-         "${CMAKE_SOURCE_DIR}/data/points/tore3D_1307.off" "-r" "0.25" "-m" "0.5" "-d" "3" "-p" "3" "-o" "off_results.pers")
+  # From a point cloud
+  add_executable ( point_cloud_edge_collapse_rips_persistence point_cloud_edge_collapse_rips_persistence.cpp )
+  target_link_libraries(point_cloud_edge_collapse_rips_persistence Boost::program_options)
 
-install(TARGETS point_cloud_edge_collapse_rips_persistence DESTINATION bin)
+  if (TBB_FOUND)
+    target_link_libraries(point_cloud_edge_collapse_rips_persistence ${TBB_LIBRARIES})
+  endif()
+  add_test(NAME Edge_collapse_utilities_point_cloud_rips_persistence COMMAND $<TARGET_FILE:point_cloud_edge_collapse_rips_persistence>
+           "${CMAKE_SOURCE_DIR}/data/points/tore3D_1307.off" "-r" "0.25" "-m" "0.5" "-d" "3" "-p" "3" "-o" "off_results.pers")
 
-# From a distance matrix
-add_executable ( distance_matrix_edge_collapse_rips_persistence distance_matrix_edge_collapse_rips_persistence.cpp )
-target_link_libraries(distance_matrix_edge_collapse_rips_persistence Boost::program_options)
+  install(TARGETS point_cloud_edge_collapse_rips_persistence DESTINATION bin)
 
-if (TBB_FOUND)
-  target_link_libraries(distance_matrix_edge_collapse_rips_persistence ${TBB_LIBRARIES})
-endif()
-add_test(NAME Edge_collapse_utilities_distance_matrix_rips_persistence COMMAND $<TARGET_FILE:distance_matrix_edge_collapse_rips_persistence>
-         "${CMAKE_SOURCE_DIR}/data/distance_matrix/tore3D_1307_distance_matrix.csv" "-r" "0.25" "-m" "0.5" "-d" "3" "-p" "3" "-o" "csv_results.pers")
+  # From a distance matrix
+  add_executable ( distance_matrix_edge_collapse_rips_persistence distance_matrix_edge_collapse_rips_persistence.cpp )
+  target_link_libraries(distance_matrix_edge_collapse_rips_persistence Boost::program_options)
 
-install(TARGETS distance_matrix_edge_collapse_rips_persistence DESTINATION bin)
+  if (TBB_FOUND)
+    target_link_libraries(distance_matrix_edge_collapse_rips_persistence ${TBB_LIBRARIES})
+  endif()
+  add_test(NAME Edge_collapse_utilities_distance_matrix_rips_persistence COMMAND $<TARGET_FILE:distance_matrix_edge_collapse_rips_persistence>
+           "${CMAKE_SOURCE_DIR}/data/distance_matrix/tore3D_1307_distance_matrix.csv" "-r" "0.25" "-m" "0.5" "-d" "3" "-p" "3" "-o" "csv_results.pers")
 
-if (DIFF_PATH)
-  add_test(Edge_collapse_utilities_diff_persistence ${DIFF_PATH}
-           "off_results.pers" "csv_results.pers")
-  set_tests_properties(Edge_collapse_utilities_diff_persistence PROPERTIES DEPENDS
-                       "Edge_collapse_utilities_point_cloud_rips_persistence;Edge_collapse_utilities_distance_matrix_rips_persistence")
-         
+  install(TARGETS distance_matrix_edge_collapse_rips_persistence DESTINATION bin)
+
+  if (DIFF_PATH)
+    add_test(Edge_collapse_utilities_diff_persistence ${DIFF_PATH}
+             "off_results.pers" "csv_results.pers")
+    set_tests_properties(Edge_collapse_utilities_diff_persistence PROPERTIES DEPENDS
+                         "Edge_collapse_utilities_point_cloud_rips_persistence;Edge_collapse_utilities_distance_matrix_rips_persistence")
+
+  endif()
+
 endif()


### PR DESCRIPTION
A fix proposal for #366 
I took the opportunity to test Eigen for Edge Collapse.
Tested by renaming /usr/include/eigen3/signature_of_eigen3_matrix_library

@mglisse With #369 I introduced Edge Collapse inside Python Simplex Tree. This means no Python Simplex Tree when no Eigen. I think we should create a doc/cmake issue to say Eigen is mandatory for Python compilation.