### PR TITLE
Remove bad attribute maybe_unused

### DIFF
--- a/src/Spatial_searching/include/gudhi/Kd_tree_search.h
+++ b/src/Spatial_searching/include/gudhi/Kd_tree_search.h
@@ -139,7 +139,7 @@ class Kd_tree_search {
     }
 
     template <typename Coord_iterator>
-      bool contains_point_given_as_coordinates(Coord_iterator pi, Coord_iterator CGAL_UNUSED) const {
+      bool contains_point_given_as_coordinates(Coord_iterator pi, Coord_iterator) const {
         FT distance = 0;
         auto ccci = traits.construct_cartesian_const_iterator_d_object();
         auto ci = ccci(c);


### PR DESCRIPTION
`CGAL_UNUSED` or `[[maybe_unused]]` is useful if we name the argument but don't use it. If we don't name it, the attribute is wrong as it would apply to the type and not the variable.