### PR TITLE
c++17 as a new standard to compile the library

### DIFF
--- a/.github/next_release.md
+++ b/.github/next_release.md
@@ -9,8 +9,8 @@ Below is a list of changes made since GUDHI 3.6.0:
 - [Module](link)
      - ...
 
-- [Module](link)
-     - ...
+- Installation
+     - c++17 is the new minimal standard to compile the library. This implies Visual Studio minimal version is now 2017.
 
 - Miscellaneous
      - The [list of bugs that were solved since GUDHI-3.6.0](https://github.com/GUDHI/gudhi-devel/issues?q=label%3A3.7.0+is%3Aclosed) is available on GitHub.

--- a/src/Tangential_complex/benchmark/XML_exporter.h
+++ b/src/Tangential_complex/benchmark/XML_exporter.h
@@ -157,7 +157,7 @@ class Streaming_XML_exporter {
       m_xml_fstream << "  </" << m_element_name << ">" << std::endl;
 
       // Save current pointer position
-      std::ofstream::streampos pos = m_xml_fstream.tellp();
+      auto pos = m_xml_fstream.tellp();
       // Close the XML file (temporarily) so that the XML file is always correct
       m_xml_fstream << "</" << m_list_name << ">" << std::endl;
       // Restore the pointer position so that the next "add_element" will overwrite

--- a/src/cmake/modules/GUDHI_compilation_flags.cmake
+++ b/src/cmake/modules/GUDHI_compilation_flags.cmake
@@ -11,7 +11,7 @@ macro(add_cxx_compiler_flag _flag)
   endif()
 endmacro()
 
-set (CMAKE_CXX_STANDARD 14)
+set (CMAKE_CXX_STANDARD 17)
 
 enable_testing()
 

--- a/src/common/doc/installation.h
+++ b/src/common/doc/installation.h
@@ -5,9 +5,9 @@
  * Examples of GUDHI headers inclusion can be found in \ref utilities.
  * 
  * \section compiling Compiling
- * The library uses c++14 and requires <a target="_blank" href="https://www.boost.org/">Boost</a>  &ge; 1.66.0
+ * The library uses c++17 and requires <a target="_blank" href="https://www.boost.org/">Boost</a>  &ge; 1.66.0
  * and <a target="_blank" href="https://cmake.org/">CMake</a> &ge; 3.5.
- * It is a multi-platform library and compiles on Linux, Mac OSX and Visual Studio 2015.
+ * It is a multi-platform library and compiles on Linux, Mac OSX and Visual Studio 2017.
  * 
  * \subsection utilities Utilities and examples
  * To build the utilities, run the following commands in a terminal:

--- a/src/python/doc/installation.rst
+++ b/src/python/doc/installation.rst
@@ -39,7 +39,7 @@ If you are instead using a git checkout, beware that the paths are a bit
 different, and in particular the `python/` subdirectory is actually `src/python/`
 there.
 
-The library uses c++14 and requires `Boost <https://www.boost.org/>`_ :math:`\geq` 1.66.0,
+The library uses c++17 and requires `Boost <https://www.boost.org/>`_ :math:`\geq` 1.66.0,
 `CMake <https://www.cmake.org/>`_ :math:`\geq` 3.5  to generate makefiles,
 Python :math:`\geq` 3.5, `NumPy <http://numpy.org>`_ :math:`\geq` 1.15.0, `Cython <https://www.cython.org/>`_
 :math:`\geq` 0.27 and `pybind11 <https://github.com/pybind/pybind11>`_ to compile the GUDHI Python module.


### PR DESCRIPTION
Update also the installation manual as Visual Studio 2017 is also required.
Fix compilation error in tangential benchmark as std::ofstream::streampos seems deprecated with c++17.