### PR TITLE
Compilation warnings fix

### DIFF
--- a/src/Coxeter_triangulation/include/gudhi/Functions/Function_affine_plane_in_Rd.h
+++ b/src/Coxeter_triangulation/include/gudhi/Functions/Function_affine_plane_in_Rd.h
@@ -57,7 +57,7 @@ struct Function_affine_plane_in_Rd {
    * The dimension of the vector should be the ambient dimension of the manifold.
    */
   Function_affine_plane_in_Rd(const Eigen::MatrixXd& normal_matrix, const Eigen::VectorXd& offset)
-      : normal_matrix_(normal_matrix), d_(normal_matrix.rows()), k_(normal_matrix.cols()), m_(d_ - k_), off_(offset) {
+	  : normal_matrix_(normal_matrix), d_(normal_matrix.rows()), k_(normal_matrix.cols()), off_(offset) {
     normal_matrix_.colwise().normalize();
   }
 
@@ -73,14 +73,13 @@ struct Function_affine_plane_in_Rd {
       : normal_matrix_(normal_matrix),
         d_(normal_matrix.rows()),
         k_(normal_matrix.cols()),
-        m_(d_ - k_),
         off_(Eigen::VectorXd::Zero(d_)) {
     normal_matrix_.colwise().normalize();
   }
 
  private:
   Eigen::MatrixXd normal_matrix_;
-  std::size_t d_, k_, m_;
+  std::size_t d_, k_;
   Eigen::VectorXd off_;
 };
 

--- a/src/Coxeter_triangulation/include/gudhi/Functions/Function_affine_plane_in_Rd.h
+++ b/src/Coxeter_triangulation/include/gudhi/Functions/Function_affine_plane_in_Rd.h
@@ -25,63 +25,62 @@ namespace coxeter_triangulation {
  * embedded in d-dimensional Euclidean space.
  */
 struct Function_affine_plane_in_Rd {
-  /**
-   * \brief Value of the function at a specified point.
-   * @param[in] p The input point. The dimension needs to coincide with the ambient dimension.
-   */
-  Eigen::VectorXd operator()(const Eigen::VectorXd& p) const {
-    Eigen::VectorXd result = normal_matrix_.transpose() * (p - off_);
-    return result;
-  }
+	/**
+	 * \brief Value of the function at a specified point.
+	 * @param[in] p The input point. The dimension needs to coincide with the ambient dimension.
+	 */
+	Eigen::VectorXd operator()(const Eigen::VectorXd& p) const {
+		Eigen::VectorXd result = normal_matrix_.transpose() * (p - off_);
+		return result;
+	}
 
-  /** \brief Returns the domain dimension. Same as the ambient dimension of the sphere. */
-  std::size_t amb_d() const { return d_; };
+	/** \brief Returns the domain dimension. Same as the ambient dimension of the sphere. */
+	std::size_t amb_d() const { return d_; };
 
-  /** \brief Returns the codomain dimension. Same as the codimension of the sphere. */
-  std::size_t cod_d() const { return k_; };
+	/** \brief Returns the codomain dimension. Same as the codimension of the sphere. */
+	std::size_t cod_d() const { return k_; };
 
-  /** \brief Returns a point on the affine plane. */
-  Eigen::VectorXd seed() const {
-    Eigen::VectorXd result = off_;
-    return result;
-  }
+	/** \brief Returns a point on the affine plane. */
+	Eigen::VectorXd seed() const {
+		Eigen::VectorXd result = off_;
+		return result;
+	}
 
-  /**
-   * \brief Constructor of the function that defines an m-dimensional implicit affine
-   * plane in the d-dimensional Euclidean space.
-   *
-   * @param[in] normal_matrix A normal matrix of the affine plane. The number of rows should
-   * correspond to the ambient dimension, the number of columns should correspond to
-   * the size of the normal basis (codimension).
-   * @param[in] offset The offset vector of the affine plane.
-   * The dimension of the vector should be the ambient dimension of the manifold.
-   */
-  Function_affine_plane_in_Rd(const Eigen::MatrixXd& normal_matrix, const Eigen::VectorXd& offset)
-      : normal_matrix_(normal_matrix), d_(normal_matrix.rows()), k_(normal_matrix.cols()), m_(d_ - k_), off_(offset) {
-    normal_matrix_.colwise().normalize();
-  }
+	/**
+	 * \brief Constructor of the function that defines an m-dimensional implicit affine
+	 * plane in the d-dimensional Euclidean space.
+	 *
+	 * @param[in] normal_matrix A normal matrix of the affine plane. The number of rows should
+	 * correspond to the ambient dimension, the number of columns should correspond to
+	 * the size of the normal basis (codimension).
+	 * @param[in] offset The offset vector of the affine plane.
+	 * The dimension of the vector should be the ambient dimension of the manifold.
+	 */
+	Function_affine_plane_in_Rd(const Eigen::MatrixXd& normal_matrix, const Eigen::VectorXd& offset)
+		: normal_matrix_(normal_matrix), d_(normal_matrix.rows()), k_(normal_matrix.cols()), off_(offset) {
+		normal_matrix_.colwise().normalize();
+	}
 
-  /**
-   * \brief Constructor of the function that defines an m-dimensional implicit affine
-   * plane in the d-dimensional Euclidean space that passes through origin.
-   *
-   * @param[in] normal_matrix A normal matrix of the affine plane. The number of rows should
-   * correspond to the ambient dimension, the number of columns should correspond to
-   * the size of the normal basis (codimension).
-   */
-  Function_affine_plane_in_Rd(const Eigen::MatrixXd& normal_matrix)
-      : normal_matrix_(normal_matrix),
-        d_(normal_matrix.rows()),
-        k_(normal_matrix.cols()),
-        m_(d_ - k_),
-        off_(Eigen::VectorXd::Zero(d_)) {
-    normal_matrix_.colwise().normalize();
-  }
+	/**
+	 * \brief Constructor of the function that defines an m-dimensional implicit affine
+	 * plane in the d-dimensional Euclidean space that passes through origin.
+	 *
+	 * @param[in] normal_matrix A normal matrix of the affine plane. The number of rows should
+	 * correspond to the ambient dimension, the number of columns should correspond to
+	 * the size of the normal basis (codimension).
+	 */
+	Function_affine_plane_in_Rd(const Eigen::MatrixXd& normal_matrix)
+		: normal_matrix_(normal_matrix),
+		  d_(normal_matrix.rows()),
+		  k_(normal_matrix.cols()),
+		  off_(Eigen::VectorXd::Zero(d_)) {
+		normal_matrix_.colwise().normalize();
+	}
 
- private:
-  Eigen::MatrixXd normal_matrix_;
-  std::size_t d_, k_, m_;
-  Eigen::VectorXd off_;
+private:
+	Eigen::MatrixXd normal_matrix_;
+	std::size_t d_, k_;
+	Eigen::VectorXd off_;
 };
 
 }  // namespace coxeter_triangulation

--- a/src/Coxeter_triangulation/include/gudhi/Functions/Function_affine_plane_in_Rd.h
+++ b/src/Coxeter_triangulation/include/gudhi/Functions/Function_affine_plane_in_Rd.h
@@ -25,62 +25,63 @@ namespace coxeter_triangulation {
  * embedded in d-dimensional Euclidean space.
  */
 struct Function_affine_plane_in_Rd {
-	/**
-	 * \brief Value of the function at a specified point.
-	 * @param[in] p The input point. The dimension needs to coincide with the ambient dimension.
-	 */
-	Eigen::VectorXd operator()(const Eigen::VectorXd& p) const {
-		Eigen::VectorXd result = normal_matrix_.transpose() * (p - off_);
-		return result;
-	}
+  /**
+   * \brief Value of the function at a specified point.
+   * @param[in] p The input point. The dimension needs to coincide with the ambient dimension.
+   */
+  Eigen::VectorXd operator()(const Eigen::VectorXd& p) const {
+    Eigen::VectorXd result = normal_matrix_.transpose() * (p - off_);
+    return result;
+  }
 
-	/** \brief Returns the domain dimension. Same as the ambient dimension of the sphere. */
-	std::size_t amb_d() const { return d_; };
+  /** \brief Returns the domain dimension. Same as the ambient dimension of the sphere. */
+  std::size_t amb_d() const { return d_; };
 
-	/** \brief Returns the codomain dimension. Same as the codimension of the sphere. */
-	std::size_t cod_d() const { return k_; };
+  /** \brief Returns the codomain dimension. Same as the codimension of the sphere. */
+  std::size_t cod_d() const { return k_; };
 
-	/** \brief Returns a point on the affine plane. */
-	Eigen::VectorXd seed() const {
-		Eigen::VectorXd result = off_;
-		return result;
-	}
+  /** \brief Returns a point on the affine plane. */
+  Eigen::VectorXd seed() const {
+    Eigen::VectorXd result = off_;
+    return result;
+  }
 
-	/**
-	 * \brief Constructor of the function that defines an m-dimensional implicit affine
-	 * plane in the d-dimensional Euclidean space.
-	 *
-	 * @param[in] normal_matrix A normal matrix of the affine plane. The number of rows should
-	 * correspond to the ambient dimension, the number of columns should correspond to
-	 * the size of the normal basis (codimension).
-	 * @param[in] offset The offset vector of the affine plane.
-	 * The dimension of the vector should be the ambient dimension of the manifold.
-	 */
-	Function_affine_plane_in_Rd(const Eigen::MatrixXd& normal_matrix, const Eigen::VectorXd& offset)
-		: normal_matrix_(normal_matrix), d_(normal_matrix.rows()), k_(normal_matrix.cols()), off_(offset) {
-		normal_matrix_.colwise().normalize();
-	}
+  /**
+   * \brief Constructor of the function that defines an m-dimensional implicit affine
+   * plane in the d-dimensional Euclidean space.
+   *
+   * @param[in] normal_matrix A normal matrix of the affine plane. The number of rows should
+   * correspond to the ambient dimension, the number of columns should correspond to
+   * the size of the normal basis (codimension).
+   * @param[in] offset The offset vector of the affine plane.
+   * The dimension of the vector should be the ambient dimension of the manifold.
+   */
+  Function_affine_plane_in_Rd(const Eigen::MatrixXd& normal_matrix, const Eigen::VectorXd& offset)
+      : normal_matrix_(normal_matrix), d_(normal_matrix.rows()), k_(normal_matrix.cols()), m_(d_ - k_), off_(offset) {
+    normal_matrix_.colwise().normalize();
+  }
 
-	/**
-	 * \brief Constructor of the function that defines an m-dimensional implicit affine
-	 * plane in the d-dimensional Euclidean space that passes through origin.
-	 *
-	 * @param[in] normal_matrix A normal matrix of the affine plane. The number of rows should
-	 * correspond to the ambient dimension, the number of columns should correspond to
-	 * the size of the normal basis (codimension).
-	 */
-	Function_affine_plane_in_Rd(const Eigen::MatrixXd& normal_matrix)
-		: normal_matrix_(normal_matrix),
-		  d_(normal_matrix.rows()),
-		  k_(normal_matrix.cols()),
-		  off_(Eigen::VectorXd::Zero(d_)) {
-		normal_matrix_.colwise().normalize();
-	}
+  /**
+   * \brief Constructor of the function that defines an m-dimensional implicit affine
+   * plane in the d-dimensional Euclidean space that passes through origin.
+   *
+   * @param[in] normal_matrix A normal matrix of the affine plane. The number of rows should
+   * correspond to the ambient dimension, the number of columns should correspond to
+   * the size of the normal basis (codimension).
+   */
+  Function_affine_plane_in_Rd(const Eigen::MatrixXd& normal_matrix)
+      : normal_matrix_(normal_matrix),
+        d_(normal_matrix.rows()),
+        k_(normal_matrix.cols()),
+        m_(d_ - k_),
+        off_(Eigen::VectorXd::Zero(d_)) {
+    normal_matrix_.colwise().normalize();
+  }
 
-private:
-	Eigen::MatrixXd normal_matrix_;
-	std::size_t d_, k_;
-	Eigen::VectorXd off_;
+ private:
+  Eigen::MatrixXd normal_matrix_;
+  std::size_t d_, k_, m_;
+  Eigen::VectorXd off_;
 };
 
 }  // namespace coxeter_triangulation

--- a/src/Coxeter_triangulation/include/gudhi/Functions/Function_moment_curve_in_Rd.h
+++ b/src/Coxeter_triangulation/include/gudhi/Functions/Function_moment_curve_in_Rd.h
@@ -46,6 +46,11 @@ struct Function_moment_curve_in_Rd {
     return result;
   }
 
+  /** @brief Returns the radius of the moment curve. */
+  double get_radius() const{
+	return r_;
+  }
+
   /**
    * \brief Constructor of the function that defines an implicit moment curve
    * in the d-dimensional Euclidean space.
@@ -53,7 +58,7 @@ struct Function_moment_curve_in_Rd {
    * @param[in] r Numerical parameter.
    * @param[in] d The ambient dimension.
    */
-  Function_moment_curve_in_Rd(double r, std::size_t d) : m_(1), k_(d - 1), d_(d), r_(r) {}
+  Function_moment_curve_in_Rd(double r, std::size_t d) : k_(d - 1), d_(d), r_(r) {}
 
   /**
    * \brief Constructor of the function that defines an implicit moment curve
@@ -64,10 +69,10 @@ struct Function_moment_curve_in_Rd {
    * @param[in] offset The offset of the moment curve.
    */
   Function_moment_curve_in_Rd(double r, std::size_t d, Eigen::VectorXd& offset)
-      : m_(1), k_(d - 1), d_(d), r_(r), off_(offset) {}
+	: k_(d - 1), d_(d), r_(r), off_(offset) {}
 
  private:
-  std::size_t m_, k_, d_;
+  std::size_t k_, d_;
   double r_;
   Eigen::VectorXd off_;
 };

--- a/src/Coxeter_triangulation/include/gudhi/Functions/Function_moment_curve_in_Rd.h
+++ b/src/Coxeter_triangulation/include/gudhi/Functions/Function_moment_curve_in_Rd.h
@@ -25,51 +25,57 @@ namespace coxeter_triangulation {
  * in the d-dimensional Euclidean space.
  */
 struct Function_moment_curve_in_Rd {
-  /** \brief Value of the function at a specified point.
-   * @param[in] p The input point. The dimension needs to coincide with the ambient dimension.
-   */
-  Eigen::VectorXd operator()(const Eigen::VectorXd& p) const {
-    Eigen::VectorXd result(k_);
-    for (std::size_t i = 1; i < d_; ++i) result(i - 1) = p(i) - p(0) * p(i - 1);
-    return result;
-  }
+public:
+	/** \brief Value of the function at a specified point.
+	 * @param[in] p The input point. The dimension needs to coincide with the ambient dimension.
+	 */
+	Eigen::VectorXd operator()(const Eigen::VectorXd& p) const {
+		Eigen::VectorXd result(k_);
+		for (std::size_t i = 1; i < d_; ++i) result(i - 1) = p(i) - p(0) * p(i - 1);
+		return result;
+	}
 
-  /** \brief Returns the domain (ambient) dimension.. */
-  std::size_t amb_d() const { return d_; };
+	/** \brief Returns the domain (ambient) dimension.. */
+	std::size_t amb_d() const { return d_; };
 
-  /** \brief Returns the codomain dimension. */
-  std::size_t cod_d() const { return k_; };
+	/** \brief Returns the codomain dimension. */
+	std::size_t cod_d() const { return k_; };
 
-  /** \brief Returns a point on the moment curve. */
-  Eigen::VectorXd seed() const {
-    Eigen::VectorXd result = Eigen::VectorXd::Zero(d_);
-    return result;
-  }
+	/** \brief Returns a point on the moment curve. */
+	Eigen::VectorXd seed() const {
+		Eigen::VectorXd result = Eigen::VectorXd::Zero(d_);
+		return result;
+	}
 
-  /**
-   * \brief Constructor of the function that defines an implicit moment curve
-   * in the d-dimensional Euclidean space.
-   *
-   * @param[in] r Numerical parameter.
-   * @param[in] d The ambient dimension.
-   */
-  Function_moment_curve_in_Rd(double r, std::size_t d) : m_(1), k_(d - 1), d_(d), r_(r) {}
+	/** @brief Returns the radius of the moment curve. */
+	double get_radius() const{
+		return r_;
+	}
 
-  /**
-   * \brief Constructor of the function that defines an implicit moment curve
-   * in the d-dimensional Euclidean space.
-   *
-   * @param[in] r Numerical parameter.
-   * @param[in] d The ambient dimension.
-   * @param[in] offset The offset of the moment curve.
-   */
-  Function_moment_curve_in_Rd(double r, std::size_t d, Eigen::VectorXd& offset)
-      : m_(1), k_(d - 1), d_(d), r_(r), off_(offset) {}
+	/**
+	 * \brief Constructor of the function that defines an implicit moment curve
+	 * in the d-dimensional Euclidean space.
+	 *
+	 * @param[in] r Numerical parameter.
+	 * @param[in] d The ambient dimension.
+	 */
+	Function_moment_curve_in_Rd(double r, std::size_t d) : k_(d - 1), d_(d), r_(r) {}
 
- private:
-  std::size_t m_, k_, d_;
-  double r_;
-  Eigen::VectorXd off_;
+	/**
+	 * \brief Constructor of the function that defines an implicit moment curve
+	 * in the d-dimensional Euclidean space.
+	 *
+	 * @param[in] r Numerical parameter.
+	 * @param[in] d The ambient dimension.
+	 * @param[in] offset The offset of the moment curve.
+	 */
+	Function_moment_curve_in_Rd(double r, std::size_t d, Eigen::VectorXd& offset)
+		: k_(d - 1), d_(d), r_(r), off_(offset) {}
+
+private:
+	std::size_t k_, d_;
+	double r_;
+	Eigen::VectorXd off_;
 };
 
 }  // namespace coxeter_triangulation

--- a/src/Coxeter_triangulation/include/gudhi/Functions/Function_moment_curve_in_Rd.h
+++ b/src/Coxeter_triangulation/include/gudhi/Functions/Function_moment_curve_in_Rd.h
@@ -25,57 +25,51 @@ namespace coxeter_triangulation {
  * in the d-dimensional Euclidean space.
  */
 struct Function_moment_curve_in_Rd {
-public:
-	/** \brief Value of the function at a specified point.
-	 * @param[in] p The input point. The dimension needs to coincide with the ambient dimension.
-	 */
-	Eigen::VectorXd operator()(const Eigen::VectorXd& p) const {
-		Eigen::VectorXd result(k_);
-		for (std::size_t i = 1; i < d_; ++i) result(i - 1) = p(i) - p(0) * p(i - 1);
-		return result;
-	}
+  /** \brief Value of the function at a specified point.
+   * @param[in] p The input point. The dimension needs to coincide with the ambient dimension.
+   */
+  Eigen::VectorXd operator()(const Eigen::VectorXd& p) const {
+    Eigen::VectorXd result(k_);
+    for (std::size_t i = 1; i < d_; ++i) result(i - 1) = p(i) - p(0) * p(i - 1);
+    return result;
+  }
 
-	/** \brief Returns the domain (ambient) dimension.. */
-	std::size_t amb_d() const { return d_; };
+  /** \brief Returns the domain (ambient) dimension.. */
+  std::size_t amb_d() const { return d_; };
 
-	/** \brief Returns the codomain dimension. */
-	std::size_t cod_d() const { return k_; };
+  /** \brief Returns the codomain dimension. */
+  std::size_t cod_d() const { return k_; };
 
-	/** \brief Returns a point on the moment curve. */
-	Eigen::VectorXd seed() const {
-		Eigen::VectorXd result = Eigen::VectorXd::Zero(d_);
-		return result;
-	}
+  /** \brief Returns a point on the moment curve. */
+  Eigen::VectorXd seed() const {
+    Eigen::VectorXd result = Eigen::VectorXd::Zero(d_);
+    return result;
+  }
 
-	/** @brief Returns the radius of the moment curve. */
-	double get_radius() const{
-		return r_;
-	}
+  /**
+   * \brief Constructor of the function that defines an implicit moment curve
+   * in the d-dimensional Euclidean space.
+   *
+   * @param[in] r Numerical parameter.
+   * @param[in] d The ambient dimension.
+   */
+  Function_moment_curve_in_Rd(double r, std::size_t d) : m_(1), k_(d - 1), d_(d), r_(r) {}
 
-	/**
-	 * \brief Constructor of the function that defines an implicit moment curve
-	 * in the d-dimensional Euclidean space.
-	 *
-	 * @param[in] r Numerical parameter.
-	 * @param[in] d The ambient dimension.
-	 */
-	Function_moment_curve_in_Rd(double r, std::size_t d) : k_(d - 1), d_(d), r_(r) {}
+  /**
+   * \brief Constructor of the function that defines an implicit moment curve
+   * in the d-dimensional Euclidean space.
+   *
+   * @param[in] r Numerical parameter.
+   * @param[in] d The ambient dimension.
+   * @param[in] offset The offset of the moment curve.
+   */
+  Function_moment_curve_in_Rd(double r, std::size_t d, Eigen::VectorXd& offset)
+      : m_(1), k_(d - 1), d_(d), r_(r), off_(offset) {}
 
-	/**
-	 * \brief Constructor of the function that defines an implicit moment curve
-	 * in the d-dimensional Euclidean space.
-	 *
-	 * @param[in] r Numerical parameter.
-	 * @param[in] d The ambient dimension.
-	 * @param[in] offset The offset of the moment curve.
-	 */
-	Function_moment_curve_in_Rd(double r, std::size_t d, Eigen::VectorXd& offset)
-		: k_(d - 1), d_(d), r_(r), off_(offset) {}
-
-private:
-	std::size_t k_, d_;
-	double r_;
-	Eigen::VectorXd off_;
+ private:
+  std::size_t m_, k_, d_;
+  double r_;
+  Eigen::VectorXd off_;
 };
 
 }  // namespace coxeter_triangulation

--- a/src/Coxeter_triangulation/include/gudhi/Permutahedral_representation/Integer_combination_iterator.h
+++ b/src/Coxeter_triangulation/include/gudhi/Permutahedral_representation/Integer_combination_iterator.h
@@ -68,7 +68,7 @@ class Integer_combination_iterator
  public:
   template <class Bound_range>
   Integer_combination_iterator(const uint& n, const uint& k, const Bound_range& bounds)
-      : value_(k + 2), is_end_(n == 0 || k == 0), n_(n), k_(k) {
+	  : value_(k + 2), is_end_(n == 0 || k == 0), k_(k) {
     bounds_.reserve(k + 2);
     uint sum_radices = 0;
     for (auto b : bounds) {
@@ -96,13 +96,12 @@ class Integer_combination_iterator
   }
 
   // Used for the creating an end iterator
-  Integer_combination_iterator() : is_end_(true), n_(0), k_(0) {}
+  Integer_combination_iterator() : is_end_(true), k_(0) {}
 
  private:
   value_t value_;  // the dereference value
   bool is_end_;    // is true when the current integer combination is the final one
 
-  uint n_;
   uint k_;
   std::vector<uint> bounds_;
 };

--- a/src/Coxeter_triangulation/include/gudhi/Permutahedral_representation/Integer_combination_iterator.h
+++ b/src/Coxeter_triangulation/include/gudhi/Permutahedral_representation/Integer_combination_iterator.h
@@ -25,85 +25,86 @@ typedef unsigned uint;
  *  Based on the algorithm by Mifsud.
  */
 class Integer_combination_iterator
-		: public boost::iterator_facade<Integer_combination_iterator, std::vector<uint> const,
-		boost::forward_traversal_tag> {
-	using value_t = std::vector<uint>;
+    : public boost::iterator_facade<Integer_combination_iterator, std::vector<uint> const,
+                                    boost::forward_traversal_tag> {
+  using value_t = std::vector<uint>;
 
-private:
-	friend class boost::iterator_core_access;
+ private:
+  friend class boost::iterator_core_access;
 
-	bool equal(Integer_combination_iterator const& other) const { return (is_end_ && other.is_end_); }
+  bool equal(Integer_combination_iterator const& other) const { return (is_end_ && other.is_end_); }
 
-	value_t const& dereference() const { return value_; }
+  value_t const& dereference() const { return value_; }
 
-	void increment() {
-		uint j1 = 0;
-		uint s = 0;
-		while (value_[j1] == 0 && j1 < k_) j1++;
-		uint j2 = j1 + 1;
-		while (value_[j2] == bounds_[j2]) {
-			if (bounds_[j2] != 0) {
-				s += value_[j1];
-				value_[j1] = 0;
-				j1 = j2;
-			}
-			j2++;
-		}
-		if (j2 >= k_) {
-			is_end_ = true;
-			return;
-		}
-		s += value_[j1] - 1;
-		value_[j1] = 0;
-		value_[j2]++;
-		uint i = 0;
-		while (s >= bounds_[i]) {
-			value_[i] = bounds_[i];
-			s -= bounds_[i];
-			i++;
-		}
-		value_[i++] = s;
-	}
+  void increment() {
+    uint j1 = 0;
+    uint s = 0;
+    while (value_[j1] == 0 && j1 < k_) j1++;
+    uint j2 = j1 + 1;
+    while (value_[j2] == bounds_[j2]) {
+      if (bounds_[j2] != 0) {
+        s += value_[j1];
+        value_[j1] = 0;
+        j1 = j2;
+      }
+      j2++;
+    }
+    if (j2 >= k_) {
+      is_end_ = true;
+      return;
+    }
+    s += value_[j1] - 1;
+    value_[j1] = 0;
+    value_[j2]++;
+    uint i = 0;
+    while (s >= bounds_[i]) {
+      value_[i] = bounds_[i];
+      s -= bounds_[i];
+      i++;
+    }
+    value_[i++] = s;
+  }
 
-public:
-	template <class Bound_range>
-	Integer_combination_iterator(const uint& n, const uint& k, const Bound_range& bounds)
-		: value_(k + 2), is_end_(n == 0 || k == 0), k_(k) {
-		bounds_.reserve(k + 2);
-		uint sum_radices = 0;
-		for (auto b : bounds) {
-			bounds_.push_back(b);
-			sum_radices += b;
-		}
-		bounds_.push_back(2);
-		bounds_.push_back(1);
-		if (n > sum_radices) {
-			is_end_ = true;
-			return;
-		}
-		uint i = 0;
-		uint s = n;
-		while (s >= bounds_[i]) {
-			value_[i] = bounds_[i];
-			s -= bounds_[i];
-			i++;
-		}
-		value_[i++] = s;
+ public:
+  template <class Bound_range>
+  Integer_combination_iterator(const uint& n, const uint& k, const Bound_range& bounds)
+      : value_(k + 2), is_end_(n == 0 || k == 0), n_(n), k_(k) {
+    bounds_.reserve(k + 2);
+    uint sum_radices = 0;
+    for (auto b : bounds) {
+      bounds_.push_back(b);
+      sum_radices += b;
+    }
+    bounds_.push_back(2);
+    bounds_.push_back(1);
+    if (n > sum_radices) {
+      is_end_ = true;
+      return;
+    }
+    uint i = 0;
+    uint s = n;
+    while (s >= bounds_[i]) {
+      value_[i] = bounds_[i];
+      s -= bounds_[i];
+      i++;
+    }
+    value_[i++] = s;
 
-		while (i < k_) value_[i++] = 0;
-		value_[k] = 1;
-		value_[k + 1] = 0;
-	}
+    while (i < k_) value_[i++] = 0;
+    value_[k] = 1;
+    value_[k + 1] = 0;
+  }
 
-	// Used for the creating an end iterator
-	Integer_combination_iterator() : is_end_(true), k_(0) {}
+  // Used for the creating an end iterator
+  Integer_combination_iterator() : is_end_(true), n_(0), k_(0) {}
 
-private:
-	value_t value_;  // the dereference value
-	bool is_end_;    // is true when the current integer combination is the final one
+ private:
+  value_t value_;  // the dereference value
+  bool is_end_;    // is true when the current integer combination is the final one
 
-	uint k_;
-	std::vector<uint> bounds_;
+  uint n_;
+  uint k_;
+  std::vector<uint> bounds_;
 };
 
 }  // namespace coxeter_triangulation

--- a/src/Coxeter_triangulation/include/gudhi/Permutahedral_representation/Integer_combination_iterator.h
+++ b/src/Coxeter_triangulation/include/gudhi/Permutahedral_representation/Integer_combination_iterator.h
@@ -25,86 +25,85 @@ typedef unsigned uint;
  *  Based on the algorithm by Mifsud.
  */
 class Integer_combination_iterator
-    : public boost::iterator_facade<Integer_combination_iterator, std::vector<uint> const,
-                                    boost::forward_traversal_tag> {
-  using value_t = std::vector<uint>;
+		: public boost::iterator_facade<Integer_combination_iterator, std::vector<uint> const,
+		boost::forward_traversal_tag> {
+	using value_t = std::vector<uint>;
 
- private:
-  friend class boost::iterator_core_access;
+private:
+	friend class boost::iterator_core_access;
 
-  bool equal(Integer_combination_iterator const& other) const { return (is_end_ && other.is_end_); }
+	bool equal(Integer_combination_iterator const& other) const { return (is_end_ && other.is_end_); }
 
-  value_t const& dereference() const { return value_; }
+	value_t const& dereference() const { return value_; }
 
-  void increment() {
-    uint j1 = 0;
-    uint s = 0;
-    while (value_[j1] == 0 && j1 < k_) j1++;
-    uint j2 = j1 + 1;
-    while (value_[j2] == bounds_[j2]) {
-      if (bounds_[j2] != 0) {
-        s += value_[j1];
-        value_[j1] = 0;
-        j1 = j2;
-      }
-      j2++;
-    }
-    if (j2 >= k_) {
-      is_end_ = true;
-      return;
-    }
-    s += value_[j1] - 1;
-    value_[j1] = 0;
-    value_[j2]++;
-    uint i = 0;
-    while (s >= bounds_[i]) {
-      value_[i] = bounds_[i];
-      s -= bounds_[i];
-      i++;
-    }
-    value_[i++] = s;
-  }
+	void increment() {
+		uint j1 = 0;
+		uint s = 0;
+		while (value_[j1] == 0 && j1 < k_) j1++;
+		uint j2 = j1 + 1;
+		while (value_[j2] == bounds_[j2]) {
+			if (bounds_[j2] != 0) {
+				s += value_[j1];
+				value_[j1] = 0;
+				j1 = j2;
+			}
+			j2++;
+		}
+		if (j2 >= k_) {
+			is_end_ = true;
+			return;
+		}
+		s += value_[j1] - 1;
+		value_[j1] = 0;
+		value_[j2]++;
+		uint i = 0;
+		while (s >= bounds_[i]) {
+			value_[i] = bounds_[i];
+			s -= bounds_[i];
+			i++;
+		}
+		value_[i++] = s;
+	}
 
- public:
-  template <class Bound_range>
-  Integer_combination_iterator(const uint& n, const uint& k, const Bound_range& bounds)
-      : value_(k + 2), is_end_(n == 0 || k == 0), n_(n), k_(k) {
-    bounds_.reserve(k + 2);
-    uint sum_radices = 0;
-    for (auto b : bounds) {
-      bounds_.push_back(b);
-      sum_radices += b;
-    }
-    bounds_.push_back(2);
-    bounds_.push_back(1);
-    if (n > sum_radices) {
-      is_end_ = true;
-      return;
-    }
-    uint i = 0;
-    uint s = n;
-    while (s >= bounds_[i]) {
-      value_[i] = bounds_[i];
-      s -= bounds_[i];
-      i++;
-    }
-    value_[i++] = s;
+public:
+	template <class Bound_range>
+	Integer_combination_iterator(const uint& n, const uint& k, const Bound_range& bounds)
+		: value_(k + 2), is_end_(n == 0 || k == 0), k_(k) {
+		bounds_.reserve(k + 2);
+		uint sum_radices = 0;
+		for (auto b : bounds) {
+			bounds_.push_back(b);
+			sum_radices += b;
+		}
+		bounds_.push_back(2);
+		bounds_.push_back(1);
+		if (n > sum_radices) {
+			is_end_ = true;
+			return;
+		}
+		uint i = 0;
+		uint s = n;
+		while (s >= bounds_[i]) {
+			value_[i] = bounds_[i];
+			s -= bounds_[i];
+			i++;
+		}
+		value_[i++] = s;
 
-    while (i < k_) value_[i++] = 0;
-    value_[k] = 1;
-    value_[k + 1] = 0;
-  }
+		while (i < k_) value_[i++] = 0;
+		value_[k] = 1;
+		value_[k + 1] = 0;
+	}
 
-  // Used for the creating an end iterator
-  Integer_combination_iterator() : is_end_(true), n_(0), k_(0) {}
+	// Used for the creating an end iterator
+	Integer_combination_iterator() : is_end_(true), k_(0) {}
 
- private:
-  value_t value_;  // the dereference value
-  bool is_end_;    // is true when the current integer combination is the final one
+private:
+	value_t value_;  // the dereference value
+	bool is_end_;    // is true when the current integer combination is the final one
 
-  uint n_;
-  uint k_;
-  std::vector<uint> bounds_;
+	uint k_;
+	std::vector<uint> bounds_;
 };
 
 }  // namespace coxeter_triangulation

--- a/src/Persistence_representations/test/persistence_heat_maps_test.cpp
+++ b/src/Persistence_representations/test/persistence_heat_maps_test.cpp
@@ -78,7 +78,7 @@ BOOST_AUTO_TEST_CASE(check_compute_percentage_of_active_of_heat_maps) {
   to_compute_percentage_of_active.push_back(&q);
   to_compute_percentage_of_active.push_back(&r);
   Persistence_heat_maps<constant_scaling_function> percentage_of_active;
-  percentage_of_active.compute_percentage_of_active(to_compute_percentage_of_active, 0.1);
+  percentage_of_active.compute_percentage_of_active(to_compute_percentage_of_active, 0);
 
   Persistence_heat_maps<constant_scaling_function> template_percentage_of_active;
   template_percentage_of_active.load_from_file("data/template_percentage_of_active_of_heat_maps");

--- a/src/Simplex_tree/test/simplex_tree_ctor_and_move_unit_test.cpp
+++ b/src/Simplex_tree/test/simplex_tree_ctor_and_move_unit_test.cpp
@@ -98,8 +98,16 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(simplex_copy_constructor, Simplex_tree, list_of_te
   BOOST_CHECK(st == st4);
   BOOST_CHECK(st3 == st);
 
+#ifdef __clang__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wself-assign-overloaded"
+#endif
   st = st;
-  print_simplex_filtration(st4, "Third self copy assignment from the default Simplex_tree");
+#ifdef __clang__
+#pragma GCC diagnostic pop
+#endif
+
+  print_simplex_filtration(st, "Third self copy assignment from the default Simplex_tree");
 
   BOOST_CHECK(st3 == st);
 

--- a/src/Skeleton_blocker/include/gudhi/Skeleton_blocker/internal/Trie.h
+++ b/src/Skeleton_blocker/include/gudhi/Skeleton_blocker/internal/Trie.h
@@ -150,7 +150,7 @@ struct Trie {
     ++s_pos;
     while (s_pos != s.end() && current != 0) {
       bool found = false;
-      for (const auto child : current->childs) {
+	  for (const auto& child : current->childs) {
         if (child->v == *s_pos) {
           ++s_pos;
           current = child.get();

--- a/src/Skeleton_blocker/include/gudhi/Skeleton_blocker_simplifiable_complex.h
+++ b/src/Skeleton_blocker/include/gudhi/Skeleton_blocker_simplifiable_complex.h
@@ -267,7 +267,7 @@ void Skeleton_blocker_complex<SkeletonBlockerDS>::remove_blocker_include_in_simp
 template<typename SkeletonBlockerDS>
 void Skeleton_blocker_complex<SkeletonBlockerDS>::tip_blockers(Vertex_handle a, Vertex_handle b,
                                                                std::vector<Simplex> & buffer) const {
-  for (auto const & blocker : this->const_blocker_range(a)) {
+  for (auto const blocker : this->const_blocker_range(a)) {
     Simplex beta = (*blocker);
     beta.remove_vertex(a);
     buffer.push_back(beta);


### PR DESCRIPTION
Just very small changes to fix the warnings while compilation. There also were a lot of boost warnings about deprecated headers, but they fixed them-selves when I installed the latest boost version (1.80).