### PR TITLE
Don't reveal full path in the documentation but just the relative path

### DIFF
--- a/src/Doxyfile.in
+++ b/src/Doxyfile.in
@@ -152,7 +152,7 @@ FULL_PATH_NAMES        = YES
 # will be relative from the directory where doxygen is started.
 # This tag requires that the tag FULL_PATH_NAMES is set to YES.
 
-STRIP_FROM_PATH        =
+STRIP_FROM_PATH        = @CMAKE_SOURCE_DIR@
 
 # The STRIP_FROM_INC_PATH tag can be used to strip a user-defined part of the
 # path mentioned in the documentation of a class, which tells the reader which
@@ -162,7 +162,8 @@ STRIP_FROM_PATH        =
 # using the -I flag.
 
 STRIP_FROM_INC_PATH    = include \
-                         concept
+                         concept \
+                         @CMAKE_SOURCE_DIR@
 
 # If the SHORT_NAMES tag is set to YES, doxygen will generate much shorter (but
 # less readable) file names. This can be useful is your file systems doesn't


### PR DESCRIPTION
In e,g, https://gudhi.inria.fr/doc/latest/struct_coefficient_field.html (in general in `../struct_coefficient_field.html`) we see lines like:
```
#include </home/gailuron/workspace/gudhi/gudhi-devel/build/gudhi.3.5.0/concept/Persistent_cohomology/CoefficientField.h>
```
and
```
The documentation for this struct was generated from the following file:

    /home/gailuron/workspace/gudhi/gudhi-devel/build/gudhi.3.5.0/concept/Persistent_cohomology/CoefficientField.h
```
instead of the relative names:
```
#include <src/Persistent_cohomology/concept/CoefficientField.h>
```
and
```
The documentation for this struct was generated from the following file:

    src/Persistent_cohomology/concept/CoefficientField.h

```

(the links are pointing to the correct places in all cases.)

This is corrected by stripping the path.