### PR TITLE
Some doxygen details

### DIFF
--- a/src/Doxyfile.in
+++ b/src/Doxyfile.in
@@ -1143,6 +1143,11 @@ HTML_EXTRA_STYLESHEET  = @GUDHI_DOXYGEN_COMMON_DOC_PATH@/stylesheet.css
 
 HTML_EXTRA_FILES       =
 
+# Default here is AUTO_LIGHT which means "Automatically set the mode according
+# to the user preference, use light mode if no preference is set".
+# Force it to LIGHT (white), as the rest of the documentation is white.
+HTML_COLORSTYLE        = LIGHT
+
 # The HTML_COLORSTYLE_HUE tag controls the color of the HTML output. Doxygen
 # will adjust the colors in the style sheet and background images according to
 # this color. Hue is specified as an angle on a colorwheel, see

--- a/src/common/doc/installation.h
+++ b/src/common/doc/installation.h
@@ -45,7 +45,7 @@ make \endverbatim
  * 
  * \subsection documentationgeneration C++ documentation
  * To generate the C++ documentation, the <a target="_blank" href="http://www.doxygen.org/">doxygen</a> program
- * is required (version &ge; 1.9.3 is advised). Run the following command in a terminal:
+ * is required (version &ge; 1.9.5 is advised). Run the following command in a terminal:
  * \verbatim make doxygen \endverbatim
  * Documentation will be generated in a folder named <code>html</code>.
  *


### PR DESCRIPTION
As explained on #673 it is advised to use doxygen 1.9.5 and to force `HTML_COLORSTYLE        = LIGHT` as default depends on user preferences