### PR TITLE
Documentation: Use latest MathJax 2 version

### DIFF
--- a/src/Doxyfile.in
+++ b/src/Doxyfile.in
@@ -1494,7 +1494,7 @@ MATHJAX_FORMAT         = HTML-CSS
 # The default value is: http://cdn.mathjax.org/mathjax/latest.
 # This tag requires that the tag USE_MATHJAX is set to YES.
 
-MATHJAX_RELPATH        = https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.2
+MATHJAX_RELPATH        =
 
 # The MATHJAX_EXTENSIONS tag can be used to specify one or more MathJax
 # extension names that should be enabled during MathJax rendering. For example


### PR DESCRIPTION
The MathJax 2 version in the Doxyfile is fixed  to version 2.7.2, the current version is 2.7.9 so it is better to use the default as selected by doxygen.