### PR TITLE
Build python first

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -50,6 +50,14 @@ include_directories(include)
 
 # Include module CMake subdirectories
 # GUDHI_SUB_DIRECTORIES is managed in CMAKE_MODULE_PATH/GUDHI_modules.cmake
+if (WITH_GUDHI_PYTHON)
+  # specific for cython module
+  add_subdirectory(${GUDHI_PYTHON_PATH})
+else()
+  message("++ Python module will not be compiled because WITH_GUDHI_PYTHON is set to OFF")
+  set(GUDHI_MISSING_MODULES ${GUDHI_MISSING_MODULES} "python")
+endif()
+
 foreach(GUDHI_MODULE ${GUDHI_MODULES})
   foreach(GUDHI_SUB_DIRECTORY ${GUDHI_SUB_DIRECTORIES})
     if(EXISTS ${CMAKE_SOURCE_DIR}/${GUDHI_SUB_DIRECTORY}/${GUDHI_MODULE}/CMakeLists.txt)
@@ -59,14 +67,6 @@ foreach(GUDHI_MODULE ${GUDHI_MODULES})
 endforeach()
 
 add_subdirectory(GudhUI)
-
-if (WITH_GUDHI_PYTHON)
-  # specific for cython module
-  add_subdirectory(${GUDHI_PYTHON_PATH})
-else()
-  message("++ Python module will not be compiled because WITH_GUDHI_PYTHON is set to OFF")
-  set(GUDHI_MISSING_MODULES ${GUDHI_MISSING_MODULES} "python")
-endif()
 
 message("++ GUDHI_MODULES list is:\"${GUDHI_MODULES}\"")
 message("++ GUDHI_MISSING_MODULES list is:\"${GUDHI_MISSING_MODULES}\"")


### PR DESCRIPTION
This subdirectory is built sequentially and takes a very long time.
Starting it first, in a parallel build, it is still the last to end, but
since it started earlier it also ends earlier.

Usually I build the plugin directly with
> python3 setup.py build_ext --inplace -j20

But I don't think there is a natural way to do that from the makefile
(except for the unlimited -j), since I doubt setuptools knows how to
cooperate with make, ninja, etc to share a pool of workers.