### PR TITLE
Documentation: Redirecting some links properly to the gudhi website

### DIFF
--- a/src/Persistent_cohomology/doc/Intro_persistent_cohomology.h
+++ b/src/Persistent_cohomology/doc/Intro_persistent_cohomology.h
@@ -142,7 +142,7 @@ diagram.
 3  1 0.104347 inf 
 3  2 0.138335 inf \endcode
 
-More details on the <a href="../../ripscomplex/">Rips complex utilities</a> dedicated page.
+More details on the <a href="https://gudhi.inria.fr/ripscomplex/" target="gudhi_web">Rips complex utilities</a> dedicated page.
 
 \li <a href="rips_multifield_persistence_8cpp-example.html">
 Persistent_cohomology/rips_multifield_persistence.cpp</a> computes the Rips complex of a point cloud and outputs its
@@ -156,7 +156,7 @@ The file should contain square or lower triangular distance matrix with semicolo
 The code do not check if it is dealing with a distance matrix. It is the user responsibility to provide a valid input.
 Please refer to data/distance_matrix/lower_triangular_distance_matrix.csv for an example of a file.
 
-More details on the <a href="../../ripscomplex/">Rips complex utilities</a> dedicated page.
+More details on the <a href="https://gudhi.inria.fr/ripscomplex/" target="gudhi_web">Rips complex utilities</a> dedicated page.
 
 \li <a href="rips_correlation_matrix_persistence_8cpp-example.html">
 Rips_complex/rips_correlation_matrix_persistence.cpp</a>
@@ -167,7 +167,7 @@ It is the user responsibility to ensure that this is the case. The input is to b
 triangular matrix.
 Please refer to data/correlation_matrix/lower_triangular_correlation_matrix.csv for an example of a file.
 
-More details on the <a href="../../ripscomplex/">Rips complex utilities</a> dedicated page.
+More details on the <a href="https://gudhi.inria.fr/ripscomplex/" target="gudhi_web">Rips complex utilities</a> dedicated page.
 
 \li <a href="alpha_complex_3d_persistence_8cpp-example.html">
 Alpha_complex/alpha_complex_3d_persistence.cpp</a> computes the persistent homology with
@@ -179,7 +179,7 @@ Alpha_complex/alpha_complex_3d_persistence.cpp</a> computes the persistent homol
 2  1 0.0934117 1.00003 
 2  2 0.56444 1.03938 \endcode
 
-More details on the <a href="../../alphacomplex/">Alpha complex utilities</a> dedicated page.
+More details on the <a href="https://gudhi.inria.fr/alphacomplex/" target="gudhi_web">Alpha complex utilities</a> dedicated page.
 
 CGAL can be forced to compute the exact values, it is slower, but it is necessary when points are on a grid
 for instance (the fast version `--fast` would give incorrect values).
@@ -246,7 +246,7 @@ Simplex_tree dim: 3
 2  1 0.0934117 1.00003 
 2  2 0.56444 1.03938 \endcode
 
-More details on the <a href="../../alphacomplex/">Alpha complex utilities</a> dedicated page.
+More details on the <a href="https://gudhi.inria.fr/alphacomplex/" target="gudhi_web">Alpha complex utilities</a> dedicated page.
 
 \li <a href="plain_homology_8cpp-example.html">
 Persistent_cohomology/plain_homology.cpp</a> computes the plain homology of a simple simplicial complex without

--- a/src/common/doc/header.html
+++ b/src/common/doc/header.html
@@ -35,49 +35,49 @@ $extrastylesheet
     <section class="top-bar-section">
       <ul class="right">
               <li class="divider"></li>
-              <li><a  href="/contact/">Contact</a></li>
+              <li><a  href="https://gudhi.inria.fr/contact/" target="gudhi_web">Contact</a></li>
       </ul>
       <ul class="left">
-              <li><a  href="/"> <img src="/assets/img/home.png" alt="  GUDHI">  GUDHI </a></li>
+              <li><a  href="https://gudhi.inria.fr" target="gudhi_web"> <img src="https://gudhi.inria.fr/assets/img/home.png" alt="  GUDHI">  GUDHI </a></li>
               <li class="divider"></li>
               <li class="has-dropdown">
                 <a  href="#">Project</a>
                   <ul class="dropdown">
-                      <li><a  href="/people/">People</a></li>
-                      <li><a  href="/keepintouch/">Keep in touch</a></li>
-                      <li><a  href="/partners/">Partners and Funding</a></li>
-                      <li><a  href="/relatedprojects/">Related projects</a></li>
-                      <li><a  href="/theyaretalkingaboutus/">They are talking about us</a></li>
-                      <li><a  href="/inaction/">GUDHI in action</a></li>
-                      <li><a  href="/etymology/">Etymology</a></li>
+                      <li><a  href="https://gudhi.inria.fr/people/" target="gudhi_web">People</a></li>
+                      <li><a  href="https://gudhi.inria.fr/keepintouch/" target="gudhi_web">Keep in touch</a></li>
+                      <li><a  href="https://gudhi.inria.fr/partners/" target="gudhi_web">Partners and Funding</a></li>
+                      <li><a  href="https://gudhi.inria.fr/relatedprojects/" target="gudhi_web">Related projects</a></li>
+                      <li><a  href="https://gudhi.inria.fr/theyaretalkingaboutus/" target="gudhi_web">They are talking about us</a></li>
+                      <li><a  href="https://gudhi.inria.fr/inaction/" target="gudhi_web">GUDHI in action</a></li>
+                      <li><a  href="https://gudhi.inria.fr/etymology/" target="gudhi_web">Etymology</a></li>
                   </ul>
               </li>
               <li class="divider"></li>
               <li class="has-dropdown">
                 <a  href="#">Download</a>
                   <ul class="dropdown">
-                      <li><a  href="/licensing/">Licensing</a></li>
+                      <li><a  href="https://gudhi.inria.fr/licensing/" target="gudhi_web">Licensing</a></li>
                       <li><a  href="https://github.com/GUDHI/gudhi-devel/releases/latest" target="_blank">Get the latest sources</a></li>
-                      <li><a  href="/conda/">Conda package</a></li>
+                      <li><a  href="https://gudhi.inria.fr/conda/" target="gudhi_web">Conda package</a></li>
                       <li><a  href="https://pypi.org/project/gudhi/" target="_blank">Pip package</a></li>
-                      <li><a  href="/dockerfile/">Dockerfile</a></li>
+                      <li><a  href="https://gudhi.inria.fr/dockerfile/" target="gudhi_web">Dockerfile</a></li>
                   </ul>
               </li>
               <li class="divider"></li>
               <li class="has-dropdown">
                 <a  href="#">Documentation</a>
                   <ul class="dropdown">
-                      <li><a  href="/introduction/">Introduction</a></li>
-                      <li><a  href="/doc/latest/installation.html">C++ installation manual</a></li>
-                      <li><a  href="/doc/latest/">C++ documentation</a></li>
-                      <li><a  href="/python/latest/installation.html">Python installation manual</a></li>
-                      <li><a  href="/python/latest/">Python documentation</a></li>
-                      <li><a  href="/utils/">Utilities</a></li>
-                      <li><a  href="/tutorials/">Tutorials</a></li>
+                      <li><a  href="https://gudhi.inria.fr/introduction/" target="gudhi_web">Introduction</a></li>
+                      <li><a  href="https://gudhi.inria.fr/doc/latest/installation.html" target="_blank">C++ installation manual</a></li>
+                      <li><a  href="https://gudhi.inria.fr/doc/latest/" target="_blank">C++ documentation</a></li>
+                      <li><a  href="https://gudhi.inria.fr/python/latest/installation.html" target="_blank">Python installation manual</a></li>
+                      <li><a  href="https://gudhi.inria.fr/python/latest/" target="_blank">Python documentation</a></li>
+                      <li><a  href="https://gudhi.inria.fr/utils/" target="gudhi_web">Utilities</a></li>
+                      <li><a  href="https://gudhi.inria.fr/tutorials/" target="gudhi_web">Tutorials</a></li>
                   </ul>
               </li>
               <li class="divider"></li>
-              <li><a  href="/interfaces/">Interfaces</a></li>
+              <li><a  href="https://gudhi.inria.fr/interfaces/" target="gudhi_web">Interfaces</a></li>
               <li class="divider"></li>
       </ul>
     </section>

--- a/src/common/doc/main_page.md
+++ b/src/common/doc/main_page.md
@@ -124,7 +124,7 @@
     <td width="15%">
       <b>Author:</b> David Salinas<br>
       <b>Introduced in:</b> GUDHI 1.1.0<br>
-      <b>Copyright:</b> MIT [(LGPL v3)](../../licensing/)<br>
+      <b>Copyright:</b> MIT [(LGPL v3)](https://gudhi.inria.fr/licensing/)<br>
       <b>Requires:</b> \ref cgal &ge; 4.11.0
     </td>
  </tr>
@@ -155,7 +155,7 @@
     <td width="15%">
       <b>Author:</b> Vincent Rouvreau<br>
       <b>Introduced in:</b> GUDHI 1.3.0<br>
-      <b>Copyright:</b> MIT [(GPL v3)](../../licensing/)<br>
+      <b>Copyright:</b> MIT [(GPL v3)](https://gudhi.inria.fr/licensing/)<br>
       <b>Requires:</b> \ref eigen &ge; 3.1.0 and \ref cgal &ge; 4.11.0
     </td>
  </tr>
@@ -180,7 +180,7 @@
     <td width="15%">
       <b>Author:</b> Vincent Rouvreau<br>
       <b>Introduced in:</b> GUDHI 2.2.0<br>
-      <b>Copyright:</b> MIT [(GPL v3)](../../licensing/)<br>
+      <b>Copyright:</b> MIT [(GPL v3)](https://gudhi.inria.fr/licensing/)<br>
       <b>Includes:</b> [Miniball](https://people.inf.ethz.ch/gaertner/subdir/software/miniball.html)<br>
     </td>
  </tr>
@@ -260,7 +260,7 @@
     <td width="15%">
       <b>Author:</b> Siargey Kachanovich<br>
       <b>Introduced in:</b> GUDHI 1.3.0<br>
-      <b>Copyright:</b> MIT ([GPL v3](../../licensing/) for Euclidean version)<br>
+      <b>Copyright:</b> MIT ([GPL v3](https://gudhi.inria.fr/licensing/) for Euclidean version)<br>
       <b>Euclidean version requires:</b> \ref eigen &ge; 3.1.0 and \ref cgal &ge; 4.11.0
     </td>
  </tr>
@@ -286,7 +286,7 @@
     <td width="15%">
       <b>Author:</b> Mathieu Carri&egrave;re<br>
       <b>Introduced in:</b> GUDHI 2.1.0<br>
-      <b>Copyright:</b> MIT [(GPL v3)](../../licensing/)<br>
+      <b>Copyright:</b> MIT [(GPL v3)](https://gudhi.inria.fr/licensing/)<br>
       <b>Requires:</b> \ref cgal &ge; 4.11.0
     </td>
  </tr>
@@ -312,7 +312,7 @@
     <td width="15%">
       <b>Author:</b> Siargey Kachanovich<br>
       <b>Introduced in:</b> GUDHI 3.4.0<br>
-      <b>Copyright:</b> MIT [(LGPL v3)](../../licensing/)<br>
+      <b>Copyright:</b> MIT [(LGPL v3)](https://gudhi.inria.fr/licensing/)<br>
       <b>Requires:</b> \ref eigen &ge; 3.1.0
     </td>
  </tr>
@@ -340,7 +340,7 @@
     <td width="15%">
       <b>Author:</b> Cl&eacute;ment Jamin<br>
       <b>Introduced in:</b> GUDHI 2.0.0<br>
-      <b>Copyright:</b> MIT [(GPL v3)](../../licensing/)<br>
+      <b>Copyright:</b> MIT [(GPL v3)](https://gudhi.inria.fr/licensing/)<br>
       <b>Requires:</b> \ref eigen &ge; 3.1.0 and \ref cgal &ge; 4.11.0
     </td>
  </tr>
@@ -403,7 +403,7 @@
     <td width="15%">
       <b>Author:</b> Fran&ccedil;ois Godi<br>
       <b>Introduced in:</b> GUDHI 2.0.0<br>
-      <b>Copyright:</b> MIT [(GPL v3)](../../licensing/)<br>
+      <b>Copyright:</b> MIT [(GPL v3)](https://gudhi.inria.fr/licensing/)<br>
       <b>Requires:</b> \ref cgal &ge; 4.11.0
     </td>
  </tr>
@@ -452,7 +452,7 @@
     <td width="15%">
       <b>Author:</b> Clément Jamin<br>
       <b>Introduced in:</b> GUDHI 1.3.0<br>
-      <b>Copyright:</b> MIT [(GPL v3)](../../licensing/)<br>
+      <b>Copyright:</b> MIT [(GPL v3)](https://gudhi.inria.fr/licensing/)<br>
     </td>
  </tr>
  <tr>


### PR DESCRIPTION
In the code (mostly the top bar) there are links to links like `../../licensing/`, this works OK on the website but in the user generated local documentation this gives an unknown link.
- properly create the links as `https://gudhi.inria.fr/licensing/`
- redirect the pages from the website to their own tab / iframe by means of `target="gudhi_web"`, so the manual is still properly visible. The `target="-blank"` hasn't been used as in that case each time when a link was clicked from the manual a new tab would be opened. (see also: https://www.w3schools.com/tags/att_a_target.asp)