### PR TITLE
No need to copy Doxyfile.in

### DIFF
--- a/src/cmake/modules/GUDHI_user_version_target.cmake
+++ b/src/cmake/modules/GUDHI_user_version_target.cmake
@@ -14,8 +14,6 @@ add_custom_command(TARGET user_version PRE_BUILD COMMAND ${CMAKE_COMMAND} -E
                    make_directory ${GUDHI_USER_VERSION_DIR}
                    COMMENT "user_version creation in ${GUDHI_USER_VERSION_DIR}")
 
-file(COPY "${CMAKE_SOURCE_DIR}/src/Doxyfile.in" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}/")
-
 # Generate bib files for Doxygen - cf. root CMakeLists.txt for explanation
 string(TIMESTAMP GUDHI_VERSION_YEAR "%Y")
 configure_file(${CMAKE_SOURCE_DIR}/biblio/how_to_cite_gudhi.bib.in "${CMAKE_CURRENT_BINARY_DIR}/biblio/how_to_cite_gudhi.bib" @ONLY)


### PR DESCRIPTION
In my opinion there is no need to copy the `Doxyfile.in` file to the build directory (neither in the User nor the development version).
The usage is:
```
configure_file(${GUDHI_DOXYGEN_SOURCE_PREFIX}/Doxyfile.in "${CMAKE_CURRENT_BINARY_DIR}/Doxyfile" @ONLY)
```
in the file `src/cmake/modules/GUDHI_doxygen_target.cmake` and we see that this uses the file from its original source directory.