### PR TITLE
Meet PEP518 requirements

### DIFF
--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -41,14 +41,15 @@ function( add_gudhi_debug_info DEBUG_INFO )
 endfunction( add_gudhi_debug_info )
 
 if(PYTHONINTERP_FOUND)
-  if(PYBIND11_FOUND)
+  if(PYBIND11_FOUND AND CYTHON_FOUND)
     add_gudhi_debug_info("Pybind11 version ${PYBIND11_VERSION}")
+    # PyBind11 modules
     set(GUDHI_PYTHON_MODULES "${GUDHI_PYTHON_MODULES}'bottleneck', ")
     set(GUDHI_PYTHON_MODULES_EXTRA "${GUDHI_PYTHON_MODULES_EXTRA}'hera', ")
     set(GUDHI_PYTHON_MODULES_EXTRA "${GUDHI_PYTHON_MODULES_EXTRA}'clustering', ")
     set(GUDHI_PYTHON_MODULES_EXTRA "${GUDHI_PYTHON_MODULES_EXTRA}'datasets', ")
-  endif()
-  if(CYTHON_FOUND)
+
+    # Cython modules
     set(GUDHI_PYTHON_MODULES "${GUDHI_PYTHON_MODULES}'off_reader', ")
     set(GUDHI_PYTHON_MODULES "${GUDHI_PYTHON_MODULES}'simplex_tree', ")
     set(GUDHI_PYTHON_MODULES "${GUDHI_PYTHON_MODULES}'rips_complex', ")
@@ -299,35 +300,30 @@ if(PYTHONINTERP_FOUND)
             if(SCIPY_FOUND)
               if(SKLEARN_FOUND)
                 if(OT_FOUND)
-                  if(PYBIND11_FOUND)
-                    if(NOT CGAL_WITH_EIGEN3_VERSION VERSION_LESS 4.11.0)
-                      set (GUDHI_SPHINX_MESSAGE "Generating API documentation with Sphinx in ${CMAKE_CURRENT_BINARY_DIR}/sphinx/")
-                      # User warning - Sphinx is a static pages generator, and configured to work fine with user_version
-                      # Images and biblio warnings because not found on developper version
-                      if (GUDHI_PYTHON_PATH STREQUAL "src/python")
-                        set (GUDHI_SPHINX_MESSAGE "${GUDHI_SPHINX_MESSAGE} \n WARNING : Sphinx is configured for user version, you run it on developper version. Images and biblio will miss")
-                      endif()
-                      # sphinx target requires gudhi.so, because conf.py reads gudhi version from it
-                      add_custom_target(sphinx
-                          WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/doc
-                          COMMAND ${CMAKE_COMMAND} -E env "${GUDHI_PYTHON_PATH_ENV}"
-                          ${SPHINX_PATH} -b html ${CMAKE_CURRENT_SOURCE_DIR}/doc ${CMAKE_CURRENT_BINARY_DIR}/sphinx
-                          DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/gudhi.so"
-                          COMMENT "${GUDHI_SPHINX_MESSAGE}" VERBATIM)
-                      add_test(NAME sphinx_py_test
-                               WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-                               COMMAND ${CMAKE_COMMAND} -E env "${GUDHI_PYTHON_PATH_ENV}"
-                               ${SPHINX_PATH} -b doctest ${CMAKE_CURRENT_SOURCE_DIR}/doc ${CMAKE_CURRENT_BINARY_DIR}/doctest)
-                      # Set missing or not modules
-                      set(GUDHI_MODULES ${GUDHI_MODULES} "python-documentation" CACHE INTERNAL "GUDHI_MODULES")
-                    else(NOT CGAL_WITH_EIGEN3_VERSION VERSION_LESS 4.11.0)
-                      message("++ Python documentation module will not be compiled because it requires a Eigen3 and CGAL version >= 4.11.0")
-                      set(GUDHI_MISSING_MODULES ${GUDHI_MISSING_MODULES} "python-documentation" CACHE INTERNAL "GUDHI_MISSING_MODULES")
-                    endif(NOT CGAL_WITH_EIGEN3_VERSION VERSION_LESS 4.11.0)
-                  else(PYBIND11_FOUND)
-                    message("++ Python documentation module will not be compiled because pybind11 was not found")
+                  if(NOT CGAL_WITH_EIGEN3_VERSION VERSION_LESS 4.11.0)
+                    set (GUDHI_SPHINX_MESSAGE "Generating API documentation with Sphinx in ${CMAKE_CURRENT_BINARY_DIR}/sphinx/")
+                    # User warning - Sphinx is a static pages generator, and configured to work fine with user_version
+                    # Images and biblio warnings because not found on developper version
+                    if (GUDHI_PYTHON_PATH STREQUAL "src/python")
+                      set (GUDHI_SPHINX_MESSAGE "${GUDHI_SPHINX_MESSAGE} \n WARNING : Sphinx is configured for user version, you run it on developper version. Images and biblio will miss")
+                    endif()
+                    # sphinx target requires gudhi.so, because conf.py reads gudhi version from it
+                    add_custom_target(sphinx
+                        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/doc
+                        COMMAND ${CMAKE_COMMAND} -E env "${GUDHI_PYTHON_PATH_ENV}"
+                        ${SPHINX_PATH} -b html ${CMAKE_CURRENT_SOURCE_DIR}/doc ${CMAKE_CURRENT_BINARY_DIR}/sphinx
+                        DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/gudhi.so"
+                        COMMENT "${GUDHI_SPHINX_MESSAGE}" VERBATIM)
+                    add_test(NAME sphinx_py_test
+                             WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+                             COMMAND ${CMAKE_COMMAND} -E env "${GUDHI_PYTHON_PATH_ENV}"
+                             ${SPHINX_PATH} -b doctest ${CMAKE_CURRENT_SOURCE_DIR}/doc ${CMAKE_CURRENT_BINARY_DIR}/doctest)
+                    # Set missing or not modules
+                    set(GUDHI_MODULES ${GUDHI_MODULES} "python-documentation" CACHE INTERNAL "GUDHI_MODULES")
+                  else(NOT CGAL_WITH_EIGEN3_VERSION VERSION_LESS 4.11.0)
+                    message("++ Python documentation module will not be compiled because it requires a Eigen3 and CGAL version >= 4.11.0")
                     set(GUDHI_MISSING_MODULES ${GUDHI_MISSING_MODULES} "python-documentation" CACHE INTERNAL "GUDHI_MISSING_MODULES")
-                  endif(PYBIND11_FOUND)
+                  endif(NOT CGAL_WITH_EIGEN3_VERSION VERSION_LESS 4.11.0)
                 else(OT_FOUND)
                   message("++ Python documentation module will not be compiled because POT was not found")
                   set(GUDHI_MISSING_MODULES ${GUDHI_MISSING_MODULES} "python-documentation" CACHE INTERNAL "GUDHI_MISSING_MODULES")
@@ -403,9 +399,7 @@ if(PYTHONINTERP_FOUND)
                COMMAND ${CMAKE_COMMAND} -E env "${GUDHI_PYTHON_PATH_ENV}"
                ${PYTHON_EXECUTABLE} "${CMAKE_CURRENT_SOURCE_DIR}/example/bottleneck_basic_example.py")
 
-      if (PYBIND11_FOUND)
-        add_gudhi_py_test(test_bottleneck_distance)
-      endif()
+      add_gudhi_py_test(test_bottleneck_distance)
 
       # Cover complex
       file(COPY ${CMAKE_SOURCE_DIR}/data/points/human.off DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/)
@@ -519,14 +513,14 @@ if(PYTHONINTERP_FOUND)
     add_gudhi_py_test(test_reader_utils)
 
     # Wasserstein
-    if(OT_FOUND AND PYBIND11_FOUND)
+    if(OT_FOUND)
       # EagerPy dependency because of enable_autodiff=True
       if(EAGERPY_FOUND)
         add_gudhi_py_test(test_wasserstein_distance)
       endif()
+
       add_gudhi_py_test(test_wasserstein_barycenter)
-    endif()
-    if(OT_FOUND)
+
       if(TORCH_FOUND AND TENSORFLOW_FOUND AND EAGERPY_FOUND)
         add_gudhi_py_test(test_wasserstein_with_tensors)
       endif()
@@ -547,7 +541,7 @@ if(PYTHONINTERP_FOUND)
     endif()
 
     # Tomato
-    if(SCIPY_FOUND AND SKLEARN_FOUND AND PYBIND11_FOUND)
+    if(SCIPY_FOUND AND SKLEARN_FOUND)
       add_gudhi_py_test(test_tomato)
     endif()
 
@@ -564,10 +558,10 @@ if(PYTHONINTERP_FOUND)
 
     # Set missing or not modules
     set(GUDHI_MODULES ${GUDHI_MODULES} "python" CACHE INTERNAL "GUDHI_MODULES")
-  else(CYTHON_FOUND)
-    message("++ Python module will not be compiled because cython was not found")
+  else(PYBIND11_FOUND AND CYTHON_FOUND)
+    message("++ Python module will not be compiled because cython and/or pybind11 was/were not found")
     set(GUDHI_MISSING_MODULES ${GUDHI_MISSING_MODULES} "python" CACHE INTERNAL "GUDHI_MISSING_MODULES")
-  endif(CYTHON_FOUND)
+  endif(PYBIND11_FOUND AND CYTHON_FOUND)
 else(PYTHONINTERP_FOUND)
   message("++ Python module will not be compiled because no Python interpreter was found")
   set(GUDHI_MISSING_MODULES ${GUDHI_MISSING_MODULES} "python" CACHE INTERNAL "GUDHI_MISSING_MODULES")

--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -278,6 +278,7 @@ if(PYTHONINTERP_FOUND)
 
     # Some files for pip package
     file(COPY "introduction.rst" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}/")
+    file(COPY "pyproject.toml" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}/")
 
     add_custom_command(
         OUTPUT gudhi.so

--- a/src/python/pyproject.toml
+++ b/src/python/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "wheel", "numpy>=1.15.0", "cython", "pybind11"]
+build-backend = "setuptools.build_meta"

--- a/src/python/setup.py.in
+++ b/src/python/setup.py.in
@@ -82,6 +82,7 @@ setup(
         },
     description='The Gudhi library is an open source library for ' \
         'Computational Topology and Topological Data Analysis (TDA).',
+    data_files=[('.', ['./introduction.rst'])],
     long_description_content_type='text/x-rst',
     long_description=long_description,
     ext_modules = ext_modules,

--- a/src/python/setup.py.in
+++ b/src/python/setup.py.in
@@ -86,6 +86,5 @@ setup(
     long_description=long_description,
     ext_modules = ext_modules,
     install_requires = ['numpy >= 1.15.0',],
-    setup_requires = ['cython','numpy >= 1.15.0','pybind11',],
     package_data={"": ["*.dll"], },
 )


### PR DESCRIPTION
Fix #479 by removing setup_requires.
Even if cmake tests what is already installed, I created a pyproject.toml, where I put all mandatory packages in order to be able to build python package as explained in [setuptools documentation](https://setuptools.readthedocs.io/en/latest/build_meta.html#how-to-use-it) with `python -m build` (everything is built in a virtual env).

This allows me to reproduce and fix #416 on 3954d88b.