### PR TITLE
Name the argument n_neighbors of NearestNeighbors

### DIFF
--- a/src/python/gudhi/point_cloud/knn.py
+++ b/src/python/gudhi/point_cloud/knn.py
@@ -111,7 +111,7 @@ class KNearestNeighbors:
             nargs = {
                 k: v for k, v in self.params.items() if k in {"p", "n_jobs", "metric_params", "algorithm", "leaf_size"}
             }
-            self.nn = NearestNeighbors(self.k, metric=self.metric, **nargs)
+            self.nn = NearestNeighbors(n_neighbors=self.k, metric=self.metric, **nargs)
             self.nn.fit(X)
 
         if self.params["implementation"] == "hnsw":


### PR DESCRIPTION
It seems that it has had the same name for a while, so this shouldn't break anything.

> sklearn/utils/validation.py:70: FutureWarning: Pass n_neighbors=3 as keyword args. From version 1.0 (renaming of 0.25) passing these as positional arguments will result in an error