### PR TITLE
Remove default argument of read_points_from_off_file

### DIFF
--- a/src/python/gudhi/off_reader.pyx
+++ b/src/python/gudhi/off_reader.pyx
@@ -23,7 +23,7 @@ __license__ = "MIT"
 cdef extern from "Off_reader_interface.h" namespace "Gudhi":
     vector[vector[double]] read_points_from_OFF_file(string off_file)
 
-def read_points_from_off_file(off_file=''):
+def read_points_from_off_file(off_file):
     """Read points from OFF file.
 
     :param off_file: An OFF file style name.


### PR DESCRIPTION
Was there a reason to have a default argument here?