### PR TITLE
cmake witout python improvement

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,9 +2,9 @@ cmake_minimum_required(VERSION 3.5)
 
 project(GUDHIdev)
 
-include(CMakeGUDHIVersion.txt)
-
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/src/cmake/modules/")
+include(CMakeGUDHIVersion.txt)
+include(GUDHI_options)
 
 # Reset cache
 set(GUDHI_MODULES "" CACHE INTERNAL "GUDHI_MODULES")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,9 +2,9 @@ cmake_minimum_required(VERSION 3.5)
 
 project(GUDHI)
 
-include(CMakeGUDHIVersion.txt)
-
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/modules/")
+include(CMakeGUDHIVersion.txt)
+include(GUDHI_options)
 
 set(GUDHI_MODULES "" CACHE INTERNAL "GUDHI_MODULES")
 set(GUDHI_MISSING_MODULES "" CACHE INTERNAL "GUDHI_MISSING_MODULES")

--- a/src/cmake/modules/GUDHI_modules.cmake
+++ b/src/cmake/modules/GUDHI_modules.cmake
@@ -17,12 +17,6 @@ function(add_gudhi_module file_path)
 
 endfunction(add_gudhi_module)
 
-option(WITH_GUDHI_BENCHMARK "Activate/desactivate benchmark compilation" OFF)
-option(WITH_GUDHI_EXAMPLE "Activate/desactivate examples compilation and installation" OFF)
-option(WITH_GUDHI_PYTHON "Activate/desactivate python module compilation and installation" ON)
-option(WITH_GUDHI_TEST "Activate/desactivate examples compilation and installation" ON)
-option(WITH_GUDHI_UTILITIES "Activate/desactivate utilities compilation and installation" ON)
-
 if (WITH_GUDHI_BENCHMARK)
   set(GUDHI_SUB_DIRECTORIES "${GUDHI_SUB_DIRECTORIES};benchmark")
 endif()

--- a/src/cmake/modules/GUDHI_options.cmake
+++ b/src/cmake/modules/GUDHI_options.cmake
@@ -1,0 +1,5 @@
+option(WITH_GUDHI_BENCHMARK "Activate/desactivate benchmark compilation" OFF)
+option(WITH_GUDHI_EXAMPLE "Activate/desactivate examples compilation and installation" OFF)
+option(WITH_GUDHI_PYTHON "Activate/desactivate python module compilation and installation" ON)
+option(WITH_GUDHI_TEST "Activate/desactivate examples compilation and installation" ON)
+option(WITH_GUDHI_UTILITIES "Activate/desactivate utilities compilation and installation" ON)

--- a/src/cmake/modules/GUDHI_third_party_libraries.cmake
+++ b/src/cmake/modules/GUDHI_third_party_libraries.cmake
@@ -93,91 +93,92 @@ add_definitions( -DBOOST_SYSTEM_NO_DEPRECATED )
 message(STATUS "boost include dirs:" ${Boost_INCLUDE_DIRS})
 message(STATUS "boost library dirs:" ${Boost_LIBRARY_DIRS})
 
-# Find the correct Python interpreter.
-# Can be set with -DPYTHON_EXECUTABLE=/usr/bin/python3 or -DPython_ADDITIONAL_VERSIONS=3 for instance.
-find_package( PythonInterp )
+if (WITH_GUDHI_PYTHON)
+  # Find the correct Python interpreter.
+  # Can be set with -DPYTHON_EXECUTABLE=/usr/bin/python3 or -DPython_ADDITIONAL_VERSIONS=3 for instance.
+  find_package( PythonInterp )
+  
+  # find_python_module tries to import module in Python interpreter and to retrieve its version number
+  # returns ${PYTHON_MODULE_NAME_UP}_VERSION and ${PYTHON_MODULE_NAME_UP}_FOUND
+  function( find_python_module PYTHON_MODULE_NAME )
+    string(TOUPPER ${PYTHON_MODULE_NAME} PYTHON_MODULE_NAME_UP)
+    execute_process(
+            COMMAND ${PYTHON_EXECUTABLE}  -c "import ${PYTHON_MODULE_NAME}; print(${PYTHON_MODULE_NAME}.__version__)"
+            RESULT_VARIABLE PYTHON_MODULE_RESULT
+            OUTPUT_VARIABLE PYTHON_MODULE_VERSION
+            ERROR_VARIABLE PYTHON_MODULE_ERROR)
+    if(PYTHON_MODULE_RESULT EQUAL 0)
+      # Remove all carriage returns as it can be multiline
+      string(REGEX REPLACE "\n" " " PYTHON_MODULE_VERSION "${PYTHON_MODULE_VERSION}")
+      message ("++ Python module ${PYTHON_MODULE_NAME} - Version ${PYTHON_MODULE_VERSION} found")
+  
+      set(${PYTHON_MODULE_NAME_UP}_VERSION ${PYTHON_MODULE_VERSION} PARENT_SCOPE)
+      set(${PYTHON_MODULE_NAME_UP}_FOUND TRUE PARENT_SCOPE)
+    else()
+      message ("PYTHON_MODULE_NAME = ${PYTHON_MODULE_NAME}
+       - PYTHON_MODULE_RESULT = ${PYTHON_MODULE_RESULT}
+       - PYTHON_MODULE_VERSION = ${PYTHON_MODULE_VERSION}
+       - PYTHON_MODULE_ERROR = ${PYTHON_MODULE_ERROR}")
+      unset(${PYTHON_MODULE_NAME_UP}_VERSION PARENT_SCOPE)
+      set(${PYTHON_MODULE_NAME_UP}_FOUND FALSE PARENT_SCOPE)
+    endif()
+  endfunction( find_python_module )
 
-# find_python_module tries to import module in Python interpreter and to retrieve its version number
-# returns ${PYTHON_MODULE_NAME_UP}_VERSION and ${PYTHON_MODULE_NAME_UP}_FOUND
-function( find_python_module PYTHON_MODULE_NAME )
-  string(TOUPPER ${PYTHON_MODULE_NAME} PYTHON_MODULE_NAME_UP)
-  execute_process(
-          COMMAND ${PYTHON_EXECUTABLE}  -c "import ${PYTHON_MODULE_NAME}; print(${PYTHON_MODULE_NAME}.__version__)"
-          RESULT_VARIABLE PYTHON_MODULE_RESULT
-          OUTPUT_VARIABLE PYTHON_MODULE_VERSION
-          ERROR_VARIABLE PYTHON_MODULE_ERROR)
-  if(PYTHON_MODULE_RESULT EQUAL 0)
-    # Remove all carriage returns as it can be multiline
-    string(REGEX REPLACE "\n" " " PYTHON_MODULE_VERSION "${PYTHON_MODULE_VERSION}")
-    message ("++ Python module ${PYTHON_MODULE_NAME} - Version ${PYTHON_MODULE_VERSION} found")
-
-    set(${PYTHON_MODULE_NAME_UP}_VERSION ${PYTHON_MODULE_VERSION} PARENT_SCOPE)
-    set(${PYTHON_MODULE_NAME_UP}_FOUND TRUE PARENT_SCOPE)
-  else()
-    message ("PYTHON_MODULE_NAME = ${PYTHON_MODULE_NAME}
-     - PYTHON_MODULE_RESULT = ${PYTHON_MODULE_RESULT}
-     - PYTHON_MODULE_VERSION = ${PYTHON_MODULE_VERSION}
-     - PYTHON_MODULE_ERROR = ${PYTHON_MODULE_ERROR}")
-    unset(${PYTHON_MODULE_NAME_UP}_VERSION PARENT_SCOPE)
-    set(${PYTHON_MODULE_NAME_UP}_FOUND FALSE PARENT_SCOPE)
+  # For modules that do not define module.__version__
+  function( find_python_module_no_version PYTHON_MODULE_NAME )
+    string(TOUPPER ${PYTHON_MODULE_NAME} PYTHON_MODULE_NAME_UP)
+    execute_process(
+            COMMAND ${PYTHON_EXECUTABLE}  -c "import ${PYTHON_MODULE_NAME}"
+            RESULT_VARIABLE PYTHON_MODULE_RESULT
+            ERROR_VARIABLE PYTHON_MODULE_ERROR)
+    if(PYTHON_MODULE_RESULT EQUAL 0)
+      # Remove carriage return
+      message ("++ Python module ${PYTHON_MODULE_NAME} found")
+      set(${PYTHON_MODULE_NAME_UP}_FOUND TRUE PARENT_SCOPE)
+    else()
+      message ("PYTHON_MODULE_NAME = ${PYTHON_MODULE_NAME}
+       - PYTHON_MODULE_RESULT = ${PYTHON_MODULE_RESULT}
+       - PYTHON_MODULE_ERROR = ${PYTHON_MODULE_ERROR}")
+      set(${PYTHON_MODULE_NAME_UP}_FOUND FALSE PARENT_SCOPE)
+    endif()
+  endfunction( find_python_module_no_version )
+  
+  if( PYTHONINTERP_FOUND )
+    find_python_module("cython")
+    find_python_module("pytest")
+    find_python_module("matplotlib")
+    find_python_module("numpy")
+    find_python_module("scipy")
+    find_python_module("sphinx")
+    find_python_module("sklearn")
+    find_python_module("ot")
+    find_python_module("pybind11")
+    find_python_module("torch")
+    find_python_module("pykeops")
+    find_python_module("eagerpy")
+    find_python_module_no_version("hnswlib")
+    find_python_module("tensorflow")
+    find_python_module("sphinx_paramlinks")
+    find_python_module_no_version("python_docs_theme")
   endif()
-endfunction( find_python_module )
-
-# For modules that do not define module.__version__
-function( find_python_module_no_version PYTHON_MODULE_NAME )
-  string(TOUPPER ${PYTHON_MODULE_NAME} PYTHON_MODULE_NAME_UP)
-  execute_process(
-          COMMAND ${PYTHON_EXECUTABLE}  -c "import ${PYTHON_MODULE_NAME}"
-          RESULT_VARIABLE PYTHON_MODULE_RESULT
-          ERROR_VARIABLE PYTHON_MODULE_ERROR)
-  if(PYTHON_MODULE_RESULT EQUAL 0)
-    # Remove carriage return
-    message ("++ Python module ${PYTHON_MODULE_NAME} found")
-    set(${PYTHON_MODULE_NAME_UP}_FOUND TRUE PARENT_SCOPE)
-  else()
-    message ("PYTHON_MODULE_NAME = ${PYTHON_MODULE_NAME}
-     - PYTHON_MODULE_RESULT = ${PYTHON_MODULE_RESULT}
-     - PYTHON_MODULE_ERROR = ${PYTHON_MODULE_ERROR}")
-    set(${PYTHON_MODULE_NAME_UP}_FOUND FALSE PARENT_SCOPE)
-  endif()
-endfunction( find_python_module_no_version )
-
-if( PYTHONINTERP_FOUND )
-  find_python_module("cython")
-  find_python_module("pytest")
-  find_python_module("matplotlib")
-  find_python_module("numpy")
-  find_python_module("scipy")
-  find_python_module("sphinx")
-  find_python_module("sklearn")
-  find_python_module("ot")
-  find_python_module("pybind11")
-  find_python_module("torch")
-  find_python_module("pykeops")
-  find_python_module("eagerpy")
-  find_python_module_no_version("hnswlib")
-  find_python_module("tensorflow")
-  find_python_module("sphinx_paramlinks")
-  find_python_module_no_version("python_docs_theme")
-endif()
-
-if(NOT GUDHI_PYTHON_PATH)
-  message(FATAL_ERROR "ERROR: GUDHI_PYTHON_PATH is not valid.")
-endif(NOT GUDHI_PYTHON_PATH)
-
-option(WITH_GUDHI_PYTHON_RUNTIME_LIBRARY_DIRS "Build with setting runtime_library_dirs. Usefull when setting rpath is not allowed" ON)
-
-if(PYTHONINTERP_FOUND AND CYTHON_FOUND)
-  if(SPHINX_FOUND)
-    # Documentation generation is available through sphinx
-    find_program( SPHINX_PATH sphinx-build )
-
-    if(NOT SPHINX_PATH)
-      if(PYTHON_VERSION_MAJOR EQUAL 3)
-        # In Python3, just hack sphinx-build if it does not exist
-        set(SPHINX_PATH "${PYTHON_EXECUTABLE}" "-m" "sphinx.cmd.build")
-      endif(PYTHON_VERSION_MAJOR EQUAL 3)
-    endif(NOT SPHINX_PATH)
-  endif(SPHINX_FOUND)
-endif(PYTHONINTERP_FOUND AND CYTHON_FOUND)
-
+  
+  if(NOT GUDHI_PYTHON_PATH)
+    message(FATAL_ERROR "ERROR: GUDHI_PYTHON_PATH is not valid.")
+  endif(NOT GUDHI_PYTHON_PATH)
+  
+  option(WITH_GUDHI_PYTHON_RUNTIME_LIBRARY_DIRS "Build with setting runtime_library_dirs. Usefull when setting rpath is not allowed" ON)
+  
+  if(PYTHONINTERP_FOUND AND CYTHON_FOUND)
+    if(SPHINX_FOUND)
+      # Documentation generation is available through sphinx
+      find_program( SPHINX_PATH sphinx-build )
+  
+      if(NOT SPHINX_PATH)
+        if(PYTHON_VERSION_MAJOR EQUAL 3)
+          # In Python3, just hack sphinx-build if it does not exist
+          set(SPHINX_PATH "${PYTHON_EXECUTABLE}" "-m" "sphinx.cmd.build")
+        endif(PYTHON_VERSION_MAJOR EQUAL 3)
+      endif(NOT SPHINX_PATH)
+    endif(SPHINX_FOUND)
+  endif(PYTHONINTERP_FOUND AND CYTHON_FOUND)
+endif (WITH_GUDHI_PYTHON)


### PR DESCRIPTION
Move cmake options in a dedicated file.
cmake is no more looking for python and its modules when python option is disabled.
Fix #575 