### PR TITLE
Fix unbalanced groups and some doxygen typos

### DIFF
--- a/src/Coxeter_triangulation/include/gudhi/Permutahedral_representation/Permutahedral_representation_iterators.h
+++ b/src/Coxeter_triangulation/include/gudhi/Permutahedral_representation/Permutahedral_representation_iterators.h
@@ -26,12 +26,12 @@ namespace Gudhi {
 
 namespace coxeter_triangulation {
 
-/* \addtogroup coxeter_triangulation
+/** \addtogroup coxeter_triangulation
  * Iterator types for Permutahedral_representation
  * @{
  */
 
-/* \brief Iterator over the vertices of a simplex
+/** \brief Iterator over the vertices of a simplex
  * represented by its permutahedral representation.
  *
  * Forward iterator, 'value_type' is Permutahedral_representation::Vertex.*/
@@ -83,7 +83,7 @@ class Vertex_iterator
 };  // Vertex_iterator
 
 /*---------------------------------------------------------------------------*/
-/* \brief Iterator over the k-faces of a simplex
+/** \brief Iterator over the k-faces of a simplex
  *  given by its permutahedral representation.
  *
  * Forward iterator, value_type is Permutahedral_representation. */
@@ -141,7 +141,7 @@ class Face_iterator : public boost::iterator_facade<Face_iterator<Permutahedral_
 };  // Face_iterator
 
 /*---------------------------------------------------------------------------*/
-/* \brief Iterator over the k-cofaces of a simplex
+/** \brief Iterator over the k-cofaces of a simplex
  *  given by its permutahedral representation.
  *
  * Forward iterator, value_type is Permutahedral_representation. */
@@ -246,6 +246,8 @@ class Coface_iterator
   value_t value_;  // the dereference value
 
 };  // Coface_iterator
+
+/** @} */
 
 }  // namespace coxeter_triangulation
 

--- a/src/Persistent_cohomology/concept/FilteredComplex.h
+++ b/src/Persistent_cohomology/concept/FilteredComplex.h
@@ -103,7 +103,7 @@ Filtration_simplex_range filtration_simplex_range();
 /** @} */
  
 
-/* \brief Iterator over the simplices of the complex,
+/** \brief Iterator over the simplices of the complex,
   * in an arbitrary order.
   *
   * 'value_type' must be 'Simplex_handle'.*/

--- a/src/Simplex_tree/include/gudhi/Simplex_tree.h
+++ b/src/Simplex_tree/include/gudhi/Simplex_tree.h
@@ -42,6 +42,10 @@
 
 namespace Gudhi {
 
+/** \addtogroup simplex_tree 
+ *  @{
+ */
+
 /**
  * \class Extended_simplex_type Simplex_tree.h gudhi/Simplex_tree.h
  * \brief Extended simplex type data structure for representing the type of simplices in an extended filtration.
@@ -97,8 +101,7 @@ class Simplex_tree {
   // Simplex_key next to each other).
   typedef typename boost::container::flat_map<Vertex_handle, Node> Dictionary;
 
-  /* \brief Set of nodes sharing a same parent in the simplex tree. */
-  /* \brief Set of nodes sharing a same parent in the simplex tree. */
+  /** \brief Set of nodes sharing a same parent in the simplex tree. */
   typedef Simplex_tree_siblings<Simplex_tree, Dictionary> Siblings;
 
 
@@ -1338,7 +1341,7 @@ class Simplex_tree {
     }
   }
 
-  /* \private Returns the Simplex_handle composed of the vertex list (from the Simplex_handle), plus the given
+  /** \private Returns the Simplex_handle composed of the vertex list (from the Simplex_handle), plus the given
    * Vertex_handle if the Vertex_handle is found in the Simplex_handle children list.
    * Returns null_simplex() if it does not exist
   */
@@ -1801,7 +1804,7 @@ struct Simplex_tree_options_fast_persistence {
   static const bool contiguous_vertices = true;
 };
 
-/** @} */  // end defgroup simplex_tree
+/** @}*/  // end addtogroup simplex_tree
 
 }  // namespace Gudhi
 

--- a/src/Simplex_tree/include/gudhi/Simplex_tree/Simplex_tree_iterators.h
+++ b/src/Simplex_tree/include/gudhi/Simplex_tree/Simplex_tree_iterators.h
@@ -22,12 +22,12 @@
 
 namespace Gudhi {
 
-/* \addtogroup simplex_tree
+/** \addtogroup simplex_tree 
  * Iterators and range types for the Simplex_tree.
- * @{
+ *  @{
  */
 
-/* \brief Iterator over the vertices of a simplex
+/** \brief Iterator over the vertices of a simplex
  * in a SimplexTree.
  *
  * Forward iterator, 'value_type' is SimplexTree::Vertex_handle.*/
@@ -73,7 +73,7 @@ class Simplex_tree_simplex_vertex_iterator : public boost::iterator_facade<
 };
 
 /*---------------------------------------------------------------------------*/
-/* \brief Iterator over the simplices of the boundary of a
+/** \brief Iterator over the simplices of the boundary of a
  *  simplex.
  *
  * Forward iterator, value_type is SimplexTree::Simplex_handle.*/
@@ -181,7 +181,7 @@ class Simplex_tree_boundary_simplex_iterator : public boost::iterator_facade<
   SimplexTree * st_;  // simplex containing the simplicial complex
 };
 
-/* \brief Iterator over the simplices of the boundary of a simplex and their opposite vertices.
+/** \brief Iterator over the simplices of the boundary of a simplex and their opposite vertices.
  *
  * Forward iterator, value_type is std::pair<SimplexTree::Simplex_handle, SimplexTree::Vertex_handle>.*/
 template<class SimplexTree>
@@ -291,7 +291,7 @@ class Simplex_tree_boundary_opposite_vertex_simplex_iterator : public boost::ite
 };
 
 /*---------------------------------------------------------------------------*/
-/* \brief Iterator over the simplices of a simplicial complex.
+/** \brief Iterator over the simplices of a simplicial complex.
  *
  * Forward iterator, value_type is SimplexTree::Simplex_handle.*/
 template<class SimplexTree>
@@ -364,7 +364,7 @@ class Simplex_tree_complex_simplex_iterator : public boost::iterator_facade<
   SimplexTree * st_;
 };
 
-/* \brief Iterator over the simplices of the skeleton of a given
+/** \brief Iterator over the simplices of the skeleton of a given
  * dimension of the simplicial complex.
  *
  * Forward iterator, value_type is SimplexTree::Simplex_handle.*/
@@ -447,7 +447,8 @@ class Simplex_tree_skeleton_simplex_iterator : public boost::iterator_facade<
   int curr_dim_;
 };
 
-/* @} */  // end addtogroup simplex_tree
+/** @}*/  // end addtogroup simplex_tree
+
 }  // namespace Gudhi
 
 #endif  // SIMPLEX_TREE_SIMPLEX_TREE_ITERATORS_H_

--- a/src/Simplex_tree/include/gudhi/Simplex_tree/Simplex_tree_node_explicit_storage.h
+++ b/src/Simplex_tree/include/gudhi/Simplex_tree/Simplex_tree_node_explicit_storage.h
@@ -15,13 +15,12 @@
 
 namespace Gudhi {
 
-/* \addtogroup simplex_tree
+/** \addtogroup simplex_tree
  * Represents a node of a Simplex_tree.
  * @{
  */
 
-/*
- * \brief Node of a simplex tree with filtration value
+/** \brief Node of a simplex tree with filtration value
  * and simplex key.
  *
  * It stores explicitely its own filtration value and its own Simplex_key.
@@ -54,7 +53,8 @@ struct Simplex_tree_node_explicit_storage : SimplexTree::Filtration_simplex_base
   Siblings * children_;
 };
 
-/* @} */  // end addtogroup simplex_tree
+/** @}*/  // end addtogroup simplex_tree
+
 }  // namespace Gudhi
 
 #endif  // SIMPLEX_TREE_SIMPLEX_TREE_NODE_EXPLICIT_STORAGE_H_

--- a/src/Simplex_tree/include/gudhi/Simplex_tree/Simplex_tree_siblings.h
+++ b/src/Simplex_tree/include/gudhi/Simplex_tree/Simplex_tree_siblings.h
@@ -20,12 +20,12 @@
 
 namespace Gudhi {
 
-/* \addtogroup simplex_tree
+/** \addtogroup simplex_tree
  * Represents a set of node of a Simplex_tree that share the same parent.
  * @{
  */
 
-/* \brief Data structure to store a set of nodes in a SimplexTree sharing
+/** \brief Data structure to store a set of nodes in a SimplexTree sharing
  * the same parent node.*/
 template<class SimplexTree, class MapContainer>
 class Simplex_tree_siblings {
@@ -58,7 +58,7 @@ class Simplex_tree_siblings {
         members_() {
   }
 
-  /* \brief Constructor with initialized set of members.
+  /** \brief Constructor with initialized set of members.
    *
    * 'members' must be sorted and unique.*/
   template<typename RandomAccessVertexRange>
@@ -72,8 +72,7 @@ class Simplex_tree_siblings {
     }
   }
 
-  /*
-   * \brief Inserts a Node in the set of siblings nodes.
+  /** \brief Inserts a Node in the set of siblings nodes.
    *
    * If already present, assigns the minimal filtration value 
    * between input filtration_value and the value already 
@@ -114,7 +113,8 @@ class Simplex_tree_siblings {
   Dictionary members_;
 };
 
-/* @} */  // end addtogroup simplex_tree
+/** @}*/  // end addtogroup simplex_tree
+
 }  // namespace Gudhi
 
 #endif  // SIMPLEX_TREE_SIMPLEX_TREE_SIBLINGS_H_

--- a/src/Simplex_tree/include/gudhi/Simplex_tree/indexing_tag.h
+++ b/src/Simplex_tree/include/gudhi/Simplex_tree/indexing_tag.h
@@ -20,7 +20,7 @@ namespace Gudhi {
 struct linear_indexing_tag {
 };
 
-/* \brief Tag for a zigzag ordering of simplices. */
+/** \brief Tag for a zigzag ordering of simplices. */
 //  struct zigzag_indexing_tag {};
 }  // namespace Gudhi
 

--- a/src/Witness_complex/include/gudhi/Active_witness/Active_witness.h
+++ b/src/Witness_complex/include/gudhi/Active_witness/Active_witness.h
@@ -18,7 +18,7 @@ namespace Gudhi {
 
 namespace witness_complex {
 
-  /* \class Active_witness
+  /** \class Active_witness
    *  \brief Class representing a list of nearest neighbors to a given witness.
    *  \details Every element is a pair of a landmark identifier and the squared distance to it.
   */

--- a/src/Witness_complex/include/gudhi/Active_witness/Active_witness_iterator.h
+++ b/src/Witness_complex/include/gudhi/Active_witness/Active_witness_iterator.h
@@ -18,7 +18,7 @@ namespace Gudhi {
 
 namespace witness_complex {
 
-/* \brief Iterator in the nearest landmark list.
+/** \brief Iterator in the nearest landmark list.
  *  \details After the iterator reaches the end of the list,
  *          the list is augmented by a (nearest landmark, distance) pair if possible.
  *          If all the landmarks are present in the list, iterator returns the specific end value

--- a/src/Witness_complex/include/gudhi/Strong_witness_complex.h
+++ b/src/Witness_complex/include/gudhi/Strong_witness_complex.h
@@ -125,7 +125,7 @@ class Strong_witness_complex {
   //@}
 
  private:
-    /* \brief Adds recursively all the faces of a certain dimension dim-1 witnessed by the same witness.
+    /** \brief Adds recursively all the faces of a certain dimension dim-1 witnessed by the same witness.
      * Iterator is needed to know until how far we can take landmarks to form simplexes.
      * simplex is the prefix of the simplexes to insert.
      * The landmark pointed by aw_it is added to all formed simplices.

--- a/src/Witness_complex/include/gudhi/Witness_complex.h
+++ b/src/Witness_complex/include/gudhi/Witness_complex.h
@@ -127,7 +127,7 @@ class Witness_complex {
   //@}
 
  private:
-  /* \brief Adds recursively all the faces of a certain dimension dim witnessed by the same witness.
+  /** \brief Adds recursively all the faces of a certain dimension dim witnessed by the same witness.
    * Iterator is needed to know until how far we can take landmarks to form simplexes.
    * simplex is the prefix of the simplexes to insert.
    * The output value indicates if the witness rests active or not.

--- a/src/Witness_complex/include/gudhi/Witness_complex/all_faces_in.h
+++ b/src/Witness_complex/include/gudhi/Witness_complex/all_faces_in.h
@@ -11,7 +11,7 @@
 #ifndef WITNESS_COMPLEX_ALL_FACES_IN_H_
 #define WITNESS_COMPLEX_ALL_FACES_IN_H_
 
-/* \brief Check if the facets of the k-dimensional simplex witnessed 
+/** \brief Check if the facets of the k-dimensional simplex witnessed 
  *  by witness witness_id are already in the complex.
  *  inserted_vertex is the handle of the (k+1)-th vertex witnessed by witness_id
  */


### PR DESCRIPTION
Fix #608 
Consequences on the documentation:
* Coxeter [actual](https://gudhi.inria.fr/doc/latest/group__coxeter__triangulation.html) vs [after](https://output.circle-artifacts.com/output/job/53bc4a23-2966-49a9-911a-5f701756245f/artifacts/0/doxygen/group__coxeter__triangulation.html)
* Simplex tree [actual](https://gudhi.inria.fr/doc/latest/group__simplex__tree.html) vs [after](https://output.circle-artifacts.com/output/job/53bc4a23-2966-49a9-911a-5f701756245f/artifacts/0/doxygen/group__simplex__tree.html)
* Witness complex [actual]() vs [after](https://output.circle-artifacts.com/output/job/53bc4a23-2966-49a9-911a-5f701756245f/artifacts/0/doxygen/class_gudhi_1_1witness__complex_1_1_active__witness__iterator.html)

It also fixes this bug for Filtered complexes in the left menu bar:
Before
![Screenshot from 2022-05-23 09-43-34](https://user-images.githubusercontent.com/10407034/169769097-5ac7280d-72f4-4769-8c82-60350a28e188.png)
After
![Screenshot from 2022-05-23 09-44-00](https://user-images.githubusercontent.com/10407034/169769151-1053a01f-58dc-49f1-8509-9a330ea9c4b5.png)

