### PR TITLE
Documentation: Updating redirected links

### DIFF
--- a/biblio/bibliography.bib
+++ b/biblio/bibliography.bib
@@ -167,7 +167,7 @@ language={English},
     number = {RR-8436},
     year = {2013},
     month = Dec,
-    pdf = {https://hal.inria.fr/hal-00922572/PDF/RR-8436.pdf},
+    pdf = {https://hal.inria.fr/hal-00922572v5/document},
 }
 
 

--- a/biblio/bibliography.bib
+++ b/biblio/bibliography.bib
@@ -14,7 +14,7 @@ publisher = {JMLR.org},
 title = {{Statistical analysis and parameter selection for Mapper}},
 volume = {19},
 year = {2018},
-url = {http://jmlr.org/papers/v19/17-291.html},
+url = {https://jmlr.org/papers/v19/17-291.html},
 }
 
 @inproceedings{Dey13,
@@ -151,10 +151,10 @@ language={English},
 
 
 %% hal-00922572, version 2
-%% http://hal.inria.fr/hal-00922572
+%% https://hal.inria.fr/hal-00922572
 @techreport{boissonnat:hal-00922572,
     hal_id = {hal-00922572},
-    url = {http://hal.inria.fr/hal-00922572},
+    url = {https://hal.inria.fr/hal-00922572},
     title = {Computing Persistent Homology with Various Coefficient Fields in a Single Pass},
     author = {Boissonnat, Jean-Daniel and Maria, Cl{\'e}ment},
     abstract = {{In this article, we introduce the multi-field persistence diagram for the persistence homology of a filtered complex. It encodes compactly the superimposition of the persistence diagrams of the complex with several field coefficients, and provides a substantially more precise description of the topology of the filtered complex. Specifically, the multi-field persistence diagram encodes the Betti numbers of integral homology and the prime divisors of the torsion coefficients of the underlying shape. Moreover, it enjoys similar stability properties as the ones of standard persistence diagrams, with the appropriate notion of distance. These properties make the multi-field persistence diagram a useful tool in computational topology.}},
@@ -167,7 +167,7 @@ language={English},
     number = {RR-8436},
     year = {2013},
     month = Dec,
-    pdf = {http://hal.inria.fr/hal-00922572/PDF/RR-8436.pdf},
+    pdf = {https://hal.inria.fr/hal-00922572/PDF/RR-8436.pdf},
 }
 
 
@@ -323,7 +323,7 @@ language={English},
 %------------------------------------------------------------------
 @article{rips2012,
     hal_id = {hal-00785072},
-    url = {http://hal.archives-ouvertes.fr/hal-00785072},
+    url = {https://hal.archives-ouvertes.fr/hal-00785072},
     title = {{Vietoris-Rips Complexes also Provide Topologically Correct Reconstructions of Sampled Shapes}},
     author = {Attali, Dominique and Lieutier, Andr{\'e} and Salinas, David},
     keywords = {Shape reconstruction \sep Rips complexes \sep clique complexes \sep \v Cech complexes ; homotopy equivalence ; collapses ; high dimensions},
@@ -1115,7 +1115,7 @@ language={English}
   author = {Nicholas J. Cavanna and Mahmoodreza Jahanseir and Donald R. Sheehy},
   booktitle = {Proceedings of the Canadian Conference on Computational Geometry},
   title = {A Geometric Perspective on Sparse Filtrations},
-  url = {http://research.cs.queensu.ca/cccg2015/CCCG15-papers/01.pdf},
+  url = {https://research.cs.queensu.ca/cccg2015/CCCG15-papers/01.pdf},
   year = {2015}
 }
 
@@ -1151,7 +1151,7 @@ language={English}
   editor =	{Lars Arge and J{\'a}nos Pach},
   publisher =	{Schloss Dagstuhl--Leibniz-Zentrum fuer Informatik},
   address =	{Dagstuhl, Germany},
-  URL =		{http://drops.dagstuhl.de/opus/volltexte/2015/5098},
+  URL =		{https://drops.dagstuhl.de/opus/volltexte/2015/5098},
   URN =		{urn:nbn:de:0030-drops-50981},
   doi =		{10.4230/LIPIcs.SOCG.2015.642},
   annote =	{Keywords: Simplicial complex, Compact data structures, Automaton, NP-hard}
@@ -1164,7 +1164,7 @@ language={English}
   journal   = {CoRR},
   volume    = {abs/1607.08449},
   year      = {2016},
-  url       = {http://arxiv.org/abs/1607.08449},
+  url       = {https://arxiv.org/abs/1607.08449},
   archivePrefix = {arXiv},
   eprint    = {1607.08449},
   timestamp = {Mon, 13 Aug 2018 16:46:26 +0200},

--- a/src/Nerve_GIC/doc/Intro_graph_induced_complex.h
+++ b/src/Nerve_GIC/doc/Intro_graph_induced_complex.h
@@ -24,7 +24,7 @@ namespace cover_complex {
  * Visualizations of the simplicial complexes can be done with either
  * neato (from <a target="_blank" href="http://www.graphviz.org/">graphviz</a>),
  * <a target="_blank" href="http://www.geomview.org/">geomview</a>,
- * <a target="_blank" href="https://github.com/MLWave/kepler-mapper">KeplerMapper</a>.
+ * <a target="_blank" href="https://github.com/scikit-tda/kepler-mapper">KeplerMapper</a>.
  * Input point clouds are assumed to be \ref FileFormatsOFF "OFF files"
  *
  * \section covers Covers

--- a/src/common/doc/installation.h
+++ b/src/common/doc/installation.h
@@ -5,8 +5,8 @@
  * Examples of GUDHI headers inclusion can be found in \ref utilities.
  * 
  * \section compiling Compiling
- * The library uses c++14 and requires <a target="_blank" href="http://www.boost.org/">Boost</a>  &ge; 1.66.0
- * and <a target="_blank" href="https://www.cmake.org/">CMake</a> &ge; 3.5.
+ * The library uses c++14 and requires <a target="_blank" href="https://www.boost.org/">Boost</a>  &ge; 1.66.0
+ * and <a target="_blank" href="https://cmake.org/">CMake</a> &ge; 3.5.
  * It is a multi-platform library and compiles on Linux, Mac OSX and Visual Studio 2015.
  * 
  * \subsection utilities Utilities and examples
@@ -56,7 +56,7 @@ make \endverbatim
  * The multi-field persistent homology algorithm requires GMP which is a free library for arbitrary-precision
  * arithmetic, operating on signed integers, rational numbers, and floating point numbers.
  * 
- * The following example requires the <a target="_blank" href="http://gmplib.org/">GNU Multiple Precision Arithmetic
+ * The following example requires the <a target="_blank" href="https://gmplib.org/">GNU Multiple Precision Arithmetic
  * Library</a> (GMP) and will not be built if GMP is not installed:
  * \li <a href="rips_multifield_persistence_8cpp-example.html">
  * Persistent_cohomology/rips_multifield_persistence.cpp</a>
@@ -131,10 +131,10 @@ make \endverbatim
  *
  * \subsection eigen Eigen
  * Some GUDHI modules (cf. \ref main_page "modules list"), and few examples require
- * <a target="_blank" href="http://eigen.tuxfamily.org/">Eigen</a> is a C++ template library for linear algebra:
+ * <a target="_blank" href="https://eigen.tuxfamily.org/index.php?title=Main_Page">Eigen</a> is a C++ template library for linear algebra:
  * matrices, vectors, numerical solvers, and related algorithms.
  * 
- * The following examples/utilities require the <a target="_blank" href="http://eigen.tuxfamily.org/">Eigen</a> and will not be
+ * The following examples/utilities require the <a target="_blank" href="https://eigen.tuxfamily.org/index.php?title=Main_Page">Eigen</a> and will not be
  * built if Eigen is not installed:
  * \li <a href="_alpha_complex_from_off_8cpp-example.html">
  * Alpha_complex/Alpha_complex_from_off.cpp</a>
@@ -180,7 +180,7 @@ make \endverbatim
  * Coxeter_triangulation/manifold_tracing_flat_torus_with_boundary.cpp</a>
  *
  * \subsection tbb Threading Building Blocks
- * <a target="_blank" href="https://www.threadingbuildingblocks.org/">Intel&reg; TBB</a> lets you easily write parallel
+ * <a target="_blank" href="https://github.com/oneapi-src/oneTBB">Intel&reg; TBB</a> lets you easily write parallel
  * C++ programs that take full advantage of multicore performance, that are portable and composable, and that have
  * future-proof scalability.
  * 

--- a/src/common/doc/installation.h
+++ b/src/common/doc/installation.h
@@ -131,7 +131,7 @@ make \endverbatim
  *
  * \subsection eigen Eigen
  * Some GUDHI modules (cf. \ref main_page "modules list"), and few examples require
- * <a target="_blank" href="https://eigen.tuxfamily.org/index.php?title=Main_Page">Eigen</a> is a C++ template library for linear algebra:
+ * <a target="_blank" href="https://eigen.tuxfamily.org">Eigen</a> is a C++ template library for linear algebra:
  * matrices, vectors, numerical solvers, and related algorithms.
  * 
  * The following examples/utilities require the <a target="_blank" href="https://eigen.tuxfamily.org/index.php?title=Main_Page">Eigen</a> and will not be

--- a/src/common/doc/installation.h
+++ b/src/common/doc/installation.h
@@ -134,7 +134,7 @@ make \endverbatim
  * <a target="_blank" href="https://eigen.tuxfamily.org">Eigen</a> is a C++ template library for linear algebra:
  * matrices, vectors, numerical solvers, and related algorithms.
  * 
- * The following examples/utilities require the <a target="_blank" href="https://eigen.tuxfamily.org/index.php?title=Main_Page">Eigen</a> and will not be
+ * The following examples/utilities require the <a target="_blank" href="https://eigen.tuxfamily.org">Eigen</a> and will not be
  * built if Eigen is not installed:
  * \li <a href="_alpha_complex_from_off_8cpp-example.html">
  * Alpha_complex/Alpha_complex_from_off.cpp</a>

--- a/src/python/doc/nerve_gic_complex_user.rst
+++ b/src/python/doc/nerve_gic_complex_user.rst
@@ -12,7 +12,7 @@ Definition
 Visualizations of the simplicial complexes can be done with either
 neato (from `graphviz <http://www.graphviz.org/>`_),
 `geomview <http://www.geomview.org/>`_,
-`KeplerMapper <https://github.com/MLWave/kepler-mapper>`_.
+`KeplerMapper <https://github.com/scikit-tda/kepler-mapper>`_.
 Input point clouds are assumed to be OFF files (cf. `OFF file format <fileformats.html#off-file-format>`_).
 
 Covers


### PR DESCRIPTION
Updating simple links in documentation sources for which we got during link checking:
```
This is a permanent redirect. The link should be updated.
```