### PR TITLE
Documentation: Doxygen warnings

### DIFF
--- a/src/Contraction/include/gudhi/Edge_contraction.h
+++ b/src/Contraction/include/gudhi/Edge_contraction.h
@@ -26,6 +26,7 @@ namespace contraction {
 
 
 /** \defgroup contr Edge contraction
+@{
 
 \author David Salinas
 
@@ -194,7 +195,6 @@ int main (int argc, char *argv[])
 	std::clog << "Time to simplify and enumerate simplices:\n";
 
 	return EXIT_SUCCESS;
-}
 }
   \endcode
 

--- a/src/Doxyfile.in
+++ b/src/Doxyfile.in
@@ -231,12 +231,6 @@ TAB_SIZE               = 2
 
 ALIASES                =
 
-# This tag can be used to specify a number of word-keyword mappings (TCL only).
-# A mapping has the form "name=value". For example adding "class=itcl::class"
-# will allow you to use the command class in the itcl::class meaning.
-
-TCL_SUBST              =
-
 # Set the OPTIMIZE_OUTPUT_FOR_C tag to YES if your project consists of C sources
 # only. Doxygen will then generate output that is more tailored for C. For
 # instance, some of the names that are used will be different. The list of all
@@ -706,7 +700,7 @@ LAYOUT_FILE            =
 
 CITE_BIB_FILES         = @CMAKE_SOURCE_DIR@/biblio/bibliography.bib \
                          @CMAKE_SOURCE_DIR@/biblio/how_to_cite_cgal.bib \
-                         @CMAKE_SOURCE_DIR@/biblio/how_to_cite_gudhi.bib
+                         @CMAKE_CURRENT_BINARY_DIR@/biblio/how_to_cite_gudhi.bib
 
 #---------------------------------------------------------------------------
 # Configuration options related to warning and progress messages
@@ -874,7 +868,7 @@ EXCLUDE_SYMBOLS        =
 # that contain example code fragments that are included (see the \include
 # command).
 
-EXAMPLE_PATH           = @CMAKE_SOURCE_DIR@/biblio/ \
+EXAMPLE_PATH           = @CMAKE_CURRENT_BINARY_DIR@ \
                          @CMAKE_SOURCE_DIR@/data/ \
                          @GUDHI_DOXYGEN_EXAMPLE_PATH@
 
@@ -1040,25 +1034,6 @@ USE_HTAGS              = NO
 
 VERBATIM_HEADERS       = YES
 
-# If the CLANG_ASSISTED_PARSING tag is set to YES then doxygen will use the
-# clang parser (see: http://clang.llvm.org/) for more accurate parsing at the
-# cost of reduced performance. This can be particularly helpful with template
-# rich C++ code for which doxygen's built-in parser lacks the necessary type
-# information.
-# Note: The availability of this option depends on whether or not doxygen was
-# generated with the -Duse-libclang=ON option for CMake.
-# The default value is: NO.
-
-CLANG_ASSISTED_PARSING = NO
-
-# If clang assisted parsing is enabled you can provide the compiler with command
-# line options that you would normally use when invoking the compiler. Note that
-# the include paths will already be set by doxygen for the files and directories
-# specified with INPUT and INCLUDE_PATH.
-# This tag requires that the tag CLANG_ASSISTED_PARSING is set to YES.
-
-CLANG_OPTIONS          =
-
 #---------------------------------------------------------------------------
 # Configuration options related to the alphabetical class index
 #---------------------------------------------------------------------------
@@ -1069,13 +1044,6 @@ CLANG_OPTIONS          =
 # The default value is: YES.
 
 ALPHABETICAL_INDEX     = YES
-
-# The COLS_IN_ALPHA_INDEX tag can be used to specify the number of columns in
-# which the alphabetical index list will be split.
-# Minimum value: 1, maximum value: 20, default value: 5.
-# This tag requires that the tag ALPHABETICAL_INDEX is set to YES.
-
-COLS_IN_ALPHA_INDEX    = 5
 
 # In case all classes in a project start with a common prefix, all classes will
 # be put under the same header in the alphabetical index. The IGNORE_PREFIX tag
@@ -1775,16 +1743,6 @@ LATEX_BATCHMODE        = NO
 
 LATEX_HIDE_INDICES     = NO
 
-# If the LATEX_SOURCE_CODE tag is set to YES then doxygen will include source
-# code with syntax highlighting in the LaTeX output.
-#
-# Note that which sources are shown also depends on other settings such as
-# SOURCE_BROWSER.
-# The default value is: NO.
-# This tag requires that the tag GENERATE_LATEX is set to YES.
-
-LATEX_SOURCE_CODE      = NO
-
 # The LATEX_BIB_STYLE tag can be used to specify the style to use for the
 # bibliography, e.g. plainnat, or ieeetr. See
 # http://en.wikipedia.org/wiki/BibTeX and \cite for more info.
@@ -1856,16 +1814,6 @@ RTF_STYLESHEET_FILE    =
 # This tag requires that the tag GENERATE_RTF is set to YES.
 
 RTF_EXTENSIONS_FILE    =
-
-# If the RTF_SOURCE_CODE tag is set to YES then doxygen will include source code
-# with syntax highlighting in the RTF output.
-#
-# Note that which sources are shown also depends on other settings such as
-# SOURCE_BROWSER.
-# The default value is: NO.
-# This tag requires that the tag GENERATE_RTF is set to YES.
-
-RTF_SOURCE_CODE        = NO
 
 #---------------------------------------------------------------------------
 # Configuration options related to the man page output
@@ -1955,15 +1903,6 @@ GENERATE_DOCBOOK       = NO
 # This tag requires that the tag GENERATE_DOCBOOK is set to YES.
 
 DOCBOOK_OUTPUT         = docbook
-
-# If the DOCBOOK_PROGRAMLISTING tag is set to YES, doxygen will include the
-# program listings (including syntax highlighting and cross-referencing
-# information) to the DOCBOOK output. Note that enabling this will significantly
-# increase the size of the DOCBOOK output.
-# The default value is: NO.
-# This tag requires that the tag GENERATE_DOCBOOK is set to YES.
-
-DOCBOOK_PROGRAMLISTING = NO
 
 #---------------------------------------------------------------------------
 # Configuration options for the AutoGen Definitions output
@@ -2139,12 +2078,6 @@ EXTERNAL_GROUPS        = YES
 
 EXTERNAL_PAGES         = YES
 
-# The PERL_PATH should be the absolute path and name of the perl script
-# interpreter (i.e. the result of 'which perl').
-# The default file (with absolute path) is: /usr/bin/perl.
-
-PERL_PATH              = /usr/bin/perl
-
 #---------------------------------------------------------------------------
 # Configuration options related to the dot tool
 #---------------------------------------------------------------------------
@@ -2157,15 +2090,6 @@ PERL_PATH              = /usr/bin/perl
 # The default value is: YES.
 
 CLASS_DIAGRAMS         = NO
-
-# You can define message sequence charts within doxygen comments using the \msc
-# command. Doxygen will then run the mscgen tool (see:
-# http://www.mcternan.me.uk/mscgen/)) to produce the chart and insert it in the
-# documentation. The MSCGEN_PATH tag allows you to specify the directory where
-# the mscgen tool resides. If left empty the tool is assumed to be found in the
-# default search path.
-
-MSCGEN_PATH            =
 
 # You can include diagrams made with dia in doxygen documentation. Doxygen will
 # then run dia to produce the diagram and insert it in the documentation. The

--- a/src/Doxyfile.in
+++ b/src/Doxyfile.in
@@ -700,7 +700,7 @@ LAYOUT_FILE            =
 
 CITE_BIB_FILES         = @CMAKE_SOURCE_DIR@/biblio/bibliography.bib \
                          @CMAKE_SOURCE_DIR@/biblio/how_to_cite_cgal.bib \
-                         @CMAKE_CURRENT_BINARY_DIR@/biblio/how_to_cite_gudhi.bib
+                         @CMAKE_SOURCE_DIR@/biblio/how_to_cite_gudhi.bib
 
 #---------------------------------------------------------------------------
 # Configuration options related to warning and progress messages
@@ -868,7 +868,7 @@ EXCLUDE_SYMBOLS        =
 # that contain example code fragments that are included (see the \include
 # command).
 
-EXAMPLE_PATH           = @CMAKE_CURRENT_BINARY_DIR@ \
+EXAMPLE_PATH           = @CMAKE_SOURCE_DIR@ \
                          @CMAKE_SOURCE_DIR@/data/ \
                          @GUDHI_DOXYGEN_EXAMPLE_PATH@
 

--- a/src/common/doc/examples.h
+++ b/src/common/doc/examples.h
@@ -1,6 +1,6 @@
 // List of GUDHI examples and utils - Doxygen needs at least a file tag to analyse comments
 // Generated from scripts/cpp_examples_for_doxygen.py
-/*! @file Examples
+/*! @file
  * \section Witness_complex_example_section Witness_complex
  * @example strong_witness_persistence.cpp
  * @example weak_witness_persistence.cpp


### PR DESCRIPTION
When running doxygen on the sources we get (a.o.) the following warnings:
```
.../gudhi-devel/src/Contraction/include/gudhi/Edge_contraction.h:214: warning: unbalanced grouping commands
.../gudhi-devel/src/common/doc/examples.h:3: warning: the name 'Examples' supplied as the argument in the \file statement is not an input file
error: bib file .../gudhi-devel/biblio/how_to_cite_gudhi.bib not found!
.../gudhi-devel/src/common/doc/installation.h:271: warning: included file biblio/how_to_cite_gudhi.bib is not found. Check your EXAMPLE_PATH
```
This is corrected in the different files and in the settings in src/Doxyfile.in

Also there are a number of settings that are obsolete like:
```
warning: Tag 'LATEX_SOURCE_CODE' at line 1835 of file '.../gudhi-devel/build_windows_fork/Doxyfile' has become obsolete.
```
This is corrected in the src/Doxyfile.in file