### PR TITLE
Compare lists with ==

### DIFF
--- a/src/python/test/test_tomato.py
+++ b/src/python/test/test_tomato.py
@@ -37,7 +37,7 @@ def test_tomato_1():
     t = Tomato(metric="euclidean", graph_type="radius", r=4.7, k=4)
     t.fit(a)
     assert t.max_weight_per_cc_.size == 2
-    assert np.array_equal(t.neighbors_, [[0, 1, 2], [0, 1, 2], [0, 1, 2], [3, 4, 5, 6], [3, 4, 5], [3, 4, 5], [3, 6]])
+    assert t.neighbors_ == [[0, 1, 2], [0, 1, 2], [0, 1, 2], [3, 4, 5, 6], [3, 4, 5], [3, 4, 5], [3, 6]]
     t.plot_diagram()
 
     t = Tomato(graph_type="radius", r=4.7, k=4, symmetrize_graph=True)


### PR DESCRIPTION
Otherwise we get this warning

> numpy/core/_asarray.py:102: VisibleDeprecationWarning: Creating an ndarray from ragged nested sequences (which is a list-or-tuple of lists-or-tuples-or ndarrays with different lengths or shapes) is deprecated. If you meant to do this, you must specify 'dtype=object' when creating the ndarray.

And indead trying to build an array from `[[1,2],[3]]` is weird.