### PR TITLE
Documentation: Incorrect links to examples

### DIFF
--- a/src/common/doc/installation.h
+++ b/src/common/doc/installation.h
@@ -126,7 +126,7 @@ make \endverbatim
  * Alpha_complex/Weighted_alpha_complex_3d_from_points.cpp</a>
  * \li <a href="alpha_complex_3d_persistence_8cpp-example.html">
  * Alpha_complex/alpha_complex_3d_persistence.cpp</a>
- * \li <a href="_coxeter_triangulation_2manifold_tracing_flat_torus_with_boundary_8cpp-example.html">
+ * \li <a href="manifold_tracing_flat_torus_with_boundary_8cpp-example.html">
  * Coxeter_triangulation/manifold_tracing_flat_torus_with_boundary.cpp</a>
  *
  * \subsection eigen Eigen
@@ -172,11 +172,11 @@ make \endverbatim
  * Witness_complex/example_witness_complex_off.cpp</a>
  * \li <a href="example_witness_complex_sphere_8cpp-example.html">
  * Witness_complex/example_witness_complex_sphere.cpp</a>
- * \li <a href="_coxeter_triangulation_2cell_complex_from_basic_circle_manifold_8cpp-example.html">
+ * \li <a href="cell_complex_from_basic_circle_manifold_8cpp-example.html">
  * Coxeter_triangulation/cell_complex_from_basic_circle_manifold.cpp</a>
- * \li <a href="_coxeter_triangulation_2manifold_tracing_custom_function_8cpp-example.html">
+ * \li <a href="manifold_tracing_custom_function_8cpp-example.html">
  * Coxeter_triangulation/manifold_tracing_custom_function.cpp</a>
- * \li <a href="_coxeter_triangulation_2manifold_tracing_flat_torus_with_boundary_8cpp-example.html">
+ * \li <a href="manifold_tracing_flat_torus_with_boundary_8cpp-example.html">
  * Coxeter_triangulation/manifold_tracing_flat_torus_with_boundary.cpp</a>
  *
  * \subsection tbb Threading Building Blocks


### PR DESCRIPTION
The links to the examples from the `Coxeter_triangulation` were incorrect (looks lie they contained the path).