### PR TITLE
Sparse Rips and choose_n_farthest_points, fix #456

### DIFF
--- a/src/Rips_complex/include/gudhi/Sparse_rips_complex.h
+++ b/src/Rips_complex/include/gudhi/Sparse_rips_complex.h
@@ -15,7 +15,7 @@
 #include <gudhi/graph_simplicial_complex.h>
 #include <gudhi/choose_n_farthest_points.h>
 
-#include <boost/graph/adjacency_list.hpp>
+#include <boost/graph/graph_traits.hpp>
 #include <boost/range/metafunctions.hpp>
 #include <boost/iterator/counting_iterator.hpp>
 
@@ -118,7 +118,7 @@ class Sparse_rips_complex {
    *
    */
   template <typename RandomAccessPointRange, typename Distance>
-  Sparse_rips_complex(const RandomAccessPointRange& points, Distance distance, double epsilon, Filtration_value mini=-std::numeric_limits<Filtration_value>::infinity(), Filtration_value maxi=std::numeric_limits<Filtration_value>::infinity())
+  Sparse_rips_complex(const RandomAccessPointRange& points, Distance distance, double const epsilon, Filtration_value const mini=-std::numeric_limits<Filtration_value>::infinity(), Filtration_value const maxi=std::numeric_limits<Filtration_value>::infinity())
       : epsilon_(epsilon) {
     GUDHI_CHECK(epsilon > 0, "epsilon must be positive");
     auto dist_fun = [&](Vertex_handle i, Vertex_handle j) { return distance(points[i], points[j]); };
@@ -139,7 +139,7 @@ class Sparse_rips_complex {
    * @param[in] maxi Maximal filtration value. Ignore anything above this scale.
    */
   template <typename DistanceMatrix>
-  Sparse_rips_complex(const DistanceMatrix& distance_matrix, double epsilon, Filtration_value mini=-std::numeric_limits<Filtration_value>::infinity(), Filtration_value maxi=std::numeric_limits<Filtration_value>::infinity())
+  Sparse_rips_complex(const DistanceMatrix& distance_matrix, double const epsilon, Filtration_value const mini=-std::numeric_limits<Filtration_value>::infinity(), Filtration_value const maxi=std::numeric_limits<Filtration_value>::infinity())
       : Sparse_rips_complex(boost::irange<Vertex_handle>(0, boost::size(distance_matrix)),
                             [&](Vertex_handle i, Vertex_handle j) { return (i==j) ? 0 : (i<j) ? distance_matrix[j][i] : distance_matrix[i][j]; },
                             epsilon, mini, maxi) {}
@@ -155,7 +155,7 @@ class Sparse_rips_complex {
    *
    */
   template <typename SimplicialComplexForRips>
-  void create_complex(SimplicialComplexForRips& complex, int dim_max) {
+  void create_complex(SimplicialComplexForRips& complex, int const dim_max) {
     GUDHI_CHECK(complex.num_vertices() == 0,
                 std::invalid_argument("Sparse_rips_complex::create_complex - simplicial complex is not empty"));
 
@@ -185,7 +185,7 @@ class Sparse_rips_complex {
  private:
   // PointRange must be random access.
   template <typename Distance>
-  void compute_sparse_graph(Distance& dist, double epsilon, Filtration_value mini, Filtration_value maxi) {
+  void compute_sparse_graph(Distance& dist, double const epsilon, Filtration_value const mini, Filtration_value const maxi) {
     const auto& points = sorted_points; // convenience alias
     Vertex_handle n = boost::size(points);
     double cst = epsilon * (1 - epsilon) / 2;

--- a/src/Rips_complex/include/gudhi/Sparse_rips_complex.h
+++ b/src/Rips_complex/include/gudhi/Sparse_rips_complex.h
@@ -164,10 +164,10 @@ class Sparse_rips_complex {
       complex.expansion(dim_max);
       return;
     }
-    const Vertex_handle n = num_vertices(graph_);
+    const std::size_t n = num_vertices(graph_);
     std::vector<Filtration_value> lambda(max_v + 1);
     // lambda[original_order]=params[sorted_order]
-    for(Vertex_handle i=0;i<n;++i)
+    for(std::size_t i=0;i<n;++i)
       lambda[sorted_points[i]] = params[i];
     double cst = epsilon_ * (1 - epsilon_) / 2;
     auto block = [cst,&complex,&lambda](typename SimplicialComplexForRips::Simplex_handle sh){
@@ -187,10 +187,10 @@ class Sparse_rips_complex {
   template <typename Distance>
   void compute_sparse_graph(Distance& dist, double const epsilon, Filtration_value const mini, Filtration_value const maxi) {
     const auto& points = sorted_points; // convenience alias
-    Vertex_handle n = boost::size(points);
+    std::size_t n = boost::size(points);
     double cst = epsilon * (1 - epsilon) / 2;
     max_v = -1; // Useful for the size of the map lambda.
-    for (Vertex_handle i = 0; i < n; ++i) {
+    for (std::size_t i = 0; i < n; ++i) {
       if ((params[i] < mini || params[i] <= 0) && i != 0) break;
       // The parameter of the first point is not very meaningful, it is supposed to be infinite,
       // but if the type does not support it...
@@ -203,13 +203,13 @@ class Sparse_rips_complex {
     // TODO(MG):
     // - make it parallel
     // - only test near-enough neighbors
-    for (Vertex_handle i = 0; i < n; ++i) {
+    for (std::size_t i = 0; i < n; ++i) {
       auto&& pi = points[i];
       auto li = params[i];
       // If we inserted all the points, points with multiplicity would get connected to their first representative,
       // no need to handle the redundant ones in the outer loop.
       // if (li <= 0 && i != 0) break;
-      for (Vertex_handle j = i + 1; j < n; ++j) {
+      for (std::size_t j = i + 1; j < n; ++j) {
         auto&& pj = points[j];
         auto d = dist(pi, pj);
         auto lj = params[j];

--- a/src/Rips_complex/include/gudhi/Sparse_rips_complex.h
+++ b/src/Rips_complex/include/gudhi/Sparse_rips_complex.h
@@ -53,9 +53,9 @@ edges(Graph<Vertex_handle, Filtration_value> const&g) {
   return { I(0), I(g.elist.size()) };
 }
 template <class Vertex_handle, class Filtration_value>
-std::size_t source(std::size_t e, Graph<Vertex_handle, Filtration_value> const&g) { return std::get<0>(g.elist[e]); }
+Vertex_handle source(std::size_t e, Graph<Vertex_handle, Filtration_value> const&g) { return std::get<0>(g.elist[e]); }
 template <class Vertex_handle, class Filtration_value>
-std::size_t target(std::size_t e, Graph<Vertex_handle, Filtration_value> const&g) { return std::get<1>(g.elist[e]); }
+Vertex_handle target(std::size_t e, Graph<Vertex_handle, Filtration_value> const&g) { return std::get<1>(g.elist[e]); }
 template <class Vertex_handle, class Filtration_value>
 Filtration_value get(vertex_filtration_t, Graph<Vertex_handle, Filtration_value> const&, Vertex_handle) { return 0; }
 template <class Vertex_handle, class Filtration_value>

--- a/src/Simplex_tree/include/gudhi/Simplex_tree.h
+++ b/src/Simplex_tree/include/gudhi/Simplex_tree.h
@@ -1060,8 +1060,8 @@ class Simplex_tree {
    *
    * Inserts all vertices and edges given by a OneSkeletonGraph.
    * OneSkeletonGraph must be a model of
-   * <a href="http://www.boost.org/doc/libs/1_65_1/libs/graph/doc/EdgeListGraph.html">boost::EdgeListGraph</a>
-   * and <a href="http://www.boost.org/doc/libs/1_65_1/libs/graph/doc/PropertyGraph.html">boost::PropertyGraph</a>.
+   * <a href="http://www.boost.org/doc/libs/1_76_0/libs/graph/doc/VertexAndEdgeListGraph.html">boost::VertexAndEdgeListGraph</a>
+   * and <a href="http://www.boost.org/doc/libs/1_76_0/libs/graph/doc/PropertyGraph.html">boost::PropertyGraph</a>.
    *
    * The vertex filtration value is accessible through the property tag
    * vertex_filtration_t.
@@ -1081,7 +1081,10 @@ class Simplex_tree {
     // the simplex tree must be empty
     assert(num_simplices() == 0);
 
-    if (boost::num_vertices(skel_graph) == 0) {
+    // is there a better way to let the compiler know that we don't mean Simplex_tree::num_vertices?
+    using boost::num_vertices;
+
+    if (num_vertices(skel_graph) == 0) {
       return;
     }
     if (num_edges(skel_graph) == 0) {
@@ -1090,18 +1093,18 @@ class Simplex_tree {
       dimension_ = 1;
     }
 
-    root_.members_.reserve(boost::num_vertices(skel_graph));
+    root_.members_.reserve(num_vertices(skel_graph));
 
     typename boost::graph_traits<OneSkeletonGraph>::vertex_iterator v_it,
         v_it_end;
-    for (std::tie(v_it, v_it_end) = boost::vertices(skel_graph); v_it != v_it_end;
+    for (std::tie(v_it, v_it_end) = vertices(skel_graph); v_it != v_it_end;
          ++v_it) {
       root_.members_.emplace_hint(
                                   root_.members_.end(), *v_it,
-                                  Node(&root_, boost::get(vertex_filtration_t(), skel_graph, *v_it)));
+                                  Node(&root_, get(vertex_filtration_t(), skel_graph, *v_it)));
     }
     std::pair<typename boost::graph_traits<OneSkeletonGraph>::edge_iterator,
-              typename boost::graph_traits<OneSkeletonGraph>::edge_iterator> boost_edges = boost::edges(skel_graph);
+              typename boost::graph_traits<OneSkeletonGraph>::edge_iterator> boost_edges = edges(skel_graph);
     // boost_edges.first is the equivalent to boost_edges.begin()
     // boost_edges.second is the equivalent to boost_edges.end()
     for (; boost_edges.first != boost_edges.second; boost_edges.first++) {
@@ -1123,7 +1126,7 @@ class Simplex_tree {
       }
 
       sh->second.children()->members().emplace(v,
-          Node(sh->second.children(), boost::get(edge_filtration_t(), skel_graph, edge)));
+          Node(sh->second.children(), get(edge_filtration_t(), skel_graph, edge)));
     }
   }
 

--- a/src/Subsampling/test/test_choose_n_farthest_points.cpp
+++ b/src/Subsampling/test/test_choose_n_farthest_points.cpp
@@ -102,11 +102,12 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(test_choose_farthest_point_limits, Kernel, list_of
   BOOST_CHECK(distances[1] == 1);
   landmarks.clear(); distances.clear();
 
-  // Ignore duplicated points
+  // Accept duplicated points
   points.emplace_back(point.begin(), point.end());
   Gudhi::subsampling::choose_n_farthest_points(d, points, -1, -1, std::back_inserter(landmarks), std::back_inserter(distances));
-  BOOST_CHECK(landmarks.size() == 2 && distances.size() == 2);
+  BOOST_CHECK(landmarks.size() == 3 && distances.size() == 3);
   BOOST_CHECK(distances[0] == std::numeric_limits<FT>::infinity());
   BOOST_CHECK(distances[1] == 1);
+  BOOST_CHECK(distances[2] == 0);
   landmarks.clear(); distances.clear();
 }

--- a/src/python/test/test_rips_complex.py
+++ b/src/python/test/test_rips_complex.py
@@ -133,3 +133,24 @@ def test_filtered_rips_from_distance_matrix():
 
     assert simplex_tree.num_simplices() == 8
     assert simplex_tree.num_vertices() == 4
+
+
+def test_sparse_with_multiplicity():
+    points = [
+        [3, 4],
+        [0.1, 2],
+        [0.1, 2],
+        [0.1, 2],
+        [0.1, 2],
+        [0.1, 2],
+        [0.1, 2],
+        [0.1, 2],
+        [0.1, 2],
+        [0.1, 2],
+        [0.1, 2],
+        [3, 4.1],
+    ]
+    rips = RipsComplex(points=points, sparse=0.01)
+    simplex_tree = rips.create_simplex_tree(max_dimension=2)
+    assert simplex_tree.num_simplices() == 25
+    diag = simplex_tree.persistence()

--- a/src/python/test/test_rips_complex.py
+++ b/src/python/test/test_rips_complex.py
@@ -152,5 +152,5 @@ def test_sparse_with_multiplicity():
     ]
     rips = RipsComplex(points=points, sparse=0.01)
     simplex_tree = rips.create_simplex_tree(max_dimension=2)
-    assert simplex_tree.num_simplices() == 25
+    assert simplex_tree.num_simplices() == 7
     diag = simplex_tree.persistence()


### PR DESCRIPTION
That was way more work than I hoped...
You can see gradual improvements with the commits. The first one is probably not necessary after the whole series, but it still looks better to me. First I made choose_n_farthest_points return all the points, which fixes the bug. But we build a complete graph on equal points, so I updated the sparse Rips so redundant vertices are connected through just one edge. And finally I actually dropped the redundant points.
One small missing optimization is a way to say: stop choose_n_farthest_points once we reach a small enough distance. Currently, that would require passing a special output iterator that throws an exception when that happens...

Fix #456