### PR TITLE
Fix badly centered barcode

### DIFF
--- a/src/python/gudhi/persistence_graphical_tools.py
+++ b/src/python/gudhi/persistence_graphical_tools.py
@@ -194,19 +194,21 @@ def plot_persistence_barcode(
         y=[(death - birth) if death != float("inf") else (infinity - birth) for (dim,(birth,death)) in persistence]
         c=[colormap[dim] for (dim,(birth,death)) in persistence]
 
-        axes.barh(list(reversed(range(len(x)))), y, height=0.8, left=x, alpha=alpha, color=c, linewidth=0)
+        axes.barh(range(len(x)), y, left=x, alpha=alpha, color=c, linewidth=0)
 
         if legend:
-            dimensions = list(set(item[0] for item in persistence))
+            dimensions = set(item[0] for item in persistence)
             axes.legend(
                 handles=[mpatches.Patch(color=colormap[dim], label=str(dim)) for dim in dimensions], loc="lower right",
             )
 
         axes.set_title("Persistence barcode", fontsize=fontsize)
+        axes.set_yticks([])
+        axes.invert_yaxis()
 
         # Ends plot on infinity value and starts a little bit before min_birth
         if len(x) != 0:
-            axes.axis([axis_start, infinity, 0, len(x)])
+            axes.set_xlim((axis_start, infinity))
         return axes
 
     except ImportError as import_error:


### PR DESCRIPTION
Fix #685.
The main issue was the line
```python
axes.axis([axis_start, infinity, 0, len(x)])
```
which sets bogus bounds for the y axis. It should go roughly from `-.5` to `len(x)-.5` (or the bars should be aligned differently), but it seems easier to let matplotlib handle this axis automatically (with many bars, the automatic setting leaves much more white at the top and bottom, while the manual setting would let the bars touch the border, so it isn't equivalent)
Other changes are suggestions. I removed the labels on the y axis because seeing `0.25` made no sense, but `axes.yaxis.get_major_locator().set_params(integer=True)` would be another way to handle that.
Not tested much.