### PR TITLE
Doxygen only

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,9 +95,9 @@ jobs:
             mkdir build
             cd build
             cmake -DWITH_GUDHI_CPP_DOCUMENTATION_ONLY=ON ..
-            make doxygen 2>&1 | tee dox.log
-            grep warning dox.log
-            cp dox.log html/
+            make doxygen 2>&1
+            grep warning doxygen.log
+            cp doxygen.log html/
             cp -R html /tmp/doxygen
 
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,7 @@ jobs:
 
   python:
     docker:
-      - image: gudhi/ci_for_gudhi:latest
+      - image: gudhi/doxygen_for_gudhi:latest
     steps:
       - checkout
       - run:
@@ -58,7 +58,7 @@ jobs:
             git submodule update
             mkdir build
             cd build
-            cmake -DUSER_VERSION_DIR=version ..
+            cmake -DWITH_GUDHI_CPP_DOCUMENTATION_ONLY=ON -DUSER_VERSION_DIR=version ..
             make user_version
             cd version
             cmake -DCMAKE_BUILD_TYPE=Release -DWITH_GUDHI_EXAMPLE=OFF -DWITH_GUDHI_UTILITIES=OFF -DWITH_GUDHI_PYTHON=ON -DPython_ADDITIONAL_VERSIONS=3 .
@@ -89,12 +89,12 @@ jobs:
             git submodule update
             mkdir build
             cd build
-            cmake -DCMAKE_BUILD_TYPE=Release -DWITH_GUDHI_EXAMPLE=OFF -DWITH_GUDHI_TEST=OFF -DWITH_GUDHI_UTILITIES=OFF -DWITH_GUDHI_PYTHON=OFF -DUSER_VERSION_DIR=version ..
+            cmake -DWITH_GUDHI_CPP_DOCUMENTATION_ONLY=ON -DUSER_VERSION_DIR=version ..
             make user_version
             cd version
             mkdir build
             cd build
-            cmake -DCMAKE_BUILD_TYPE=Release -DWITH_GUDHI_EXAMPLE=OFF -DWITH_GUDHI_TEST=OFF -DWITH_GUDHI_UTILITIES=OFF -DWITH_GUDHI_PYTHON=OFF ..
+            cmake -DWITH_GUDHI_CPP_DOCUMENTATION_ONLY=ON ..
             make doxygen 2>&1 | tee dox.log
             grep warning dox.log
             cp dox.log html/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,7 @@ jobs:
 
   python:
     docker:
-      - image: gudhi/doxygen_for_gudhi:latest
+      - image: gudhi/ci_for_gudhi:latest
     steps:
       - checkout
       - run:
@@ -79,7 +79,7 @@ jobs:
 
   doxygen:
     docker:
-      - image: gudhi/ci_for_gudhi:latest
+      - image: gudhi/doxygen_for_gudhi:latest
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,7 @@ jobs:
             git submodule update
             mkdir build
             cd build
-            cmake -DWITH_GUDHI_CPP_DOCUMENTATION_ONLY=ON -DUSER_VERSION_DIR=version ..
+            cmake -DWITH_GUDHI_THIRD_PARTY=OFF -DUSER_VERSION_DIR=version ..
             make user_version
             cd version
             cmake -DCMAKE_BUILD_TYPE=Release -DWITH_GUDHI_EXAMPLE=OFF -DWITH_GUDHI_UTILITIES=OFF -DWITH_GUDHI_PYTHON=ON -DPython_ADDITIONAL_VERSIONS=3 .
@@ -89,13 +89,13 @@ jobs:
             git submodule update
             mkdir build
             cd build
-            cmake -DWITH_GUDHI_CPP_DOCUMENTATION_ONLY=ON -DUSER_VERSION_DIR=version ..
+            cmake -DWITH_GUDHI_THIRD_PARTY=OFF -DUSER_VERSION_DIR=version ..
             make user_version
             cd version
             mkdir build
             cd build
-            cmake -DWITH_GUDHI_CPP_DOCUMENTATION_ONLY=ON ..
-            make doxygen 2>&1
+            cmake -DWITH_GUDHI_THIRD_PARTY=OFF ..
+            make doxygen
             grep warning doxygen.log
             cp doxygen.log html/
             cp -R html /tmp/doxygen

--- a/.github/for_maintainers/tests_strategy.md
+++ b/.github/for_maintainers/tests_strategy.md
@@ -4,6 +4,11 @@ This document tries to sum up the tests strategy that has been put in place for 
 
 The aim is to help maintainers to anticipate third parties modifications, updates.
 
+## CMake options
+
+[CMake GUDHI options](../../src/cmake/modules/GUDHI_options.cmake) allows to activate/deactivate what should be built and tested.
+Note the special option `WITH_GUDHI_THIRD_PARTY` that, when set to `OFF`, accelerates doxygen documentation generation or `user_version` for instance.
+
 ## Builds
 
 ### Linux

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,8 @@ set(GUDHI_MISSING_MODULES "" CACHE INTERNAL "GUDHI_MISSING_MODULES")
 # This variable is used by Cython CMakeLists.txt and by GUDHI_third_party_libraries to know its path
 set(GUDHI_PYTHON_PATH "src/python")
 
+include(GUDHI_submodules)
+
 if (NOT WITH_GUDHI_CPP_DOCUMENTATION_ONLY)
   # For third parties libraries management - To be done last as CGAL updates CMAKE_MODULE_PATH
   include(GUDHI_third_party_libraries NO_POLICY_SCOPE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,3 @@
-
-option(WITH_GUDHI_CPP_DOCUMENTATION_ONLY    "Build only the GUDHI C++ documentation (with doxygen)." OFF)
-
 cmake_minimum_required(VERSION 3.5)
 
 project(GUDHIdev)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ set(GUDHI_PYTHON_PATH "src/python")
 
 include(GUDHI_submodules)
 
-if (NOT WITH_GUDHI_CPP_DOCUMENTATION_ONLY)
+if (WITH_GUDHI_THIRD_PARTY)
   # For third parties libraries management - To be done last as CGAL updates CMAKE_MODULE_PATH
   include(GUDHI_third_party_libraries NO_POLICY_SCOPE)
 endif()
@@ -56,7 +56,7 @@ foreach(GUDHI_MODULE ${GUDHI_MODULES})
   endforeach()
 endforeach()
 
-if (NOT WITH_GUDHI_CPP_DOCUMENTATION_ONLY)
+if (WITH_GUDHI_THIRD_PARTY)
   add_subdirectory(src/GudhUI)
 endif()
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,7 +14,7 @@ set(GUDHI_PYTHON_PATH "python")
 
 include(GUDHI_submodules)
 
-if (NOT WITH_GUDHI_CPP_DOCUMENTATION_ONLY)
+if (WITH_GUDHI_THIRD_PARTY)
   # For third parties libraries management - To be done last as CGAL updates CMAKE_MODULE_PATH
   include(GUDHI_third_party_libraries NO_POLICY_SCOPE)
 endif()
@@ -71,7 +71,7 @@ foreach(GUDHI_MODULE ${GUDHI_MODULES})
   endforeach()
 endforeach()
 
-if (NOT WITH_GUDHI_CPP_DOCUMENTATION_ONLY)
+if (WITH_GUDHI_THIRD_PARTY)
   add_subdirectory(GudhUI)
 endif()
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,6 +12,8 @@ set(GUDHI_MISSING_MODULES "" CACHE INTERNAL "GUDHI_MISSING_MODULES")
 # This variable is used by Cython CMakeLists.txt and by GUDHI_third_party_libraries to know its path
 set(GUDHI_PYTHON_PATH "python")
 
+include(GUDHI_submodules)
+
 if (NOT WITH_GUDHI_CPP_DOCUMENTATION_ONLY)
   # For third parties libraries management - To be done last as CGAL updates CMAKE_MODULE_PATH
   include(GUDHI_third_party_libraries NO_POLICY_SCOPE)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,8 +12,10 @@ set(GUDHI_MISSING_MODULES "" CACHE INTERNAL "GUDHI_MISSING_MODULES")
 # This variable is used by Cython CMakeLists.txt and by GUDHI_third_party_libraries to know its path
 set(GUDHI_PYTHON_PATH "python")
 
-# For third parties libraries management - To be done last as CGAL updates CMAKE_MODULE_PATH
-include(GUDHI_third_party_libraries NO_POLICY_SCOPE)
+if (NOT WITH_GUDHI_CPP_DOCUMENTATION_ONLY)
+  # For third parties libraries management - To be done last as CGAL updates CMAKE_MODULE_PATH
+  include(GUDHI_third_party_libraries NO_POLICY_SCOPE)
+endif()
 
 include(GUDHI_compilation_flags)
 
@@ -67,7 +69,9 @@ foreach(GUDHI_MODULE ${GUDHI_MODULES})
   endforeach()
 endforeach()
 
-add_subdirectory(GudhUI)
+if (NOT WITH_GUDHI_CPP_DOCUMENTATION_ONLY)
+  add_subdirectory(GudhUI)
+endif()
 
 message("++ GUDHI_MODULES list is:\"${GUDHI_MODULES}\"")
 message("++ GUDHI_MISSING_MODULES list is:\"${GUDHI_MISSING_MODULES}\"")

--- a/src/Doxyfile.in
+++ b/src/Doxyfile.in
@@ -711,7 +711,7 @@ CITE_BIB_FILES         = @CMAKE_SOURCE_DIR@/biblio/bibliography.bib \
 # messages are off.
 # The default value is: NO.
 
-QUIET                  = NO
+QUIET                  = YES
 
 # The WARNINGS tag can be used to turn on/off the warning messages that are
 # generated to standard error (stderr) by doxygen. If WARNINGS is set to YES
@@ -765,7 +765,7 @@ WARN_FORMAT            = "$file:$line: $text"
 # messages should be written. If left blank the output is written to standard
 # error (stderr).
 
-WARN_LOGFILE           =
+WARN_LOGFILE           = doxygen.log
 
 #---------------------------------------------------------------------------
 # Configuration options related to the input files

--- a/src/cmake/modules/GUDHI_options.cmake
+++ b/src/cmake/modules/GUDHI_options.cmake
@@ -3,3 +3,12 @@ option(WITH_GUDHI_EXAMPLE "Activate/deactivate examples compilation and installa
 option(WITH_GUDHI_PYTHON "Activate/deactivate python module compilation and installation" ON)
 option(WITH_GUDHI_TEST "Activate/deactivate examples compilation and installation" ON)
 option(WITH_GUDHI_UTILITIES "Activate/deactivate utilities compilation and installation" ON)
+option(WITH_GUDHI_CPP_DOCUMENTATION_ONLY    "Build only the GUDHI C++ documentation (with doxygen)." OFF)
+
+if (WITH_GUDHI_CPP_DOCUMENTATION_ONLY)
+  set (WITH_GUDHI_BENCHMARK OFF)
+  set (WITH_GUDHI_EXAMPLE OFF)
+  set (WITH_GUDHI_PYTHON OFF)
+  set (WITH_GUDHI_TEST OFF)
+  set (WITH_GUDHI_UTILITIES OFF)
+endif()

--- a/src/cmake/modules/GUDHI_options.cmake
+++ b/src/cmake/modules/GUDHI_options.cmake
@@ -3,9 +3,9 @@ option(WITH_GUDHI_EXAMPLE "Activate/deactivate examples compilation and installa
 option(WITH_GUDHI_PYTHON "Activate/deactivate python module compilation and installation" ON)
 option(WITH_GUDHI_TEST "Activate/deactivate examples compilation and installation" ON)
 option(WITH_GUDHI_UTILITIES "Activate/deactivate utilities compilation and installation" ON)
-option(WITH_GUDHI_CPP_DOCUMENTATION_ONLY    "Build only the GUDHI C++ documentation (with doxygen)." OFF)
+option(WITH_GUDHI_THIRD_PARTY "Activate/deactivate third party libraries cmake detection. When set to OFF, it is usefull for doxygen or user_version i.e." ON)
 
-if (WITH_GUDHI_CPP_DOCUMENTATION_ONLY)
+if (NOT WITH_GUDHI_THIRD_PARTY)
   set (WITH_GUDHI_BENCHMARK OFF)
   set (WITH_GUDHI_EXAMPLE OFF)
   set (WITH_GUDHI_PYTHON OFF)

--- a/src/cmake/modules/GUDHI_submodules.cmake
+++ b/src/cmake/modules/GUDHI_submodules.cmake
@@ -1,0 +1,5 @@
+# For those who dislike bundled dependencies, this indicates where to find a preinstalled Hera.
+set(HERA_WASSERSTEIN_INTERNAL_INCLUDE_DIR ${CMAKE_SOURCE_DIR}/ext/hera/wasserstein/include)
+set(HERA_WASSERSTEIN_INCLUDE_DIR ${HERA_WASSERSTEIN_INTERNAL_INCLUDE_DIR} CACHE PATH "Directory where one can find Hera's wasserstein.h")
+set(HERA_BOTTLENECK_INTERNAL_INCLUDE_DIR ${CMAKE_SOURCE_DIR}/ext/hera/bottleneck/include)
+set(HERA_BOTTLENECK_INCLUDE_DIR ${HERA_BOTTLENECK_INTERNAL_INCLUDE_DIR} CACHE PATH "Directory where one can find Hera's bottleneck.h")

--- a/src/cmake/modules/GUDHI_third_party_libraries.cmake
+++ b/src/cmake/modules/GUDHI_third_party_libraries.cmake
@@ -48,12 +48,6 @@ if(CGAL_FOUND)
   include( ${CGAL_USE_FILE} )
 endif()
 
-# For those who dislike bundled dependencies, this indicates where to find a preinstalled Hera.
-set(HERA_WASSERSTEIN_INTERNAL_INCLUDE_DIR ${CMAKE_SOURCE_DIR}/ext/hera/wasserstein/include)
-set(HERA_WASSERSTEIN_INCLUDE_DIR ${HERA_WASSERSTEIN_INTERNAL_INCLUDE_DIR} CACHE PATH "Directory where one can find Hera's wasserstein.h")
-set(HERA_BOTTLENECK_INTERNAL_INCLUDE_DIR ${CMAKE_SOURCE_DIR}/ext/hera/bottleneck/include)
-set(HERA_BOTTLENECK_INCLUDE_DIR ${HERA_BOTTLENECK_INTERNAL_INCLUDE_DIR} CACHE PATH "Directory where one can find Hera's bottleneck.h")
-
 option(WITH_GUDHI_USE_TBB "Build with Intel TBB parallelization" ON)
 
 # Find TBB package for parallel sort - not mandatory, just optional.

--- a/src/common/doc/installation.h
+++ b/src/common/doc/installation.h
@@ -42,8 +42,8 @@ make \endverbatim
  * \verbatim ctest --output-on-failure \endverbatim
  * 
  * \subsection documentationgeneration C++ documentation
- * To generate the C++ documentation, for this the <a target="_blank" href="http://www.doxygen.org/">doxygen</a> program
- * is required, run the following command in a terminal:
+ * To generate the C++ documentation, the <a target="_blank" href="http://www.doxygen.org/">doxygen</a> program
+ * is required. Run the following command in a terminal:
  * \verbatim make doxygen \endverbatim
  * Documentation will be generated in a folder named <code>html</code>.
  *

--- a/src/common/doc/installation.h
+++ b/src/common/doc/installation.h
@@ -43,13 +43,13 @@ make \endverbatim
  * 
  * \subsection documentationgeneration C++ documentation
  * To generate the C++ documentation, the <a target="_blank" href="http://www.doxygen.org/">doxygen</a> program
- * is required. Run the following command in a terminal:
+ * is required (version &ge; 1.9.3 is advised). Run the following command in a terminal:
  * \verbatim make doxygen \endverbatim
  * Documentation will be generated in a folder named <code>html</code>.
  *
  * In case there is not a full setup present and only the documentation should be build the following command sequence
  * can be used:
-\verbatim  cmake -DWITH_GUDHI_CPP_DOCUMENTATION_ONLY=ON ..
+\verbatim  cmake -DWITH_GUDHI_THIRD_PARTY=OFF ..
 make doxygen\endverbatim
  *
  * \subsection helloworld Hello world !


### PR DESCRIPTION
Rework #611 for doxygen only build.
* Update gudhi-deploy submodule
* Warns no more on standard output but in a file
* Also apply the feature for user version also (was missing in previous PR)
* Use new option when only build cpp documentation in CI - useful when performing user version also
* Move new cmake option in the correct file. Disable every option when only build cpp documentation