### PR TITLE
pip package for python 3.10

### DIFF
--- a/.github/workflows/pip-build-linux.yml
+++ b/.github/workflows/pip-build-linux.yml
@@ -23,4 +23,5 @@ jobs:
       - name: Install and test wheel for Python 3.10
         run: |
           $PYTHON310/bin/python -m pip install --user pytest build_310/src/python/dist/*.whl
+          $PYTHON310/bin/python -c "import gudhi; print(gudhi.__version__)"
           $PYTHON310/bin/python -m pytest src/python/test/test_alpha_complex.py

--- a/.github/workflows/pip-build-linux.yml
+++ b/.github/workflows/pip-build-linux.yml
@@ -12,15 +12,15 @@ jobs:
       - uses: actions/checkout@v1
         with:
           submodules: true
-      - name: Build wheel for Python 3.9
+      - name: Build wheel for Python 3.10
         run: |
-          mkdir build_39
-          cd build_39
-          cmake -DCMAKE_BUILD_TYPE=Release -DPYTHON_EXECUTABLE=$PYTHON39/bin/python ..
+          mkdir build_310
+          cd build_310
+          cmake -DCMAKE_BUILD_TYPE=Release -DPYTHON_EXECUTABLE=$PYTHON310/bin/python ..
           cd src/python
-          $PYTHON39/bin/python setup.py bdist_wheel
+          $PYTHON310/bin/python setup.py bdist_wheel
           auditwheel repair dist/*.whl
-      - name: Install and test wheel for Python 3.9
+      - name: Install and test wheel for Python 3.10
         run: |
-          $PYTHON39/bin/python -m pip install --user pytest build_39/src/python/dist/*.whl
-          $PYTHON39/bin/python -m pytest src/python/test/test_alpha_complex.py
+          $PYTHON310/bin/python -m pip install --user pytest build_310/src/python/dist/*.whl
+          $PYTHON310/bin/python -m pytest src/python/test/test_alpha_complex.py

--- a/.github/workflows/pip-build-osx.yml
+++ b/.github/workflows/pip-build-osx.yml
@@ -35,4 +35,5 @@ jobs:
       - name: Install and test python wheel
         run: |
           python -m pip install --user pytest build/src/python/dist/*.whl
+          python -c "import gudhi; print(gudhi.__version__)"
           python -m pytest src/python/test/test_alpha_complex.py

--- a/.github/workflows/pip-build-osx.yml
+++ b/.github/workflows/pip-build-osx.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ['3.9']
+        python-version: ['3.10']
     name: Build wheels for Python ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/pip-build-windows.yml
+++ b/.github/workflows/pip-build-windows.yml
@@ -26,7 +26,7 @@ jobs:
           ls "C:\vcpkg\installed\x64-windows\bin\"
           python -m pip install --user -r .\ext\gudhi-deploy\build-requirements.txt
           python -m pip list
-      - name: Build python wheel
+      - name: Build python wheel and install it
         run: |
           mkdir build
           cd ".\build\"
@@ -38,13 +38,10 @@ jobs:
           cp "C:\vcpkg\installed\x64-windows\bin\gmp.dll" ".\gudhi\"
           python setup.py bdist_wheel
           ls dist
-      - name: Install and test python wheel
-        run: |
-          Get-Location
-          dir
           cd ".\dist\"
           Get-ChildItem *.whl | ForEach-Object{python -m pip install --user $_.Name}
-          cd ..
+      - name: Test python wheel
+        run: |
           Get-Location
           dir
           python -m pip install --user pytest

--- a/.github/workflows/pip-build-windows.yml
+++ b/.github/workflows/pip-build-windows.yml
@@ -30,7 +30,7 @@ jobs:
         run: |
           mkdir build
           cd ".\build\"
-          cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=c:\Tools\vcpkg\scripts\buildsystems\vcpkg.cmake -DVCPKG_TARGET_TRIPLET=x64-windows ..
+          cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=c:\vcpkg\scripts\buildsystems\vcpkg.cmake -DVCPKG_TARGET_TRIPLET=x64-windows ..
           Get-Location
           dir
           cd ".\src\python\"

--- a/.github/workflows/pip-build-windows.yml
+++ b/.github/workflows/pip-build-windows.yml
@@ -23,31 +23,29 @@ jobs:
           set VCPKG_BUILD_TYPE=release
           vcpkg install eigen3 cgal --triplet x64-windows
           vcpkg version
-          ls C:/vcpkg/installed/x64-windows/bin
-          cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=c:/vcpkg/scripts/buildsystems/vcpkg.cmake -DVCPKG_TARGET_TRIPLET=x64-windows .
-          cd ${{ github.workspace }}
-          python -m pip install --user -r ext/gudhi-deploy/build-requirements.txt
+          ls "C:\vcpkg\installed\x64-windows\bin\"
+          python -m pip install --user -r .\ext\gudhi-deploy\build-requirements.txt
           python -m pip list
       - name: Build python wheel
         run: |
           mkdir build
-          cd build
-          cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=c:/vcpkg/scripts/buildsystems/vcpkg.cmake -DVCPKG_TARGET_TRIPLET=x64-windows ..
-          echo %CD%
+          cd ".\build\"
+          cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=c:\Tools\vcpkg\scripts\buildsystems\vcpkg.cmake -DVCPKG_TARGET_TRIPLET=x64-windows ..
+          Get-Location
           dir
-          cd src\python
-          cp c:/vcpkg/installed/x64-windows/bin/mpfr-6.dll gudhi/
-          cp c:/vcpkg/installed/x64-windows/bin/gmp.dll gudhi/
+          cd ".\src\python\"
+          cp "C:\vcpkg\installed\x64-windows\bin\mpfr-6.dll" ".\gudhi\"
+          cp "C:\vcpkg\installed\x64-windows\bin\gmp.dll" ".\gudhi\"
           python setup.py bdist_wheel
           ls dist
       - name: Install and test python wheel
         run: |
-          echo %CD%
+          Get-Location
           dir
-          cd dist
+          cd ".\dist\"
           Get-ChildItem *.whl | ForEach-Object{python -m pip install --user $_.Name}
           cd ..
-          echo %CD%
+          Get-Location
           dir
           python -m pip install --user pytest
-          python -m pytest src/python/test/test_alpha_complex.py
+          python -m pytest ".\src\python\test\test_alpha_complex.py"

--- a/.github/workflows/pip-build-windows.yml
+++ b/.github/workflows/pip-build-windows.yml
@@ -33,16 +33,21 @@ jobs:
           mkdir build
           cd build
           cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=c:/vcpkg/scripts/buildsystems/vcpkg.cmake -DVCPKG_TARGET_TRIPLET=x64-windows ..
-          cd src/python
+          echo %CD%
+          dir
+          cd src\python
           cp c:/vcpkg/installed/x64-windows/bin/mpfr-6.dll gudhi/
           cp c:/vcpkg/installed/x64-windows/bin/gmp.dll gudhi/
           python setup.py bdist_wheel
           ls dist
       - name: Install and test python wheel
         run: |
-          cd ${{ github.workspace }}
-          cd build/src/python/dist/
+          echo %CD%
+          dir
+          cd dist
           Get-ChildItem *.whl | ForEach-Object{python -m pip install --user $_.Name}
-          cd ${{ github.workspace }}
+          cd ..
+          echo %CD%
+          dir
           python -m pip install --user pytest
           python -m pytest src/python/test/test_alpha_complex.py

--- a/.github/workflows/pip-build-windows.yml
+++ b/.github/workflows/pip-build-windows.yml
@@ -45,4 +45,5 @@ jobs:
           Get-Location
           dir
           python -m pip install --user pytest
+          python -c "import gudhi; print(gudhi.__version__)"
           python -m pytest ".\src\python\test\test_alpha_complex.py"

--- a/.github/workflows/pip-build-windows.yml
+++ b/.github/workflows/pip-build-windows.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ['3.9']
+        python-version: ['3.10']
     name: Build wheels for Python ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@v1
@@ -20,18 +20,11 @@ jobs:
           architecture: x64
       - name: Install dependencies
         run: |
-          cd c:/vcpkg
-          git fetch --all --tags
-          git checkout 2020.11-1
-          bootstrap-vcpkg.bat
           set VCPKG_BUILD_TYPE=release
-          vcpkg install eigen3 mpfr boost-accumulators boost-algorithm boost-bimap boost-callable-traits boost-concept-check boost-container boost-core boost-detail boost-filesystem boost-functional boost-fusion boost-geometry boost-graph boost-heap boost-intrusive boost-iostreams boost-iterator boost-lambda boost-logic boost-math boost-mpl boost-multi-index boost-multiprecision boost-numeric-conversion boost-optional boost-parameter boost-pool boost-preprocessor boost-property-map boost-property-tree boost-ptr-container boost-random boost-range boost-serialization boost-spirit boost-thread boost-tuple boost-type-traits boost-units boost-utility boost-variant --triplet x64-windows
+          vcpkg install eigen3 cgal --triplet x64-windows
           vcpkg version
           ls C:/vcpkg/installed/x64-windows/bin
-          Invoke-WebRequest https://github.com/CGAL/cgal/releases/download/v5.2.1/CGAL-5.2.1.zip -OutFile CGAL-5.2.1.zip
-          Expand-Archive -Path CGAL-5.2.1.zip -DestinationPath .
-          cd CGAL-5.2.1
-          cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=c:/vcpkg/scripts/buildsystems/vcpkg.cmake -DVCPKG_TARGET_TRIPLET=x64-windows -DGMP_INCLUDE_DIR=c:/vcpkg/installed/x64-windows/include -DGMP_LIBRARIES=c:/vcpkg/installed/x64-windows/bin/mpir.dll .
+          cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=c:/vcpkg/scripts/buildsystems/vcpkg.cmake -DVCPKG_TARGET_TRIPLET=x64-windows .
           cd ${{ github.workspace }}
           python -m pip install --user -r ext/gudhi-deploy/build-requirements.txt
           python -m pip list
@@ -39,10 +32,10 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake -DCGAL_DIR=c:/vcpkg/CGAL-5.2.1 -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=c:/vcpkg/scripts/buildsystems/vcpkg.cmake -DVCPKG_TARGET_TRIPLET=x64-windows -DGMP_INCLUDE_DIR=c:/vcpkg/installed/x64-windows/include -DGMP_LIBRARIES=c:/vcpkg/installed/x64-windows/bin/mpir.dll ..
+          cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=c:/vcpkg/scripts/buildsystems/vcpkg.cmake -DVCPKG_TARGET_TRIPLET=x64-windows ..
           cd src/python
-          cp c:/vcpkg/installed/x64-windows/bin/mpfr.dll gudhi/
-          cp c:/vcpkg/installed/x64-windows/bin/mpir.dll gudhi/
+          cp c:/vcpkg/installed/x64-windows/bin/mpfr-6.dll gudhi/
+          cp c:/vcpkg/installed/x64-windows/bin/gmp.dll gudhi/
           python setup.py bdist_wheel
           ls dist
       - name: Install and test python wheel

--- a/.github/workflows/pip-packaging-linux.yml
+++ b/.github/workflows/pip-packaging-linux.yml
@@ -25,6 +25,7 @@ jobs:
       - name: Install and test wheel for Python 3.6
         run: |
           $PYTHON36/bin/python -m pip install --user pytest build_36/src/python/dist/*.whl
+          $PYTHON36/bin/python -c "import gudhi; print(gudhi.__version__)"
           $PYTHON36/bin/python -m pytest src/python/test/test_alpha_complex.py
       - name: Build wheel for Python 3.7
         run: |
@@ -37,6 +38,7 @@ jobs:
       - name: Install and test wheel for Python 3.7
         run: |
           $PYTHON37/bin/python -m pip install --user pytest build_37/src/python/dist/*.whl
+          $PYTHON37/bin/python -c "import gudhi; print(gudhi.__version__)"
           $PYTHON37/bin/python -m pytest src/python/test/test_alpha_complex.py
       - name: Build wheel for Python 3.8
         run: |
@@ -49,6 +51,7 @@ jobs:
       - name: Install and test wheel for Python 3.8
         run: |
           $PYTHON38/bin/python -m pip install --user pytest build_38/src/python/dist/*.whl
+          $PYTHON38/bin/python -c "import gudhi; print(gudhi.__version__)"
           $PYTHON38/bin/python -m pytest src/python/test/test_alpha_complex.py
       - name: Build wheel for Python 3.9
         run: |
@@ -61,6 +64,7 @@ jobs:
       - name: Install and test wheel for Python 3.9
         run: |
           $PYTHON39/bin/python -m pip install --user pytest build_39/src/python/dist/*.whl
+          $PYTHON39/bin/python -c "import gudhi; print(gudhi.__version__)"
           $PYTHON39/bin/python -m pytest src/python/test/test_alpha_complex.py
       - name: Build wheel for Python 3.10
         run: |
@@ -73,6 +77,7 @@ jobs:
       - name: Install and test wheel for Python 3.10
         run: |
           $PYTHON310/bin/python -m pip install --user pytest build_310/src/python/dist/*.whl
+          $PYTHON310/bin/python -c "import gudhi; print(gudhi.__version__)"
           $PYTHON310/bin/python -m pytest src/python/test/test_alpha_complex.py
       - name: Publish on PyPi
         env:

--- a/.github/workflows/pip-packaging-osx.yml
+++ b/.github/workflows/pip-packaging-osx.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ['3.5', '3.6', '3.7', '3.8', '3.9']
+        python-version: ['3.5', '3.6', '3.7', '3.8', '3.9', '3.10']
     name: Build wheels for Python ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@v1
@@ -37,6 +37,7 @@ jobs:
       - name: Install and test python wheel
         run: |
           python -m pip install --user pytest build/src/python/dist/*.whl
+          python -c "import gudhi; print(gudhi.__version__)"
           python -m pytest src/python/test/test_alpha_complex.py
       - name: Publish on PyPi
         env:

--- a/.github/workflows/pip-packaging-windows.yml
+++ b/.github/workflows/pip-packaging-windows.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ['3.5', '3.6', '3.7', '3.8', '3.9']
+        python-version: ['3.5', '3.6', '3.7', '3.8', '3.9', '3.10']
     name: Build wheels for Python ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@v1
@@ -22,40 +22,32 @@ jobs:
           architecture: x64
       - name: Install dependencies
         run: |
-          cd c:/vcpkg
-          git fetch --all --tags
-          git checkout 2020.11-1
-          bootstrap-vcpkg.bat
           set VCPKG_BUILD_TYPE=release
-          vcpkg install eigen3 mpfr boost-accumulators boost-algorithm boost-bimap boost-callable-traits boost-concept-check boost-container boost-core boost-detail boost-filesystem boost-functional boost-fusion boost-geometry boost-graph boost-heap boost-intrusive boost-iostreams boost-iterator boost-lambda boost-logic boost-math boost-mpl boost-multi-index boost-multiprecision boost-numeric-conversion boost-optional boost-parameter boost-pool boost-preprocessor boost-property-map boost-property-tree boost-ptr-container boost-random boost-range boost-serialization boost-spirit boost-thread boost-tuple boost-type-traits boost-units boost-utility boost-variant --triplet x64-windows
+          vcpkg install eigen3 cgal --triplet x64-windows
           vcpkg version
-          ls C:/vcpkg/installed/x64-windows/bin
-          Invoke-WebRequest https://github.com/CGAL/cgal/releases/download/v5.2.1/CGAL-5.2.1.zip -OutFile CGAL-5.2.1.zip
-          Expand-Archive -Path CGAL-5.2.1.zip -DestinationPath .
-          cd CGAL-5.2.1
-          cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=c:/vcpkg/scripts/buildsystems/vcpkg.cmake -DVCPKG_TARGET_TRIPLET=x64-windows -DGMP_INCLUDE_DIR=c:/vcpkg/installed/x64-windows/include -DGMP_LIBRARIES=c:/vcpkg/installed/x64-windows/bin/mpir.dll .
-          cd ${{ github.workspace }}
-          python -m pip install --user -r ext/gudhi-deploy/build-requirements.txt
+          ls "C:\vcpkg\installed\x64-windows\bin\"
+          python -m pip install --user -r .\ext\gudhi-deploy\build-requirements.txt
           python -m pip install --user twine
           python -m pip list
-      - name: Build python wheel
+      - name: Build python wheel and install it
         run: |
           mkdir build
-          cd build
-          cmake -DCGAL_DIR=c:/vcpkg/CGAL-5.2.1 -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=c:/vcpkg/scripts/buildsystems/vcpkg.cmake -DVCPKG_TARGET_TRIPLET=x64-windows -DGMP_INCLUDE_DIR=c:/vcpkg/installed/x64-windows/include -DGMP_LIBRARIES=c:/vcpkg/installed/x64-windows/bin/mpir.dll ..
-          cd src/python
-          cp c:/vcpkg/installed/x64-windows/bin/mpfr.dll gudhi/
-          cp c:/vcpkg/installed/x64-windows/bin/mpir.dll gudhi/
+          cd ".\build\"
+          cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=c:\vcpkg\scripts\buildsystems\vcpkg.cmake -DVCPKG_TARGET_TRIPLET=x64-windows ..
+          Get-Location
+          dir
+          cd ".\src\python\"
+          cp "C:\vcpkg\installed\x64-windows\bin\mpfr-6.dll" ".\gudhi\"
+          cp "C:\vcpkg\installed\x64-windows\bin\gmp.dll" ".\gudhi\"
           python setup.py bdist_wheel
           ls dist
-      - name: Install and test python wheel
-        run: |
-          cd ${{ github.workspace }}
-          cd build/src/python/dist/
+          cd ".\dist\"
           Get-ChildItem *.whl | ForEach-Object{python -m pip install --user $_.Name}
-          cd ${{ github.workspace }}
+      - name: Test python wheel
+        run: |
           python -m pip install --user pytest
-          python -m pytest src/python/test/test_alpha_complex.py
+          python -c "import gudhi; print(gudhi.__version__)"
+          python -m pytest ".\src\python\test\test_alpha_complex.py"
       - name: Publish on PyPi
         env:
           TWINE_USERNAME: __token__


### PR DESCRIPTION
Fix #550 with a pip package for python 3.10
* python 3.10 to test build pip
* update vcpkg cgal installation
* use cgal 5.3 to build linux pip package in [docker build](https://github.com/GUDHI/gudhi-deploy/blob/main/install_cgal.sh)
* print `gudhi.__version__` in test and packages