### PR TITLE
Documentation: make it easier to build only the documentation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-option(build_documentation_only    "Build only the documentation with doxygen." OFF)
+option(WITH_GUDHI_CPP_DOCUMENTATION_ONLY    "Build only the GUDHI C++ documentation (with doxygen)." OFF)
 
 cmake_minimum_required(VERSION 3.5)
 
@@ -16,7 +16,7 @@ set(GUDHI_MISSING_MODULES "" CACHE INTERNAL "GUDHI_MISSING_MODULES")
 # This variable is used by Cython CMakeLists.txt and by GUDHI_third_party_libraries to know its path
 set(GUDHI_PYTHON_PATH "src/python")
 
-if (NOT build_documentation_only)
+if (NOT WITH_GUDHI_CPP_DOCUMENTATION_ONLY)
   # For third parties libraries management - To be done last as CGAL updates CMAKE_MODULE_PATH
   include(GUDHI_third_party_libraries NO_POLICY_SCOPE)
 endif()
@@ -57,7 +57,7 @@ foreach(GUDHI_MODULE ${GUDHI_MODULES})
   endforeach()
 endforeach()
 
-if (NOT build_documentation_only)
+if (NOT WITH_GUDHI_CPP_DOCUMENTATION_ONLY)
   add_subdirectory(src/GudhUI)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,6 @@
+
+option(build_documentation_only    "Build only the documentation with doxygen." OFF)
+
 cmake_minimum_required(VERSION 3.5)
 
 project(GUDHIdev)
@@ -13,8 +16,10 @@ set(GUDHI_MISSING_MODULES "" CACHE INTERNAL "GUDHI_MISSING_MODULES")
 # This variable is used by Cython CMakeLists.txt and by GUDHI_third_party_libraries to know its path
 set(GUDHI_PYTHON_PATH "src/python")
 
-# For third parties libraries management - To be done last as CGAL updates CMAKE_MODULE_PATH
-include(GUDHI_third_party_libraries NO_POLICY_SCOPE)
+if (NOT build_documentation_only)
+  # For third parties libraries management - To be done last as CGAL updates CMAKE_MODULE_PATH
+  include(GUDHI_third_party_libraries NO_POLICY_SCOPE)
+endif()
 
 include(GUDHI_compilation_flags)
 
@@ -52,7 +57,9 @@ foreach(GUDHI_MODULE ${GUDHI_MODULES})
   endforeach()
 endforeach()
 
-add_subdirectory(src/GudhUI)
+if (NOT build_documentation_only)
+  add_subdirectory(src/GudhUI)
+endif()
 
 if (WITH_GUDHI_PYTHON)
   # specific for cython module

--- a/src/common/doc/installation.h
+++ b/src/common/doc/installation.h
@@ -41,11 +41,16 @@ make \endverbatim
  * program). If some of the tests are failing, please send us the result of the following command:
  * \verbatim ctest --output-on-failure \endverbatim
  * 
- * \subsection documentationgeneration Documentation
- * To generate the documentation, <a target="_blank" href="http://www.doxygen.org/">Doxygen</a> is required.
- * Run the following command in a terminal:
+ * \subsection documentationgeneration C++ documentation
+ * To generate the C++ documentation, for this the <a target="_blank" href="http://www.doxygen.org/">doxygen</a> program
+ * is required, run the following command in a terminal:
  * \verbatim make doxygen \endverbatim
  * Documentation will be generated in a folder named <code>html</code>.
+ *
+ * In case there is not a full setup present and only the documentation should be build the following command sequence
+ * can be used:
+\verbatim  cmake -DWITH_GUDHI_CPP_DOCUMENTATION_ONLY=ON ..
+make doxygen\endverbatim
  *
  * \subsection helloworld Hello world !
  * The <a target="_blank" href="https://github.com/GUDHI/hello-gudhi-world">Hello world for GUDHI</a>


### PR DESCRIPTION
Introduce the possibility:
```
-Dbuild_documentation_only=ON
```
so that only the doxygen documentation can be build and we don't have to resort to installing all kinds of sub packages like Boost or manipulate the CMake files:w