### PR TITLE
Avoid confusion between dim and field of coeffs in persistent cohomology

### DIFF
--- a/src/Persistent_cohomology/test/persistent_cohomology_unit_test.cpp
+++ b/src/Persistent_cohomology/test/persistent_cohomology_unit_test.cpp
@@ -21,7 +21,7 @@ using namespace boost::unit_test;
 
 typedef Simplex_tree<> typeST;
 
-std::string test_rips_persistence(int coefficient, int min_persistence) {
+std::string test_persistence(int coefficient, int min_persistence) {
   // file is copied in CMakeLists.txt
   std::ifstream simplex_tree_stream;
   simplex_tree_stream.open("simplex_tree_file_for_unit_test.txt");
@@ -44,16 +44,16 @@ std::string test_rips_persistence(int coefficient, int min_persistence) {
   Persistent_cohomology<Simplex_tree<>, Field_Zp> pcoh(st);
 
   pcoh.init_coefficients( coefficient );  // initializes the coefficient field for homology
-  // Check infinite rips
+  // Compute the persistent homology of the complex
   pcoh.compute_persistent_cohomology( min_persistence );  // Minimal lifetime of homology feature to be recorded.
-  std::ostringstream ossInfinite;
+  std::ostringstream ossPers;
 
-  pcoh.output_diagram(ossInfinite);
-  std::string strInfinite = ossInfinite.str();
-  return strInfinite;
+  pcoh.output_diagram(ossPers);
+  std::string strPers = ossPers.str();
+  return strPers;
 }
 
-void test_rips_persistence_with_coeff_field(int coeff_field) {
+void test_persistence_with_coeff_field(int coeff_field) {
   std::string value0("  0 0.02 1.12");
   std::string value1("  0 0.03 1.13");
   std::string value2("  0 0.04 1.14");
@@ -77,90 +77,90 @@ void test_rips_persistence_with_coeff_field(int coeff_field) {
   value9.insert(0,std::to_string(coeff_field));
 
   std::clog << "********************************************************************" << std::endl;
-  std::clog << "TEST OF RIPS_PERSISTENT_COHOMOLOGY_SINGLE_FIELD COEFF_FIELD=" << coeff_field << " MIN_PERS=0" << std::endl;
+  std::clog << "TEST OF PERSISTENT_COHOMOLOGY_SINGLE_FIELD COEFF_FIELD=" << coeff_field << " MIN_PERS=0" << std::endl;
 
-  std::string str_rips_persistence = test_rips_persistence(coeff_field, 0);
-  std::clog << str_rips_persistence << std::endl;
+  std::string str_persistence = test_persistence(coeff_field, 0);
+  std::clog << str_persistence << std::endl;
   
-  BOOST_CHECK(str_rips_persistence.find(value0) != std::string::npos); // Check found
-  BOOST_CHECK(str_rips_persistence.find(value1) != std::string::npos); // Check found
-  BOOST_CHECK(str_rips_persistence.find(value2) != std::string::npos); // Check found
-  BOOST_CHECK(str_rips_persistence.find(value3) != std::string::npos); // Check found
-  BOOST_CHECK(str_rips_persistence.find(value4) != std::string::npos); // Check found
-  BOOST_CHECK(str_rips_persistence.find(value5) != std::string::npos); // Check found
-  BOOST_CHECK(str_rips_persistence.find(value6) != std::string::npos); // Check found
-  BOOST_CHECK(str_rips_persistence.find(value7) != std::string::npos); // Check found
-  BOOST_CHECK(str_rips_persistence.find(value8) != std::string::npos); // Check found
-  BOOST_CHECK(str_rips_persistence.find(value9) != std::string::npos); // Check found
-  std::clog << "str_rips_persistence=" << str_rips_persistence << std::endl;
+  BOOST_CHECK(str_persistence.find(value0) != std::string::npos); // Check found
+  BOOST_CHECK(str_persistence.find(value1) != std::string::npos); // Check found
+  BOOST_CHECK(str_persistence.find(value2) != std::string::npos); // Check found
+  BOOST_CHECK(str_persistence.find(value3) != std::string::npos); // Check found
+  BOOST_CHECK(str_persistence.find(value4) != std::string::npos); // Check found
+  BOOST_CHECK(str_persistence.find(value5) != std::string::npos); // Check found
+  BOOST_CHECK(str_persistence.find(value6) != std::string::npos); // Check found
+  BOOST_CHECK(str_persistence.find(value7) != std::string::npos); // Check found
+  BOOST_CHECK(str_persistence.find(value8) != std::string::npos); // Check found
+  BOOST_CHECK(str_persistence.find(value9) != std::string::npos); // Check found
+  std::clog << "str_persistence=" << str_persistence << std::endl;
 
   std::clog << "********************************************************************" << std::endl;
-  std::clog << "TEST OF RIPS_PERSISTENT_COHOMOLOGY_SINGLE_FIELD COEFF_FIELD=" << coeff_field << " MIN_PERS=1" << std::endl;
+  std::clog << "TEST OF PERSISTENT_COHOMOLOGY_SINGLE_FIELD COEFF_FIELD=" << coeff_field << " MIN_PERS=1" << std::endl;
 
-  str_rips_persistence = test_rips_persistence(coeff_field, 1);
+  str_persistence = test_persistence(coeff_field, 1);
 
-  BOOST_CHECK(str_rips_persistence.find(value0) != std::string::npos); // Check found
-  BOOST_CHECK(str_rips_persistence.find(value1) != std::string::npos); // Check found
-  BOOST_CHECK(str_rips_persistence.find(value2) != std::string::npos); // Check found
-  BOOST_CHECK(str_rips_persistence.find(value3) != std::string::npos); // Check found
-  BOOST_CHECK(str_rips_persistence.find(value4) != std::string::npos); // Check found
-  BOOST_CHECK(str_rips_persistence.find(value5) != std::string::npos); // Check found
-  BOOST_CHECK(str_rips_persistence.find(value6) != std::string::npos); // Check found
-  BOOST_CHECK(str_rips_persistence.find(value7) != std::string::npos); // Check found
-  BOOST_CHECK(str_rips_persistence.find(value8) != std::string::npos); // Check found
-  BOOST_CHECK(str_rips_persistence.find(value9) != std::string::npos); // Check found
-  std::clog << "str_rips_persistence=" << str_rips_persistence << std::endl;
-
-  std::clog << "********************************************************************" << std::endl;
-  std::clog << "TEST OF RIPS_PERSISTENT_COHOMOLOGY_SINGLE_FIELD COEFF_FIELD=" << coeff_field << " MIN_PERS=2" << std::endl;
-
-  str_rips_persistence = test_rips_persistence(coeff_field, 2);
-
-  BOOST_CHECK(str_rips_persistence.find(value0) == std::string::npos); // Check not found
-  BOOST_CHECK(str_rips_persistence.find(value1) == std::string::npos); // Check not found
-  BOOST_CHECK(str_rips_persistence.find(value2) == std::string::npos); // Check not found
-  BOOST_CHECK(str_rips_persistence.find(value3) == std::string::npos); // Check not found
-  BOOST_CHECK(str_rips_persistence.find(value4) == std::string::npos); // Check not found
-  BOOST_CHECK(str_rips_persistence.find(value5) == std::string::npos); // Check not found
-  BOOST_CHECK(str_rips_persistence.find(value6) == std::string::npos); // Check not found
-  BOOST_CHECK(str_rips_persistence.find(value7) == std::string::npos); // Check not found
-  BOOST_CHECK(str_rips_persistence.find(value8) != std::string::npos); // Check found
-  BOOST_CHECK(str_rips_persistence.find(value9) != std::string::npos); // Check found
-  std::clog << "str_rips_persistence=" << str_rips_persistence << std::endl;
+  BOOST_CHECK(str_persistence.find(value0) != std::string::npos); // Check found
+  BOOST_CHECK(str_persistence.find(value1) != std::string::npos); // Check found
+  BOOST_CHECK(str_persistence.find(value2) != std::string::npos); // Check found
+  BOOST_CHECK(str_persistence.find(value3) != std::string::npos); // Check found
+  BOOST_CHECK(str_persistence.find(value4) != std::string::npos); // Check found
+  BOOST_CHECK(str_persistence.find(value5) != std::string::npos); // Check found
+  BOOST_CHECK(str_persistence.find(value6) != std::string::npos); // Check found
+  BOOST_CHECK(str_persistence.find(value7) != std::string::npos); // Check found
+  BOOST_CHECK(str_persistence.find(value8) != std::string::npos); // Check found
+  BOOST_CHECK(str_persistence.find(value9) != std::string::npos); // Check found
+  std::clog << "str_persistence=" << str_persistence << std::endl;
 
   std::clog << "********************************************************************" << std::endl;
-  std::clog << "TEST OF RIPS_PERSISTENT_COHOMOLOGY_SINGLE_FIELD COEFF_FIELD=" << coeff_field << " MIN_PERS=Inf" << std::endl;
+  std::clog << "TEST OF PERSISTENT_COHOMOLOGY_SINGLE_FIELD COEFF_FIELD=" << coeff_field << " MIN_PERS=2" << std::endl;
 
-  str_rips_persistence = test_rips_persistence(coeff_field, (std::numeric_limits<int>::max)());
+  str_persistence = test_persistence(coeff_field, 2);
 
-  BOOST_CHECK(str_rips_persistence.find(value0) == std::string::npos); // Check not found
-  BOOST_CHECK(str_rips_persistence.find(value1) == std::string::npos); // Check not found
-  BOOST_CHECK(str_rips_persistence.find(value2) == std::string::npos); // Check not found
-  BOOST_CHECK(str_rips_persistence.find(value3) == std::string::npos); // Check not found
-  BOOST_CHECK(str_rips_persistence.find(value4) == std::string::npos); // Check not found
-  BOOST_CHECK(str_rips_persistence.find(value5) == std::string::npos); // Check not found
-  BOOST_CHECK(str_rips_persistence.find(value6) == std::string::npos); // Check not found
-  BOOST_CHECK(str_rips_persistence.find(value7) == std::string::npos); // Check not found
-  BOOST_CHECK(str_rips_persistence.find(value8) != std::string::npos); // Check found
-  BOOST_CHECK(str_rips_persistence.find(value9) != std::string::npos); // Check found
-  std::clog << "str_rips_persistence=" << str_rips_persistence << std::endl;
+  BOOST_CHECK(str_persistence.find(value0) == std::string::npos); // Check not found
+  BOOST_CHECK(str_persistence.find(value1) == std::string::npos); // Check not found
+  BOOST_CHECK(str_persistence.find(value2) == std::string::npos); // Check not found
+  BOOST_CHECK(str_persistence.find(value3) == std::string::npos); // Check not found
+  BOOST_CHECK(str_persistence.find(value4) == std::string::npos); // Check not found
+  BOOST_CHECK(str_persistence.find(value5) == std::string::npos); // Check not found
+  BOOST_CHECK(str_persistence.find(value6) == std::string::npos); // Check not found
+  BOOST_CHECK(str_persistence.find(value7) == std::string::npos); // Check not found
+  BOOST_CHECK(str_persistence.find(value8) != std::string::npos); // Check found
+  BOOST_CHECK(str_persistence.find(value9) != std::string::npos); // Check found
+  std::clog << "str_persistence=" << str_persistence << std::endl;
+
+  std::clog << "********************************************************************" << std::endl;
+  std::clog << "TEST OF PERSISTENT_COHOMOLOGY_SINGLE_FIELD COEFF_FIELD=" << coeff_field << " MIN_PERS=Inf" << std::endl;
+
+  str_persistence = test_persistence(coeff_field, (std::numeric_limits<int>::max)());
+
+  BOOST_CHECK(str_persistence.find(value0) == std::string::npos); // Check not found
+  BOOST_CHECK(str_persistence.find(value1) == std::string::npos); // Check not found
+  BOOST_CHECK(str_persistence.find(value2) == std::string::npos); // Check not found
+  BOOST_CHECK(str_persistence.find(value3) == std::string::npos); // Check not found
+  BOOST_CHECK(str_persistence.find(value4) == std::string::npos); // Check not found
+  BOOST_CHECK(str_persistence.find(value5) == std::string::npos); // Check not found
+  BOOST_CHECK(str_persistence.find(value6) == std::string::npos); // Check not found
+  BOOST_CHECK(str_persistence.find(value7) == std::string::npos); // Check not found
+  BOOST_CHECK(str_persistence.find(value8) != std::string::npos); // Check found
+  BOOST_CHECK(str_persistence.find(value9) != std::string::npos); // Check found
+  std::clog << "str_persistence=" << str_persistence << std::endl;
 }
 
-BOOST_AUTO_TEST_CASE( rips_persistent_cohomology_single_field_coeff_not_prime )
+BOOST_AUTO_TEST_CASE( persistent_cohomology_single_field_coeff_not_prime )
 {
   for (auto non_prime : {0, 1, 4, 6})
-    BOOST_CHECK_THROW(test_rips_persistence_with_coeff_field(non_prime), std::invalid_argument);
+    BOOST_CHECK_THROW(test_persistence_with_coeff_field(non_prime), std::invalid_argument);
 }
 
-BOOST_AUTO_TEST_CASE( rips_persistent_cohomology_single_field_coeff_prime )
+BOOST_AUTO_TEST_CASE( persistent_cohomology_single_field_coeff_prime )
 {
   for (auto prime : {2, 3, 5, 11, 13})
-    test_rips_persistence_with_coeff_field(prime);
+    test_persistence_with_coeff_field(prime);
 }
 
-BOOST_AUTO_TEST_CASE( rips_persistent_cohomology_single_field_coeff_limit )
+BOOST_AUTO_TEST_CASE( persistent_cohomology_single_field_coeff_limit )
 {
-  BOOST_CHECK_THROW(test_rips_persistence_with_coeff_field(46349), std::invalid_argument);
+  BOOST_CHECK_THROW(test_persistence_with_coeff_field(46349), std::invalid_argument);
 }
 
 /** SimplexTree minimal options to test the limits.

--- a/src/Persistent_cohomology/test/persistent_cohomology_unit_test.cpp
+++ b/src/Persistent_cohomology/test/persistent_cohomology_unit_test.cpp
@@ -53,7 +53,7 @@ std::string test_rips_persistence(int coefficient, int min_persistence) {
   return strInfinite;
 }
 
-void test_rips_persistence_in_dimension(int dimension) {
+void test_rips_persistence_with_coeff_field(int coeff_field) {
   std::string value0("  0 0.02 1.12");
   std::string value1("  0 0.03 1.13");
   std::string value2("  0 0.04 1.14");
@@ -65,21 +65,21 @@ void test_rips_persistence_in_dimension(int dimension) {
   std::string value8("  0 0 inf"    );
   std::string value9("  0 0.01 inf" );
 
-  value0.insert(0,std::to_string(dimension));
-  value1.insert(0,std::to_string(dimension));
-  value2.insert(0,std::to_string(dimension));
-  value3.insert(0,std::to_string(dimension));
-  value4.insert(0,std::to_string(dimension));
-  value5.insert(0,std::to_string(dimension));
-  value6.insert(0,std::to_string(dimension));
-  value7.insert(0,std::to_string(dimension));
-  value8.insert(0,std::to_string(dimension));
-  value9.insert(0,std::to_string(dimension));
+  value0.insert(0,std::to_string(coeff_field));
+  value1.insert(0,std::to_string(coeff_field));
+  value2.insert(0,std::to_string(coeff_field));
+  value3.insert(0,std::to_string(coeff_field));
+  value4.insert(0,std::to_string(coeff_field));
+  value5.insert(0,std::to_string(coeff_field));
+  value6.insert(0,std::to_string(coeff_field));
+  value7.insert(0,std::to_string(coeff_field));
+  value8.insert(0,std::to_string(coeff_field));
+  value9.insert(0,std::to_string(coeff_field));
 
   std::clog << "********************************************************************" << std::endl;
-  std::clog << "TEST OF RIPS_PERSISTENT_COHOMOLOGY_SINGLE_FIELD DIM=" << dimension << " MIN_PERS=0" << std::endl;
+  std::clog << "TEST OF RIPS_PERSISTENT_COHOMOLOGY_SINGLE_FIELD COEFF_FIELD=" << coeff_field << " MIN_PERS=0" << std::endl;
 
-  std::string str_rips_persistence = test_rips_persistence(dimension, 0);
+  std::string str_rips_persistence = test_rips_persistence(coeff_field, 0);
   std::clog << str_rips_persistence << std::endl;
   
   BOOST_CHECK(str_rips_persistence.find(value0) != std::string::npos); // Check found
@@ -95,9 +95,9 @@ void test_rips_persistence_in_dimension(int dimension) {
   std::clog << "str_rips_persistence=" << str_rips_persistence << std::endl;
 
   std::clog << "********************************************************************" << std::endl;
-  std::clog << "TEST OF RIPS_PERSISTENT_COHOMOLOGY_SINGLE_FIELD DIM=" << dimension << " MIN_PERS=1" << std::endl;
+  std::clog << "TEST OF RIPS_PERSISTENT_COHOMOLOGY_SINGLE_FIELD COEFF_FIELD=" << coeff_field << " MIN_PERS=1" << std::endl;
 
-  str_rips_persistence = test_rips_persistence(dimension, 1);
+  str_rips_persistence = test_rips_persistence(coeff_field, 1);
 
   BOOST_CHECK(str_rips_persistence.find(value0) != std::string::npos); // Check found
   BOOST_CHECK(str_rips_persistence.find(value1) != std::string::npos); // Check found
@@ -112,9 +112,9 @@ void test_rips_persistence_in_dimension(int dimension) {
   std::clog << "str_rips_persistence=" << str_rips_persistence << std::endl;
 
   std::clog << "********************************************************************" << std::endl;
-  std::clog << "TEST OF RIPS_PERSISTENT_COHOMOLOGY_SINGLE_FIELD DIM=" << dimension << " MIN_PERS=2" << std::endl;
+  std::clog << "TEST OF RIPS_PERSISTENT_COHOMOLOGY_SINGLE_FIELD COEFF_FIELD=" << coeff_field << " MIN_PERS=2" << std::endl;
 
-  str_rips_persistence = test_rips_persistence(dimension, 2);
+  str_rips_persistence = test_rips_persistence(coeff_field, 2);
 
   BOOST_CHECK(str_rips_persistence.find(value0) == std::string::npos); // Check not found
   BOOST_CHECK(str_rips_persistence.find(value1) == std::string::npos); // Check not found
@@ -129,9 +129,9 @@ void test_rips_persistence_in_dimension(int dimension) {
   std::clog << "str_rips_persistence=" << str_rips_persistence << std::endl;
 
   std::clog << "********************************************************************" << std::endl;
-  std::clog << "TEST OF RIPS_PERSISTENT_COHOMOLOGY_SINGLE_FIELD DIM=" << dimension << " MIN_PERS=Inf" << std::endl;
+  std::clog << "TEST OF RIPS_PERSISTENT_COHOMOLOGY_SINGLE_FIELD COEFF_FIELD=" << coeff_field << " MIN_PERS=Inf" << std::endl;
 
-  str_rips_persistence = test_rips_persistence(dimension, (std::numeric_limits<int>::max)());
+  str_rips_persistence = test_rips_persistence(coeff_field, (std::numeric_limits<int>::max)());
 
   BOOST_CHECK(str_rips_persistence.find(value0) == std::string::npos); // Check not found
   BOOST_CHECK(str_rips_persistence.find(value1) == std::string::npos); // Check not found
@@ -146,54 +146,54 @@ void test_rips_persistence_in_dimension(int dimension) {
   std::clog << "str_rips_persistence=" << str_rips_persistence << std::endl;
 }
 
-BOOST_AUTO_TEST_CASE( rips_persistent_cohomology_single_field_dim_0 )
+BOOST_AUTO_TEST_CASE( rips_persistent_cohomology_single_field_coeff_0 )
 {
-  BOOST_CHECK_THROW(test_rips_persistence_in_dimension(0), std::invalid_argument);
+  BOOST_CHECK_THROW(test_rips_persistence_with_coeff_field(0), std::invalid_argument);
 }
 
-BOOST_AUTO_TEST_CASE( rips_persistent_cohomology_single_field_dim_1 )
+BOOST_AUTO_TEST_CASE( rips_persistent_cohomology_single_field_coeff_1 )
 {
-  BOOST_CHECK_THROW(test_rips_persistence_in_dimension(1), std::invalid_argument);
+  BOOST_CHECK_THROW(test_rips_persistence_with_coeff_field(1), std::invalid_argument);
 }
 
-BOOST_AUTO_TEST_CASE( rips_persistent_cohomology_single_field_dim_2 )
+BOOST_AUTO_TEST_CASE( rips_persistent_cohomology_single_field_coeff_2 )
 {
-  test_rips_persistence_in_dimension(2);
+  test_rips_persistence_with_coeff_field(2);
 }
 
-BOOST_AUTO_TEST_CASE( rips_persistent_cohomology_single_field_dim_3 )
+BOOST_AUTO_TEST_CASE( rips_persistent_cohomology_single_field_coeff_3 )
 {
-  test_rips_persistence_in_dimension(3);
+  test_rips_persistence_with_coeff_field(3);
 }
 
-BOOST_AUTO_TEST_CASE( rips_persistent_cohomology_single_field_dim_4 )
+BOOST_AUTO_TEST_CASE( rips_persistent_cohomology_single_field_coeff_4 )
 {
-  BOOST_CHECK_THROW(test_rips_persistence_in_dimension(4), std::invalid_argument);
+  BOOST_CHECK_THROW(test_rips_persistence_with_coeff_field(4), std::invalid_argument);
 }
 
-BOOST_AUTO_TEST_CASE( rips_persistent_cohomology_single_field_dim_5 )
+BOOST_AUTO_TEST_CASE( rips_persistent_cohomology_single_field_coeff_5 )
 {
-  test_rips_persistence_in_dimension(5);
+  test_rips_persistence_with_coeff_field(5);
 }
 
-BOOST_AUTO_TEST_CASE( rips_persistent_cohomology_single_field_dim_6 )
+BOOST_AUTO_TEST_CASE( rips_persistent_cohomology_single_field_coeff_6 )
 {
-  BOOST_CHECK_THROW(test_rips_persistence_in_dimension(6), std::invalid_argument);
+  BOOST_CHECK_THROW(test_rips_persistence_with_coeff_field(6), std::invalid_argument);
 }
 
-BOOST_AUTO_TEST_CASE( rips_persistent_cohomology_single_field_dim_11 )
+BOOST_AUTO_TEST_CASE( rips_persistent_cohomology_single_field_coeff_11 )
 {
-  test_rips_persistence_in_dimension(11);
+  test_rips_persistence_with_coeff_field(11);
 }
 
-BOOST_AUTO_TEST_CASE( rips_persistent_cohomology_single_field_dim_13 )
+BOOST_AUTO_TEST_CASE( rips_persistent_cohomology_single_field_coeff_13 )
 {
-  test_rips_persistence_in_dimension(13);
+  test_rips_persistence_with_coeff_field(13);
 }
 
-BOOST_AUTO_TEST_CASE( rips_persistent_cohomology_single_field_dim_46349 )
+BOOST_AUTO_TEST_CASE( rips_persistent_cohomology_single_field_coeff_46349 )
 {
-  BOOST_CHECK_THROW(test_rips_persistence_in_dimension(46349), std::invalid_argument);
+  BOOST_CHECK_THROW(test_rips_persistence_with_coeff_field(46349), std::invalid_argument);
 }
 
 /** SimplexTree minimal options to test the limits.

--- a/src/Persistent_cohomology/test/persistent_cohomology_unit_test.cpp
+++ b/src/Persistent_cohomology/test/persistent_cohomology_unit_test.cpp
@@ -146,52 +146,19 @@ void test_rips_persistence_with_coeff_field(int coeff_field) {
   std::clog << "str_rips_persistence=" << str_rips_persistence << std::endl;
 }
 
-BOOST_AUTO_TEST_CASE( rips_persistent_cohomology_single_field_coeff_0 )
+BOOST_AUTO_TEST_CASE( rips_persistent_cohomology_single_field_coeff_not_prime )
 {
-  BOOST_CHECK_THROW(test_rips_persistence_with_coeff_field(0), std::invalid_argument);
+  for (auto non_prime : {0, 1, 4, 6})
+    BOOST_CHECK_THROW(test_rips_persistence_with_coeff_field(non_prime), std::invalid_argument);
 }
 
-BOOST_AUTO_TEST_CASE( rips_persistent_cohomology_single_field_coeff_1 )
+BOOST_AUTO_TEST_CASE( rips_persistent_cohomology_single_field_coeff_prime )
 {
-  BOOST_CHECK_THROW(test_rips_persistence_with_coeff_field(1), std::invalid_argument);
+  for (auto prime : {2, 3, 5, 11, 13})
+    test_rips_persistence_with_coeff_field(prime);
 }
 
-BOOST_AUTO_TEST_CASE( rips_persistent_cohomology_single_field_coeff_2 )
-{
-  test_rips_persistence_with_coeff_field(2);
-}
-
-BOOST_AUTO_TEST_CASE( rips_persistent_cohomology_single_field_coeff_3 )
-{
-  test_rips_persistence_with_coeff_field(3);
-}
-
-BOOST_AUTO_TEST_CASE( rips_persistent_cohomology_single_field_coeff_4 )
-{
-  BOOST_CHECK_THROW(test_rips_persistence_with_coeff_field(4), std::invalid_argument);
-}
-
-BOOST_AUTO_TEST_CASE( rips_persistent_cohomology_single_field_coeff_5 )
-{
-  test_rips_persistence_with_coeff_field(5);
-}
-
-BOOST_AUTO_TEST_CASE( rips_persistent_cohomology_single_field_coeff_6 )
-{
-  BOOST_CHECK_THROW(test_rips_persistence_with_coeff_field(6), std::invalid_argument);
-}
-
-BOOST_AUTO_TEST_CASE( rips_persistent_cohomology_single_field_coeff_11 )
-{
-  test_rips_persistence_with_coeff_field(11);
-}
-
-BOOST_AUTO_TEST_CASE( rips_persistent_cohomology_single_field_coeff_13 )
-{
-  test_rips_persistence_with_coeff_field(13);
-}
-
-BOOST_AUTO_TEST_CASE( rips_persistent_cohomology_single_field_coeff_46349 )
+BOOST_AUTO_TEST_CASE( rips_persistent_cohomology_single_field_coeff_limit )
 {
   BOOST_CHECK_THROW(test_rips_persistence_with_coeff_field(46349), std::invalid_argument);
 }

--- a/src/Persistent_cohomology/test/persistent_cohomology_unit_test_multi_field.cpp
+++ b/src/Persistent_cohomology/test/persistent_cohomology_unit_test_multi_field.cpp
@@ -54,7 +54,7 @@ std::string test_rips_persistence(int min_coefficient, int max_coefficient, doub
   return strRips;
 }
 
-void test_rips_persistence_in_dimension(int min_dimension, int max_dimension) {
+void test_rips_persistence_with_coeff_field(int min_coefficient, int max_coefficient) {
   // there are 2 discontinued ensembles 
   std::string value0("  0 0.25 inf");
   std::string value1("  1 0.4 inf");
@@ -69,16 +69,16 @@ void test_rips_persistence_in_dimension(int min_dimension, int max_dimension) {
   std::string value7("  2 0.4 inf");
 
   std::clog << "********************************************************************" << std::endl;
-  std::clog << "TEST OF RIPS_PERSISTENT_COHOMOLOGY_MULTI_FIELD MIN_DIM=" << min_dimension << " MAX_DIM=" << max_dimension << " MIN_PERS=0" << std::endl;
+  std::clog << "TEST OF RIPS_PERSISTENT_COHOMOLOGY_MULTI_FIELD MIN_COEFF=" << min_coefficient << " MAX_COEFF=" << max_coefficient << " MIN_PERS=0" << std::endl;
 
-  std::string str_rips_persistence = test_rips_persistence(min_dimension, max_dimension, 0.0);
+  std::string str_rips_persistence = test_rips_persistence(min_coefficient, max_coefficient, 0.0);
   std::clog << "str_rips_persistence=" << str_rips_persistence << std::endl;
 
   BOOST_CHECK(str_rips_persistence.find(value0) != std::string::npos); // Check found
   BOOST_CHECK(str_rips_persistence.find(value1) != std::string::npos); // Check found
   BOOST_CHECK(str_rips_persistence.find(value2) != std::string::npos); // Check found
 
-  if ((min_dimension < 2) && (max_dimension < 2)) {
+  if ((min_coefficient < 2) && (max_coefficient < 2)) {
     BOOST_CHECK(str_rips_persistence.find(value3) != std::string::npos); // Check found
     BOOST_CHECK(str_rips_persistence.find(value4) != std::string::npos); // Check found
     BOOST_CHECK(str_rips_persistence.find(value5) != std::string::npos); // Check found
@@ -94,22 +94,34 @@ void test_rips_persistence_in_dimension(int min_dimension, int max_dimension) {
 
 }
 
-BOOST_AUTO_TEST_CASE(rips_persistent_cohomology_multi_field_dim_1_2) {
-  test_rips_persistence_in_dimension(0, 1);
+BOOST_AUTO_TEST_CASE(rips_persistent_cohomology_multi_field_coeff_0_0) {
+  test_rips_persistence_with_coeff_field(0, 0);
 }
 
-BOOST_AUTO_TEST_CASE(rips_persistent_cohomology_multi_field_dim_2_3) {
-  test_rips_persistence_in_dimension(1, 3);
+BOOST_AUTO_TEST_CASE(rips_persistent_cohomology_multi_field_coeff_0_1) {
+  test_rips_persistence_with_coeff_field(0, 1);
 }
 
-BOOST_AUTO_TEST_CASE(rips_persistent_cohomology_multi_field_dim_1_5) {
-  test_rips_persistence_in_dimension(1, 5);
+BOOST_AUTO_TEST_CASE(rips_persistent_cohomology_multi_field_coeff_0_6) {
+  test_rips_persistence_with_coeff_field(0, 6);
 }
 
-// TODO(VR): not working from 6
-// std::string str_rips_persistence = test_rips_persistence(6, 0);
-// TODO(VR): division by zero
-// std::string str_rips_persistence = test_rips_persistence(0, 0);
-// TODO(VR): is result OK of :
-// test_rips_persistence_in_dimension(3, 4);
+BOOST_AUTO_TEST_CASE(rips_persistent_cohomology_multi_field_coeff_1_2) {
+  test_rips_persistence_with_coeff_field(1, 2);
+}
 
+BOOST_AUTO_TEST_CASE(rips_persistent_cohomology_multi_field_coeff_1_3) {
+  test_rips_persistence_with_coeff_field(1, 3);
+}
+
+BOOST_AUTO_TEST_CASE(rips_persistent_cohomology_multi_field_coeff_1_5) {
+  test_rips_persistence_with_coeff_field(1, 5);
+}
+
+BOOST_AUTO_TEST_CASE(rips_persistent_cohomology_multi_field_coeff_2_3) {
+  test_rips_persistence_with_coeff_field(2, 3);
+}
+
+BOOST_AUTO_TEST_CASE(rips_persistent_cohomology_multi_field_coeff_3_4) {
+  test_rips_persistence_with_coeff_field(3, 4);
+}

--- a/src/Persistent_cohomology/test/persistent_cohomology_unit_test_multi_field.cpp
+++ b/src/Persistent_cohomology/test/persistent_cohomology_unit_test_multi_field.cpp
@@ -21,7 +21,7 @@ using namespace boost::unit_test;
 
 typedef Simplex_tree<> typeST;
 
-std::string test_rips_persistence(int min_coefficient, int max_coefficient, double min_persistence) {
+std::string test_persistence(int min_coefficient, int max_coefficient, double min_persistence) {
   // file is copied in CMakeLists.txt
   std::ifstream simplex_tree_stream;
   simplex_tree_stream.open("simplex_tree_file_for_multi_field_unit_test.txt");
@@ -44,17 +44,17 @@ std::string test_rips_persistence(int min_coefficient, int max_coefficient, doub
   Persistent_cohomology<Simplex_tree<>, Multi_field> pcoh(st);
 
   pcoh.init_coefficients(min_coefficient, max_coefficient); // initializes the coefficient field for homology
-  // Check infinite rips
+  // Compute the persistent homology of the complex
   pcoh.compute_persistent_cohomology(min_persistence); // Minimal lifetime of homology feature to be recorded.
 
-  std::ostringstream ossRips;
-  pcoh.output_diagram(ossRips);
+  std::ostringstream ossPers;
+  pcoh.output_diagram(ossPers);
 
-  std::string strRips = ossRips.str();
-  return strRips;
+  std::string strPers = ossPers.str();
+  return strPers;
 }
 
-void test_rips_persistence_with_coeff_field(int min_coefficient, int max_coefficient) {
+void test_persistence_with_coeff_field(int min_coefficient, int max_coefficient) {
   // there are 2 discontinued ensembles 
   std::string value0("  0 0.25 inf");
   std::string value1("  1 0.4 inf");
@@ -69,59 +69,59 @@ void test_rips_persistence_with_coeff_field(int min_coefficient, int max_coeffic
   std::string value7("  2 0.4 inf");
 
   std::clog << "********************************************************************" << std::endl;
-  std::clog << "TEST OF RIPS_PERSISTENT_COHOMOLOGY_MULTI_FIELD MIN_COEFF=" << min_coefficient << " MAX_COEFF=" << max_coefficient << " MIN_PERS=0" << std::endl;
+  std::clog << "TEST OF PERSISTENT_COHOMOLOGY_MULTI_FIELD MIN_COEFF=" << min_coefficient << " MAX_COEFF=" << max_coefficient << " MIN_PERS=0" << std::endl;
 
-  std::string str_rips_persistence = test_rips_persistence(min_coefficient, max_coefficient, 0.0);
-  std::clog << "str_rips_persistence=" << str_rips_persistence << std::endl;
+  std::string str_persistence = test_persistence(min_coefficient, max_coefficient, 0.0);
+  std::clog << "str_persistence=" << str_persistence << std::endl;
 
-  BOOST_CHECK(str_rips_persistence.find(value0) != std::string::npos); // Check found
-  BOOST_CHECK(str_rips_persistence.find(value1) != std::string::npos); // Check found
-  BOOST_CHECK(str_rips_persistence.find(value2) != std::string::npos); // Check found
+  BOOST_CHECK(str_persistence.find(value0) != std::string::npos); // Check found
+  BOOST_CHECK(str_persistence.find(value1) != std::string::npos); // Check found
+  BOOST_CHECK(str_persistence.find(value2) != std::string::npos); // Check found
 
   if ((min_coefficient < 2) && (max_coefficient < 2)) {
-    BOOST_CHECK(str_rips_persistence.find(value3) != std::string::npos); // Check found
-    BOOST_CHECK(str_rips_persistence.find(value4) != std::string::npos); // Check found
-    BOOST_CHECK(str_rips_persistence.find(value5) != std::string::npos); // Check found
-    BOOST_CHECK(str_rips_persistence.find(value6) != std::string::npos); // Check found
-    BOOST_CHECK(str_rips_persistence.find(value7) != std::string::npos); // Check found
+    BOOST_CHECK(str_persistence.find(value3) != std::string::npos); // Check found
+    BOOST_CHECK(str_persistence.find(value4) != std::string::npos); // Check found
+    BOOST_CHECK(str_persistence.find(value5) != std::string::npos); // Check found
+    BOOST_CHECK(str_persistence.find(value6) != std::string::npos); // Check found
+    BOOST_CHECK(str_persistence.find(value7) != std::string::npos); // Check found
   } else {
-    BOOST_CHECK(str_rips_persistence.find(value3) == std::string::npos); // Check not found
-    BOOST_CHECK(str_rips_persistence.find(value4) == std::string::npos); // Check not found
-    BOOST_CHECK(str_rips_persistence.find(value5) == std::string::npos); // Check not found
-    BOOST_CHECK(str_rips_persistence.find(value6) == std::string::npos); // Check not found
-    BOOST_CHECK(str_rips_persistence.find(value7) == std::string::npos); // Check not found
+    BOOST_CHECK(str_persistence.find(value3) == std::string::npos); // Check not found
+    BOOST_CHECK(str_persistence.find(value4) == std::string::npos); // Check not found
+    BOOST_CHECK(str_persistence.find(value5) == std::string::npos); // Check not found
+    BOOST_CHECK(str_persistence.find(value6) == std::string::npos); // Check not found
+    BOOST_CHECK(str_persistence.find(value7) == std::string::npos); // Check not found
   }
 
 }
 
-BOOST_AUTO_TEST_CASE(rips_persistent_cohomology_multi_field_coeff_0_0) {
-  test_rips_persistence_with_coeff_field(0, 0);
+BOOST_AUTO_TEST_CASE(persistent_cohomology_multi_field_coeff_0_0) {
+  test_persistence_with_coeff_field(0, 0);
 }
 
-BOOST_AUTO_TEST_CASE(rips_persistent_cohomology_multi_field_coeff_0_1) {
-  test_rips_persistence_with_coeff_field(0, 1);
+BOOST_AUTO_TEST_CASE(persistent_cohomology_multi_field_coeff_0_1) {
+  test_persistence_with_coeff_field(0, 1);
 }
 
-BOOST_AUTO_TEST_CASE(rips_persistent_cohomology_multi_field_coeff_0_6) {
-  test_rips_persistence_with_coeff_field(0, 6);
+BOOST_AUTO_TEST_CASE(persistent_cohomology_multi_field_coeff_0_6) {
+  test_persistence_with_coeff_field(0, 6);
 }
 
-BOOST_AUTO_TEST_CASE(rips_persistent_cohomology_multi_field_coeff_1_2) {
-  test_rips_persistence_with_coeff_field(1, 2);
+BOOST_AUTO_TEST_CASE(persistent_cohomology_multi_field_coeff_1_2) {
+  test_persistence_with_coeff_field(1, 2);
 }
 
-BOOST_AUTO_TEST_CASE(rips_persistent_cohomology_multi_field_coeff_1_3) {
-  test_rips_persistence_with_coeff_field(1, 3);
+BOOST_AUTO_TEST_CASE(persistent_cohomology_multi_field_coeff_1_3) {
+  test_persistence_with_coeff_field(1, 3);
 }
 
-BOOST_AUTO_TEST_CASE(rips_persistent_cohomology_multi_field_coeff_1_5) {
-  test_rips_persistence_with_coeff_field(1, 5);
+BOOST_AUTO_TEST_CASE(persistent_cohomology_multi_field_coeff_1_5) {
+  test_persistence_with_coeff_field(1, 5);
 }
 
-BOOST_AUTO_TEST_CASE(rips_persistent_cohomology_multi_field_coeff_2_3) {
-  test_rips_persistence_with_coeff_field(2, 3);
+BOOST_AUTO_TEST_CASE(persistent_cohomology_multi_field_coeff_2_3) {
+  test_persistence_with_coeff_field(2, 3);
 }
 
-BOOST_AUTO_TEST_CASE(rips_persistent_cohomology_multi_field_coeff_3_4) {
-  test_rips_persistence_with_coeff_field(3, 4);
+BOOST_AUTO_TEST_CASE(persistent_cohomology_multi_field_coeff_3_4) {
+  test_persistence_with_coeff_field(3, 4);
 }


### PR DESCRIPTION
Fix #515 
Avoid confusion between dimension and field of coefficients in persistent_cohomology_unit_test.cpp and persistent_cohomology_unit_test_multi_field.cpp