### PR TITLE
Fix broken links. Add a tool to generate cpp example page

### DIFF
--- a/biblio/bibliography.bib
+++ b/biblio/bibliography.bib
@@ -15,7 +15,6 @@ title = {{Statistical analysis and parameter selection for Mapper}},
 volume = {19},
 year = {2018},
 url = {http://jmlr.org/papers/v19/17-291.html},
-doi = {10.5555/3291125.3291137}
 }
 
 @inproceedings{Dey13,

--- a/scripts/cpp_examples_for_doxygen.py
+++ b/scripts/cpp_examples_for_doxygen.py
@@ -1,0 +1,16 @@
+import os
+import glob
+
+for gd_mod in glob.glob("src/*/"):
+    mod_files = []
+    for paths in [gd_mod + 'utilities', gd_mod + 'example']:
+        if os.path.isdir(paths):
+            for root, dirs, files in os.walk(paths):
+                for file in files:
+                    if file.endswith(".cpp"):
+                        mod_files.append(str(os.path.join(root, file)).split(paths)[1][1:])
+    if len(mod_files) > 0:
+        mod = str(gd_mod).split('/')[1]
+        print(' * \section ' + mod + '_example_section ' + mod)
+        for file in mod_files:
+            print(' * @example ' + file)

--- a/src/Bottleneck_distance/utilities/bottleneckdistance.md
+++ b/src/Bottleneck_distance/utilities/bottleneckdistance.md
@@ -10,14 +10,14 @@ Leave the lines above as it is required by the web site generator 'Jekyll'
 {:/comment}
 
 
-## bottleneck_read_file_example ##
+## bottleneck_distance ##
 
 This program computes the Bottleneck distance between two persistence diagram files.
 
 **Usage**
 
 ```
-   bottleneck_read_file_example <file_1.pers> <file_2.pers> [<tolerance>]
+   bottleneck_distance <file_1.pers> <file_2.pers> [<tolerance>]
 ```
 
 where

--- a/src/common/doc/examples.h
+++ b/src/common/doc/examples.h
@@ -1,98 +1,130 @@
-// List of GUDHI examples - Doxygen needs at least a file tag to analyse comments
-// In user_version, `find . -name "*.cpp"` in example and utilities folders
+// List of GUDHI examples and utils - Doxygen needs at least a file tag to analyse comments
+// Generated from scripts/cpp_examples_for_doxygen.py
 /*! @file Examples
- * \section Alpha_complex_examples Alpha complex
- * @example Alpha_complex_from_off.cpp
+ * \section Skeleton_blocker_example_section Skeleton_blocker
+ * @example Skeleton_blocker_iteration.cpp
+ * @example Skeleton_blocker_from_simplices.cpp
+ * @example Skeleton_blocker_link.cpp
+ * \section Alpha_complex_example_section Alpha_complex
+ * @example alpha_complex_persistence.cpp
+ * @example alpha_complex_3d_persistence.cpp
  * @example Alpha_complex_from_points.cpp
- * \section bottleneck_examples bottleneck
- * @example bottleneck_basic_example.cpp
- * @example alpha_rips_persistence_bottleneck_distance.cpp
- * @example example_nearest_landmark_table.cpp
- * @example example_witness_complex_off.cpp
- * @example example_witness_complex_sphere.cpp
- * @example example_strong_witness_complex_off.cpp
+ * @example Alpha_complex_3d_from_points.cpp
+ * @example Weighted_alpha_complex_3d_from_points.cpp
+ * @example Fast_alpha_complex_from_off.cpp
+ * @example Alpha_complex_from_off.cpp
+ * @example Weighted_alpha_complex_from_points.cpp
+ * \section Simplex_tree_example_section Simplex_tree
+ * @example cech_complex_cgal_mini_sphere_3d.cpp
  * @example mini_simplex_tree.cpp
+ * @example example_alpha_shapes_3_simplex_tree_from_off_file.cpp
  * @example graph_expansion_with_blocker.cpp
  * @example simple_simplex_tree.cpp
  * @example simplex_tree_from_cliques_of_graph.cpp
- * @example example_alpha_shapes_3_simplex_tree_from_off_file.cpp
- * @example cech_complex_cgal_mini_sphere_3d.cpp
- * @example plain_homology.cpp
- * @example persistence_from_file.cpp
- * @example rips_persistence_step_by_step.cpp
+ * \section Collapse_example_section Collapse
+ * @example point_cloud_edge_collapse_rips_persistence.cpp
+ * @example distance_matrix_edge_collapse_rips_persistence.cpp
+ * @example edge_collapse_basic_example.cpp
+ * @example edge_collapse_conserve_persistence.cpp
+ * \section Persistent_cohomology_example_section Persistent_cohomology
  * @example rips_persistence_via_boundary_matrix.cpp
+ * @example rips_persistence_step_by_step.cpp
+ * @example plain_homology.cpp
  * @example custom_persistence_sort.cpp
  * @example persistence_from_simple_simplex_tree.cpp
+ * @example persistence_from_file.cpp
  * @example rips_multifield_persistence.cpp
- * @example Skeleton_blocker_from_simplices.cpp
- * @example Skeleton_blocker_iteration.cpp
- * @example Skeleton_blocker_link.cpp
- * @example Garland_heckbert.cpp
- * @example Rips_contraction.cpp
- * @example Random_bitmap_cubical_complex.cpp
- * @example example_CGAL_3D_points_off_reader.cpp
- * @example example_vector_double_points_off_reader.cpp
- * @example example_CGAL_points_off_reader.cpp
- * @example example_one_skeleton_rips_from_distance_matrix.cpp
- * @example example_one_skeleton_rips_from_points.cpp
- * @example example_rips_complex_from_csv_distance_matrix_file.cpp
- * @example example_rips_complex_from_off_file.cpp
- * @example persistence_intervals.cpp
- * @example persistence_vectors.cpp
- * @example persistence_heat_maps.cpp
- * @example persistence_landscape_on_grid.cpp
- * @example persistence_landscape.cpp
- * @example example_basic.cpp
- * @example example_with_perturb.cpp
- * @example example_custom_distance.cpp
- * @example example_choose_n_farthest_points.cpp
- * @example example_sparsify_point_set.cpp
- * @example example_pick_n_random_points.cpp
- * @example CoordGIC.cpp
+ * \section Nerve_GIC_example_section Nerve_GIC
+ * @example VoronoiGIC.cpp
  * @example Nerve.cpp
  * @example FuncGIC.cpp
- * @example VoronoiGIC.cpp
- * @example example_spatial_searching.cpp
- * @example alpha_complex_3d_persistence.cpp
- * @example alpha_complex_persistence.cpp
- * @example Weighted_alpha_complex_3d_from_points.cpp
- * @example bottleneck_distance.cpp
- * @example weak_witness_persistence.cpp
- * @example strong_witness_persistence.cpp
- * @example cubical_complex_persistence.cpp
- * @example periodic_cubical_complex_persistence.cpp
- * @example off_file_from_shape_generator.cpp
- * @example rips_distance_matrix_persistence.cpp
+ * @example CoordGIC.cpp
+ * \section Rips_complex_example_section Rips_complex
  * @example rips_persistence.cpp
+ * @example sparse_rips_persistence.cpp
+ * @example rips_correlation_matrix_persistence.cpp
+ * @example rips_distance_matrix_persistence.cpp
+ * @example example_one_skeleton_rips_from_correlation_matrix.cpp
+ * @example example_rips_complex_from_csv_distance_matrix_file.cpp
+ * @example example_sparse_rips.cpp
+ * @example example_one_skeleton_rips_from_distance_matrix.cpp
+ * @example example_rips_complex_from_off_file.cpp
+ * @example example_one_skeleton_rips_from_points.cpp
+ * \section Persistence_representations_example_section Persistence_representations
+ * @example persistence_landscapes_on_grid/average_landscapes_on_grid.cpp
  * @example persistence_landscapes_on_grid/create_landscapes_on_grid.cpp
+ * @example persistence_landscapes_on_grid/compute_distance_of_landscapes_on_grid.cpp
  * @example persistence_landscapes_on_grid/plot_landscapes_on_grid.cpp
  * @example persistence_landscapes_on_grid/compute_scalar_product_of_landscapes_on_grid.cpp
- * @example persistence_landscapes_on_grid/compute_distance_of_landscapes_on_grid.cpp
- * @example persistence_landscapes_on_grid/average_landscapes_on_grid.cpp
  * @example persistence_intervals/compute_birth_death_range_in_persistence_diagram.cpp
- * @example persistence_intervals/compute_number_of_dominant_intervals.cpp
- * @example persistence_intervals/plot_persistence_Betti_numbers.cpp
  * @example persistence_intervals/plot_persistence_intervals.cpp
  * @example persistence_intervals/plot_histogram_of_intervals_lengths.cpp
  * @example persistence_intervals/compute_bottleneck_distance.cpp
- * @example persistence_heat_maps/create_pssk.cpp
- * @example persistence_heat_maps/create_p_h_m_weighted_by_arctan_of_their_persistence.cpp
- * @example persistence_heat_maps/create_p_h_m_weighted_by_squared_diag_distance.cpp
- * @example persistence_heat_maps/compute_distance_of_persistence_heat_maps.cpp
- * @example persistence_heat_maps/compute_scalar_product_of_persistence_heat_maps.cpp
- * @example persistence_heat_maps/create_p_h_m_weighted_by_distance_from_diagonal.cpp
+ * @example persistence_intervals/plot_persistence_Betti_numbers.cpp
+ * @example persistence_intervals/compute_number_of_dominant_intervals.cpp
  * @example persistence_heat_maps/average_persistence_heat_maps.cpp
+ * @example persistence_heat_maps/create_p_h_m_weighted_by_squared_diag_distance.cpp
+ * @example persistence_heat_maps/create_pssk.cpp
+ * @example persistence_heat_maps/create_p_h_m_weighted_by_distance_from_diagonal.cpp
+ * @example persistence_heat_maps/compute_distance_of_persistence_heat_maps.cpp
+ * @example persistence_heat_maps/create_p_h_m_weighted_by_arctan_of_their_persistence.cpp
  * @example persistence_heat_maps/plot_persistence_heat_map.cpp
+ * @example persistence_heat_maps/compute_scalar_product_of_persistence_heat_maps.cpp
  * @example persistence_heat_maps/create_persistence_heat_maps.cpp
- * @example persistence_vectors/plot_persistence_vectors.cpp
- * @example persistence_vectors/compute_distance_of_persistence_vectors.cpp
  * @example persistence_vectors/average_persistence_vectors.cpp
+ * @example persistence_vectors/plot_persistence_vectors.cpp
  * @example persistence_vectors/create_persistence_vectors.cpp
  * @example persistence_vectors/compute_scalar_product_of_persistence_vectors.cpp
- * @example persistence_landscapes/average_landscapes.cpp
- * @example persistence_landscapes/compute_scalar_product_of_landscapes.cpp
+ * @example persistence_vectors/compute_distance_of_persistence_vectors.cpp
  * @example persistence_landscapes/create_landscapes.cpp
+ * @example persistence_landscapes/average_landscapes.cpp
  * @example persistence_landscapes/compute_distance_of_landscapes.cpp
  * @example persistence_landscapes/plot_landscapes.cpp
+ * @example persistence_landscapes/compute_scalar_product_of_landscapes.cpp
+ * @example persistence_heat_maps.cpp
+ * @example sliced_wasserstein.cpp
+ * @example persistence_intervals.cpp
+ * @example persistence_vectors.cpp
+ * @example persistence_landscape.cpp
+ * @example persistence_landscape_on_grid.cpp
+ * \section common_example_section common
+ * @example off_file_from_shape_generator.cpp
+ * @example example_CGAL_points_off_reader.cpp
+ * @example example_vector_double_points_off_reader.cpp
+ * @example example_CGAL_3D_points_off_reader.cpp
+ * \section Subsampling_example_section Subsampling
+ * @example example_pick_n_random_points.cpp
+ * @example example_choose_n_farthest_points.cpp
+ * @example example_sparsify_point_set.cpp
+ * @example example_custom_distance.cpp
+ * \section Contraction_example_section Contraction
+ * @example Rips_contraction.cpp
+ * @example Garland_heckbert.cpp
+ * \section Bottleneck_distance_example_section Bottleneck_distance
+ * @example bottleneck_distance.cpp
+ * @example bottleneck_basic_example.cpp
+ * @example alpha_rips_persistence_bottleneck_distance.cpp
+ * \section Tangential_complex_example_section Tangential_complex
+ * @example example_basic.cpp
+ * @example example_with_perturb.cpp
+ * \section Cech_complex_example_section Cech_complex
+ * @example cech_persistence.cpp
+ * @example cech_complex_example_from_points.cpp
+ * @example cech_complex_step_by_step.cpp
+ * \section Spatial_searching_example_section Spatial_searching
+ * @example example_spatial_searching.cpp
+ * \section Bitmap_cubical_complex_example_section Bitmap_cubical_complex
+ * @example periodic_cubical_complex_persistence.cpp
+ * @example cubical_complex_persistence.cpp
+ * @example Random_bitmap_cubical_complex.cpp
+ * \section Toplex_map_example_section Toplex_map
+ * @example simple_toplex_map.cpp
+ * \section Witness_complex_example_section Witness_complex
+ * @example weak_witness_persistence.cpp
+ * @example strong_witness_persistence.cpp
+ * @example example_witness_complex_sphere.cpp
+ * @example example_strong_witness_complex_off.cpp
+ * @example example_nearest_landmark_table.cpp
+ * @example example_witness_complex_off.cpp
  */
  

--- a/src/common/doc/installation.h
+++ b/src/common/doc/installation.h
@@ -88,9 +88,9 @@ make \endverbatim
  * Witness_complex/example_witness_complex_off.cpp</a>
  * \li <a href="example_witness_complex_sphere_8cpp-example.html">
  * Witness_complex/example_witness_complex_sphere.cpp</a>
- * \li <a href="alpha_complex_from_off_8cpp-example.html">
+ * \li <a href="_alpha_complex_from_off_8cpp-example.html">
  * Alpha_complex/Alpha_complex_from_off.cpp</a>
- * \li <a href="alpha_complex_from_points_8cpp-example.html">
+ * \li <a href="_alpha_complex_from_points_8cpp-example.html">
  * Alpha_complex/Alpha_complex_from_points.cpp</a>
  * \li <a href="alpha_complex_persistence_8cpp-example.html">
  * Alpha_complex/alpha_complex_persistence.cpp</a>
@@ -100,15 +100,15 @@ make \endverbatim
  * Bottleneck_distance/alpha_rips_persistence_bottleneck_distance.cpp.cpp</a>
  * \li <a href="bottleneck_basic_example_8cpp-example.html">
  * Bottleneck_distance/bottleneck_basic_example.cpp</a>
- * \li <a href="bottleneck_read_file_8cpp-example.html">
+ * \li <a href="bottleneck_distance_8cpp-example.html">
  * Bottleneck_distance/bottleneck_distance.cpp</a>
- * \li <a href="coord_g_i_c_8cpp-example.html">
+ * \li <a href="_coord_g_i_c_8cpp-example.html">
  * Nerve_GIC/CoordGIC.cpp</a>
- * \li <a href="func_g_i_c_8cpp-example.html">
+ * \li <a href="_func_g_i_c_8cpp-example.html">
  * Nerve_GIC/FuncGIC.cpp</a>
- * \li <a href="nerve_8cpp-example.html">
+ * \li <a href="_nerve_8cpp-example.html">
  * Nerve_GIC/Nerve.cpp</a>
- * \li <a href="voronoi_g_i_c_8cpp-example.html">
+ * \li <a href="_voronoi_g_i_c_8cpp-example.html">
  * Nerve_GIC/VoronoiGIC.cpp</a>
  * \li <a href="example_spatial_searching_8cpp-example.html">
  * Spatial_searching/example_spatial_searching.cpp</a>
@@ -122,7 +122,7 @@ make \endverbatim
  * Tangential_complex/example_basic.cpp</a>
  * \li <a href="example_with_perturb_8cpp-example.html">
  * Tangential_complex/example_with_perturb.cpp</a>
- * \li <a href="weighted_alpha_complex_3d_from_points_8cpp-example.html">
+ * \li <a href="_weighted_alpha_complex_3d_from_points_8cpp-example.html">
  * Alpha_complex/Weighted_alpha_complex_3d_from_points.cpp</a>
  * \li <a href="alpha_complex_3d_persistence_8cpp-example.html">
  * Alpha_complex/alpha_complex_3d_persistence.cpp</a>
@@ -134,15 +134,15 @@ make \endverbatim
  * 
  * The following examples/utilities require the <a target="_blank" href="http://eigen.tuxfamily.org/">Eigen</a> and will not be
  * built if Eigen is not installed:
- * \li <a href="alpha_complex_from_off_8cpp-example.html">
+ * \li <a href="_alpha_complex_from_off_8cpp-example.html">
  * Alpha_complex/Alpha_complex_from_off.cpp</a>
- * \li <a href="alpha_complex_from_points_8cpp-example.html">
+ * \li <a href="_alpha_complex_from_points_8cpp-example.html">
  * Alpha_complex/Alpha_complex_from_points.cpp</a>
  * \li <a href="alpha_complex_persistence_8cpp-example.html">
  * Alpha_complex/alpha_complex_persistence.cpp</a>
  * \li <a href="alpha_complex_3d_persistence_8cpp-example.html">
  * Alpha_complex/alpha_complex_3d_persistence.cpp</a>
- * \li <a href="weighted_alpha_complex_3d_from_points_8cpp-example.html">
+ * \li <a href="_weighted_alpha_complex_3d_from_points_8cpp-example.html">
  * Alpha_complex/Weighted_alpha_complex_3d_from_points.cpp</a>
  * \li <a href="alpha_rips_persistence_bottleneck_distance_8cpp-example.html">
  * Bottleneck_distance/alpha_rips_persistence_bottleneck_distance.cpp.cpp</a>
@@ -179,27 +179,27 @@ make \endverbatim
  * Having Intel&reg; TBB installed is recommended to parallelize and accelerate some GUDHI computations.
  * 
  * The following examples/utilities are using Intel&reg; TBB if installed:
- * \li <a href="alpha_complex_from_off_8cpp-example.html">
+ * \li <a href="_alpha_complex_from_off_8cpp-example.html">
  * Alpha_complex/Alpha_complex_from_off.cpp</a>
- * \li <a href="alpha_complex_from_points_8cpp-example.html">
+ * \li <a href="_alpha_complex_from_points_8cpp-example.html">
  * Alpha_complex/Alpha_complex_from_points.cpp</a>
  * \li <a href="alpha_complex_3d_persistence_8cpp-example.html">
  * Alpha_complex/alpha_complex_3d_persistence.cpp</a>
  * \li <a href="alpha_complex_persistence_8cpp-example.html">
  * Alpha_complex/alpha_complex_persistence.cpp</a>
- * \li <a href="bitmap_cubical_complex_8cpp-example.html">
+ * \li <a href="cubical_complex_persistence_8cpp-example.html">
  * Bitmap_cubical_complex/cubical_complex_persistence.cpp</a>
- * \li <a href="bitmap_cubical_complex_periodic_boundary_conditions_8cpp-example.html">
+ * \li <a href="periodic_cubical_complex_persistence_8cpp-example.html">
  * Bitmap_cubical_complex/periodic_cubical_complex_persistence.cpp</a>
- * \li <a href="random_bitmap_cubical_complex_8cpp-example.html">
+ * \li <a href="_random_bitmap_cubical_complex_8cpp-example.html">
  * Bitmap_cubical_complex/Random_bitmap_cubical_complex.cpp</a>
- * \li <a href="coord_g_i_c_8cpp-example.html">
+ * \li <a href="_coord_g_i_c_8cpp-example.html">
  * Nerve_GIC/CoordGIC.cpp</a>
- * \li <a href="func_g_i_c_8cpp-example.html">
+ * \li <a href="_func_g_i_c_8cpp-example.html">
  * Nerve_GIC/FuncGIC.cpp</a>
- * \li <a href="nerve_8cpp-example.html">
+ * \li <a href="_nerve_8cpp-example.html">
  * Nerve_GIC/Nerve.cpp</a>
- * \li <a href="voronoi_g_i_c_8cpp-example.html">
+ * \li <a href="_voronoi_g_i_c_8cpp-example.html">
  * Nerve_GIC/VoronoiGIC.cpp</a>
  * \li <a href="simple_simplex_tree_8cpp-example.html">
  * Simplex_tree/simple_simplex_tree.cpp</a>

--- a/src/python/doc/installation.rst
+++ b/src/python/doc/installation.rst
@@ -359,7 +359,7 @@ Python Optimal Transport
 ------------------------
 
 The :doc:`Wasserstein distance </wasserstein_distance_user>`
-module requires `POT <https://pot.readthedocs.io/>`_, a library that provides
+module requires `POT <https://pythonot.github.io/>`_, a library that provides
 several solvers for optimization problems related to Optimal Transport.
 
 PyTorch


### PR DESCRIPTION
Doxygen example links go from `my_example_8cpp-example.html` to `_my_example_8cpp-example.html` when file is named `My_example.cpp`.