### PR TITLE
Bottleneck distance issue #701 fix

### DIFF
--- a/src/Bottleneck_distance/include/gudhi/Persistence_graph.h
+++ b/src/Bottleneck_distance/include/gudhi/Persistence_graph.h
@@ -20,6 +20,7 @@
 #include <vector>
 #include <algorithm>
 #include <limits>  // for numeric_limits
+#include <cmath>
 
 namespace Gudhi {
 
@@ -70,27 +71,51 @@ Persistence_graph::Persistence_graph(const Persistence_diagram1 &diag1,
     : u(), v(), b_alive(0.) {
   std::vector<double> u_alive;
   std::vector<double> v_alive;
+  std::vector<double> u_nalive;
+  std::vector<double> v_nalive;
+  int u_inf = 0;
+  int v_inf = 0;
+  double inf = std::numeric_limits<double>::infinity();
+  double neginf = -1 * inf;
+
   for (auto it = std::begin(diag1); it != std::end(diag1); ++it) {
-    if (std::get<1>(*it) == std::numeric_limits<double>::infinity())
-      u_alive.push_back(std::get<0>(*it));
-    else if (std::get<1>(*it) - std::get<0>(*it) > e)
-      u.push_back(Internal_point(std::get<0>(*it), std::get<1>(*it), u.size()));
+	if (std::get<0>(*it) != inf && std::get<1>(*it) != neginf){
+	  if (std::get<0>(*it) == neginf && std::get<1>(*it) == inf)
+		u_inf++;
+	  else if (std::get<0>(*it) == neginf)
+		u_nalive.push_back(std::get<1>(*it));
+	  else if (std::get<1>(*it) == inf)
+		u_alive.push_back(std::get<0>(*it));
+	  else if (std::get<1>(*it) - std::get<0>(*it) > e)
+		u.push_back(Internal_point(std::get<0>(*it), std::get<1>(*it), u.size()));
+	}
   }
   for (auto it = std::begin(diag2); it != std::end(diag2); ++it) {
-    if (std::get<1>(*it) == std::numeric_limits<double>::infinity())
-      v_alive.push_back(std::get<0>(*it));
-    else if (std::get<1>(*it) - std::get<0>(*it) > e)
-      v.push_back(Internal_point(std::get<0>(*it), std::get<1>(*it), v.size()));
+	if (std::get<0>(*it) != inf && std::get<1>(*it) != neginf){
+	  if (std::get<0>(*it) == neginf && std::get<1>(*it) == inf)
+		v_inf++;
+	  else if (std::get<0>(*it) == neginf)
+		v_nalive.push_back(std::get<1>(*it));
+	  else if (std::get<1>(*it) == inf)
+		v_alive.push_back(std::get<0>(*it));
+	  else if (std::get<1>(*it) - std::get<0>(*it) > e)
+		v.push_back(Internal_point(std::get<0>(*it), std::get<1>(*it), v.size()));
+	}
   }
   if (u.size() < v.size())
     swap(u, v);
-  std::sort(u_alive.begin(), u_alive.end());
-  std::sort(v_alive.begin(), v_alive.end());
-  if (u_alive.size() != v_alive.size()) {
+
+  if (u_alive.size() != v_alive.size() || u_nalive.size() != v_nalive.size() || u_inf != v_inf) {
     b_alive = std::numeric_limits<double>::infinity();
   } else {
+	std::sort(u_alive.begin(), u_alive.end());
+	std::sort(v_alive.begin(), v_alive.end());
+	std::sort(u_nalive.begin(), u_nalive.end());
+	std::sort(v_nalive.begin(), v_nalive.end());
     for (auto it_u = u_alive.cbegin(), it_v = v_alive.cbegin(); it_u != u_alive.cend(); ++it_u, ++it_v)
       b_alive = (std::max)(b_alive, std::fabs(*it_u - *it_v));
+	for (auto it_u = u_nalive.cbegin(), it_v = v_nalive.cbegin(); it_u != u_nalive.cend(); ++it_u, ++it_v)
+	  b_alive = (std::max)(b_alive, std::fabs(*it_u - *it_v));
   }
 }
 
@@ -114,7 +139,7 @@ inline int Persistence_graph::corresponding_point_in_v(int u_point_index) const 
 
 inline double Persistence_graph::distance(int u_point_index, int v_point_index) const {
   if (on_the_u_diagonal(u_point_index) && on_the_v_diagonal(v_point_index))
-    return 0.;
+	return 0.;
   Internal_point p_u = get_u_point(u_point_index);
   Internal_point p_v = get_v_point(v_point_index);
   return (std::max)(std::fabs(p_u.x() - p_v.x()), std::fabs(p_u.y() - p_v.y()));
@@ -132,9 +157,9 @@ inline std::vector<double> Persistence_graph::sorted_distances() const {
   std::vector<double> distances;
   distances.push_back(0.);  // for empty diagrams
   for (int u_point_index = 0; u_point_index < size(); ++u_point_index) {
-    distances.push_back(distance(u_point_index, corresponding_point_in_v(u_point_index)));
-    for (int v_point_index = 0; v_point_index < size(); ++v_point_index)
-      distances.push_back(distance(u_point_index, v_point_index));
+	distances.push_back(distance(u_point_index, corresponding_point_in_v(u_point_index)));
+	for (int v_point_index = 0; v_point_index < size(); ++v_point_index)
+	  distances.push_back(distance(u_point_index, v_point_index));
   }
 #ifdef GUDHI_USE_TBB
   tbb::parallel_sort(distances.begin(), distances.end());
@@ -146,7 +171,7 @@ inline std::vector<double> Persistence_graph::sorted_distances() const {
 
 inline Internal_point Persistence_graph::get_u_point(int u_point_index) const {
   if (!on_the_u_diagonal(u_point_index))
-    return u.at(u_point_index);
+	return u.at(u_point_index);
   Internal_point projector = v.at(corresponding_point_in_v(u_point_index));
   double m = (projector.x() + projector.y()) / 2.;
   return Internal_point(m, m, u_point_index);

--- a/src/Bottleneck_distance/include/gudhi/Persistence_graph.h
+++ b/src/Bottleneck_distance/include/gudhi/Persistence_graph.h
@@ -76,7 +76,7 @@ Persistence_graph::Persistence_graph(const Persistence_diagram1 &diag1,
   int u_inf = 0;
   int v_inf = 0;
   double inf = std::numeric_limits<double>::infinity();
-  double neginf = -1 * inf;
+  double neginf = -inf;
 
   for (auto it = std::begin(diag1); it != std::end(diag1); ++it) {
 	if (std::get<0>(*it) != inf && std::get<1>(*it) != neginf){

--- a/src/Bottleneck_distance/include/gudhi/Persistence_graph.h
+++ b/src/Bottleneck_distance/include/gudhi/Persistence_graph.h
@@ -32,7 +32,7 @@ namespace persistence_diagram {
  * \ingroup bottleneck_distance
  */
 class Persistence_graph {
- public:
+public:
   /** \internal \brief Constructor taking 2 PersistenceDiagrams (concept) as parameters. */
   template<typename Persistence_diagram1, typename Persistence_diagram2>
   Persistence_graph(const Persistence_diagram1& diag1, const Persistence_diagram2& diag2, double e);
@@ -59,7 +59,7 @@ class Persistence_graph {
   /** \internal \brief Returns the corresponding internal point */
   Internal_point get_v_point(int v_point_index) const;
 
- private:
+private:
   std::vector<Internal_point> u;
   std::vector<Internal_point> v;
   double b_alive;
@@ -68,7 +68,7 @@ class Persistence_graph {
 template<typename Persistence_diagram1, typename Persistence_diagram2>
 Persistence_graph::Persistence_graph(const Persistence_diagram1 &diag1,
                                      const Persistence_diagram2 &diag2, double e)
-    : u(), v(), b_alive(0.) {
+  : u(), v(), b_alive(0.) {
   std::vector<double> u_alive;
   std::vector<double> v_alive;
   std::vector<double> u_nalive;
@@ -79,28 +79,28 @@ Persistence_graph::Persistence_graph(const Persistence_diagram1 &diag1,
   double neginf = -inf;
 
   for (auto it = std::begin(diag1); it != std::end(diag1); ++it) {
-	if (std::get<0>(*it) != inf && std::get<1>(*it) != neginf){
-	  if (std::get<0>(*it) == neginf && std::get<1>(*it) == inf)
-		u_inf++;
-	  else if (std::get<0>(*it) == neginf)
-		u_nalive.push_back(std::get<1>(*it));
-	  else if (std::get<1>(*it) == inf)
-		u_alive.push_back(std::get<0>(*it));
-	  else if (std::get<1>(*it) - std::get<0>(*it) > e)
-		u.push_back(Internal_point(std::get<0>(*it), std::get<1>(*it), u.size()));
-	}
+    if (std::get<0>(*it) != inf && std::get<1>(*it) != neginf){
+      if (std::get<0>(*it) == neginf && std::get<1>(*it) == inf)
+        u_inf++;
+      else if (std::get<0>(*it) == neginf)
+        u_nalive.push_back(std::get<1>(*it));
+      else if (std::get<1>(*it) == inf)
+        u_alive.push_back(std::get<0>(*it));
+      else if (std::get<1>(*it) - std::get<0>(*it) > e)
+        u.push_back(Internal_point(std::get<0>(*it), std::get<1>(*it), u.size()));
+    }
   }
   for (auto it = std::begin(diag2); it != std::end(diag2); ++it) {
-	if (std::get<0>(*it) != inf && std::get<1>(*it) != neginf){
-	  if (std::get<0>(*it) == neginf && std::get<1>(*it) == inf)
-		v_inf++;
-	  else if (std::get<0>(*it) == neginf)
-		v_nalive.push_back(std::get<1>(*it));
-	  else if (std::get<1>(*it) == inf)
-		v_alive.push_back(std::get<0>(*it));
-	  else if (std::get<1>(*it) - std::get<0>(*it) > e)
-		v.push_back(Internal_point(std::get<0>(*it), std::get<1>(*it), v.size()));
-	}
+    if (std::get<0>(*it) != inf && std::get<1>(*it) != neginf){
+      if (std::get<0>(*it) == neginf && std::get<1>(*it) == inf)
+        v_inf++;
+      else if (std::get<0>(*it) == neginf)
+        v_nalive.push_back(std::get<1>(*it));
+      else if (std::get<1>(*it) == inf)
+        v_alive.push_back(std::get<0>(*it));
+      else if (std::get<1>(*it) - std::get<0>(*it) > e)
+        v.push_back(Internal_point(std::get<0>(*it), std::get<1>(*it), v.size()));
+    }
   }
   if (u.size() < v.size())
     swap(u, v);
@@ -108,14 +108,14 @@ Persistence_graph::Persistence_graph(const Persistence_diagram1 &diag1,
   if (u_alive.size() != v_alive.size() || u_nalive.size() != v_nalive.size() || u_inf != v_inf) {
     b_alive = std::numeric_limits<double>::infinity();
   } else {
-	std::sort(u_alive.begin(), u_alive.end());
-	std::sort(v_alive.begin(), v_alive.end());
-	std::sort(u_nalive.begin(), u_nalive.end());
-	std::sort(v_nalive.begin(), v_nalive.end());
+    std::sort(u_alive.begin(), u_alive.end());
+    std::sort(v_alive.begin(), v_alive.end());
+    std::sort(u_nalive.begin(), u_nalive.end());
+    std::sort(v_nalive.begin(), v_nalive.end());
     for (auto it_u = u_alive.cbegin(), it_v = v_alive.cbegin(); it_u != u_alive.cend(); ++it_u, ++it_v)
       b_alive = (std::max)(b_alive, std::fabs(*it_u - *it_v));
-	for (auto it_u = u_nalive.cbegin(), it_v = v_nalive.cbegin(); it_u != u_nalive.cend(); ++it_u, ++it_v)
-	  b_alive = (std::max)(b_alive, std::fabs(*it_u - *it_v));
+    for (auto it_u = u_nalive.cbegin(), it_v = v_nalive.cbegin(); it_u != u_nalive.cend(); ++it_u, ++it_v)
+      b_alive = (std::max)(b_alive, std::fabs(*it_u - *it_v));
   }
 }
 
@@ -129,17 +129,17 @@ inline bool Persistence_graph::on_the_v_diagonal(int v_point_index) const {
 
 inline int Persistence_graph::corresponding_point_in_u(int v_point_index) const {
   return on_the_v_diagonal(v_point_index) ?
-      v_point_index - static_cast<int> (v.size()) : v_point_index + static_cast<int> (u.size());
+        v_point_index - static_cast<int> (v.size()) : v_point_index + static_cast<int> (u.size());
 }
 
 inline int Persistence_graph::corresponding_point_in_v(int u_point_index) const {
   return on_the_u_diagonal(u_point_index) ?
-      u_point_index - static_cast<int> (u.size()) : u_point_index + static_cast<int> (v.size());
+        u_point_index - static_cast<int> (u.size()) : u_point_index + static_cast<int> (v.size());
 }
 
 inline double Persistence_graph::distance(int u_point_index, int v_point_index) const {
   if (on_the_u_diagonal(u_point_index) && on_the_v_diagonal(v_point_index))
-	return 0.;
+    return 0.;
   Internal_point p_u = get_u_point(u_point_index);
   Internal_point p_v = get_v_point(v_point_index);
   return (std::max)(std::fabs(p_u.x() - p_v.x()), std::fabs(p_u.y() - p_v.y()));
@@ -157,9 +157,9 @@ inline std::vector<double> Persistence_graph::sorted_distances() const {
   std::vector<double> distances;
   distances.push_back(0.);  // for empty diagrams
   for (int u_point_index = 0; u_point_index < size(); ++u_point_index) {
-	distances.push_back(distance(u_point_index, corresponding_point_in_v(u_point_index)));
-	for (int v_point_index = 0; v_point_index < size(); ++v_point_index)
-	  distances.push_back(distance(u_point_index, v_point_index));
+    distances.push_back(distance(u_point_index, corresponding_point_in_v(u_point_index)));
+    for (int v_point_index = 0; v_point_index < size(); ++v_point_index)
+      distances.push_back(distance(u_point_index, v_point_index));
   }
 #ifdef GUDHI_USE_TBB
   tbb::parallel_sort(distances.begin(), distances.end());
@@ -171,7 +171,7 @@ inline std::vector<double> Persistence_graph::sorted_distances() const {
 
 inline Internal_point Persistence_graph::get_u_point(int u_point_index) const {
   if (!on_the_u_diagonal(u_point_index))
-	return u.at(u_point_index);
+    return u.at(u_point_index);
   Internal_point projector = v.at(corresponding_point_in_v(u_point_index));
   double m = (projector.x() + projector.y()) / 2.;
   return Internal_point(m, m, u_point_index);

--- a/src/Bottleneck_distance/test/bottleneck_unit_test.cpp
+++ b/src/Bottleneck_distance/test/bottleneck_unit_test.cpp
@@ -31,14 +31,14 @@ std::vector< std::pair<double, double> > v1, v2;
 BOOST_AUTO_TEST_CASE(persistence_graph) {
   // Random construction
   for (int i = 0; i < n1; i++) {
-	double a = unif(re);
-	double b = unif(re);
-	v1.emplace_back(std::min(a, b), std::max(a, b));
+    double a = unif(re);
+    double b = unif(re);
+    v1.emplace_back(std::min(a, b), std::max(a, b));
   }
   for (int i = 0; i < n2; i++) {
-	double a = unif(re);
-	double b = unif(re);
-	v2.emplace_back(std::min(a, b), std::max(a, b));
+    double a = unif(re);
+    double b = unif(re);
+    v2.emplace_back(std::min(a, b), std::max(a, b));
   }
   Persistence_graph g(v1, v2, 0.);
   std::vector<double> d(g.sorted_distances());
@@ -84,14 +84,14 @@ BOOST_AUTO_TEST_CASE(neighbors_finder) {
   Persistence_graph g(v1, v2, 0.);
   Neighbors_finder nf(g, 1.);
   for (int v_point_index = 1; v_point_index < ((n2 + n1)*9 / 10); v_point_index += 2)
-	nf.add(v_point_index);
+    nf.add(v_point_index);
   //
   int v_point_index_1 = nf.pull_near(n2 / 2);
   BOOST_CHECK((v_point_index_1 == -1) || (g.distance(n2 / 2, v_point_index_1) <= 1.));
   std::vector<int> l = nf.pull_all_near(n2 / 2);
   bool v = true;
   for (auto it = l.cbegin(); it != l.cend(); ++it)
-	v = v && (g.distance(n2 / 2, *it) > 1.);
+    v = v && (g.distance(n2 / 2, *it) > 1.);
   BOOST_CHECK(v);
   int v_point_index_2 = nf.pull_near(n2 / 2);
   BOOST_CHECK(v_point_index_2 == -1);
@@ -101,7 +101,7 @@ BOOST_AUTO_TEST_CASE(layered_neighbors_finder) {
   Persistence_graph g(v1, v2, 0.);
   Layered_neighbors_finder lnf(g, 1.);
   for (int v_point_index = 1; v_point_index < ((n2 + n1)*9 / 10); v_point_index += 2)
-	lnf.add(v_point_index, v_point_index % 7);
+    lnf.add(v_point_index, v_point_index % 7);
   //
   int v_point_index_1 = lnf.pull_near(n2 / 2, 6);
   BOOST_CHECK((v_point_index_1 == -1) || (g.distance(n2 / 2, v_point_index_1) <= 1.));
@@ -119,7 +119,7 @@ BOOST_AUTO_TEST_CASE(graph_matching) {
   m1.set_r(0.);
   int e = 0;
   while (m1.multi_augment())
-	++e;
+    ++e;
   BOOST_CHECK(e > 0);
   BOOST_CHECK(e <= 2 * sqrt(2 * (n1 + n2)));
   Graph_matching m2 = m1;
@@ -127,7 +127,7 @@ BOOST_AUTO_TEST_CASE(graph_matching) {
   m2.set_r(upper_bound);
   e = 0;
   while (m2.multi_augment())
-	++e;
+    ++e;
   BOOST_CHECK(e <= 2 * sqrt(2 * (n1 + n2)));
   BOOST_CHECK(m2.perfect());
   BOOST_CHECK(!m1.perfect());
@@ -139,16 +139,16 @@ BOOST_AUTO_TEST_CASE(global) {
   std::default_random_engine re;
   std::vector< std::pair<double, double> > v1, v2;
   for (int i = 0; i < n1; i++) {
-	double a = unif1(re);
-	double b = unif1(re);
-	double x = unif2(re);
-	double y = unif2(re);
-	v1.emplace_back(std::min(a, b), std::max(a, b));
-	v2.emplace_back(std::min(a, b) + std::min(x, y), std::max(a, b) + std::max(x, y));
-	if (i % 5 == 0)
-	  v1.emplace_back(std::min(a, b), std::min(a, b) + x);
-	if (i % 3 == 0)
-	  v2.emplace_back(std::max(a, b), std::max(a, b) + y);
+    double a = unif1(re);
+    double b = unif1(re);
+    double x = unif2(re);
+    double y = unif2(re);
+    v1.emplace_back(std::min(a, b), std::max(a, b));
+    v2.emplace_back(std::min(a, b) + std::min(x, y), std::max(a, b) + std::max(x, y));
+    if (i % 5 == 0)
+      v1.emplace_back(std::min(a, b), std::min(a, b) + x);
+    if (i % 3 == 0)
+      v2.emplace_back(std::max(a, b), std::max(a, b) + y);
   }
   BOOST_CHECK(bottleneck_distance(v1, v2, 0.) <= upper_bound / 100.);
   BOOST_CHECK(bottleneck_distance(v1, v2, upper_bound / 10000.) <= upper_bound / 100. + upper_bound / 10000.);
@@ -166,16 +166,16 @@ BOOST_AUTO_TEST_CASE(neg_global) {
   std::default_random_engine re;
   std::vector< std::pair<double, double> > v1, v2;
   for (int i = 0; i < n1; i++) {
-	double a = std::log(unif1(re));
-	double b = std::log(unif1(re));
-	double x = std::log(unif2(re));
-	double y = std::log(unif2(re));
-	v1.emplace_back(std::min(a, b), std::max(a, b));
-	v2.emplace_back(std::min(a, b) + std::min(x, y), std::max(a, b) + std::max(x, y));
-	if (i % 5 == 0)
-	  v1.emplace_back(std::min(a, b), std::min(a, b) + x);
-	if (i % 3 == 0)
-	  v2.emplace_back(std::max(a, b), std::max(a, b) + y);
+    double a = std::log(unif1(re));
+    double b = std::log(unif1(re));
+    double x = std::log(unif2(re));
+    double y = std::log(unif2(re));
+    v1.emplace_back(std::min(a, b), std::max(a, b));
+    v2.emplace_back(std::min(a, b) + std::min(x, y), std::max(a, b) + std::max(x, y));
+    if (i % 5 == 0)
+      v1.emplace_back(std::min(a, b), std::min(a, b) + x);
+    if (i % 3 == 0)
+      v2.emplace_back(std::max(a, b), std::max(a, b) + y);
   }
   BOOST_CHECK(bottleneck_distance(v1, v2, 0.) <= upper_bound / 100.);
   BOOST_CHECK(bottleneck_distance(v1, v2, upper_bound / 10000.) <= upper_bound / 100. + upper_bound / 10000.);

--- a/src/Bottleneck_distance/test/bottleneck_unit_test.cpp
+++ b/src/Bottleneck_distance/test/bottleneck_unit_test.cpp
@@ -190,7 +190,7 @@ BOOST_AUTO_TEST_CASE(neg_global) {
 BOOST_AUTO_TEST_CASE(bottleneck_simple_test) {
   std::vector< std::pair<double, double> > v1, v2;
   double inf = std::numeric_limits<double>::infinity();
-  double neginf = -1 * inf;
+  double neginf = -inf;
   double b;
 
   v1.emplace_back(9.6, 14.);

--- a/src/Bottleneck_distance/test/bottleneck_unit_test.cpp
+++ b/src/Bottleneck_distance/test/bottleneck_unit_test.cpp
@@ -31,14 +31,14 @@ std::vector< std::pair<double, double> > v1, v2;
 BOOST_AUTO_TEST_CASE(persistence_graph) {
   // Random construction
   for (int i = 0; i < n1; i++) {
-    double a = unif(re);
-    double b = unif(re);
-    v1.emplace_back(std::min(a, b), std::max(a, b));
+	double a = unif(re);
+	double b = unif(re);
+	v1.emplace_back(std::min(a, b), std::max(a, b));
   }
   for (int i = 0; i < n2; i++) {
-    double a = unif(re);
-    double b = unif(re);
-    v2.emplace_back(std::min(a, b), std::max(a, b));
+	double a = unif(re);
+	double b = unif(re);
+	v2.emplace_back(std::min(a, b), std::max(a, b));
   }
   Persistence_graph g(v1, v2, 0.);
   std::vector<double> d(g.sorted_distances());
@@ -84,14 +84,14 @@ BOOST_AUTO_TEST_CASE(neighbors_finder) {
   Persistence_graph g(v1, v2, 0.);
   Neighbors_finder nf(g, 1.);
   for (int v_point_index = 1; v_point_index < ((n2 + n1)*9 / 10); v_point_index += 2)
-    nf.add(v_point_index);
+	nf.add(v_point_index);
   //
   int v_point_index_1 = nf.pull_near(n2 / 2);
   BOOST_CHECK((v_point_index_1 == -1) || (g.distance(n2 / 2, v_point_index_1) <= 1.));
   std::vector<int> l = nf.pull_all_near(n2 / 2);
   bool v = true;
   for (auto it = l.cbegin(); it != l.cend(); ++it)
-    v = v && (g.distance(n2 / 2, *it) > 1.);
+	v = v && (g.distance(n2 / 2, *it) > 1.);
   BOOST_CHECK(v);
   int v_point_index_2 = nf.pull_near(n2 / 2);
   BOOST_CHECK(v_point_index_2 == -1);
@@ -101,7 +101,7 @@ BOOST_AUTO_TEST_CASE(layered_neighbors_finder) {
   Persistence_graph g(v1, v2, 0.);
   Layered_neighbors_finder lnf(g, 1.);
   for (int v_point_index = 1; v_point_index < ((n2 + n1)*9 / 10); v_point_index += 2)
-    lnf.add(v_point_index, v_point_index % 7);
+	lnf.add(v_point_index, v_point_index % 7);
   //
   int v_point_index_1 = lnf.pull_near(n2 / 2, 6);
   BOOST_CHECK((v_point_index_1 == -1) || (g.distance(n2 / 2, v_point_index_1) <= 1.));
@@ -119,7 +119,7 @@ BOOST_AUTO_TEST_CASE(graph_matching) {
   m1.set_r(0.);
   int e = 0;
   while (m1.multi_augment())
-    ++e;
+	++e;
   BOOST_CHECK(e > 0);
   BOOST_CHECK(e <= 2 * sqrt(2 * (n1 + n2)));
   Graph_matching m2 = m1;
@@ -127,7 +127,7 @@ BOOST_AUTO_TEST_CASE(graph_matching) {
   m2.set_r(upper_bound);
   e = 0;
   while (m2.multi_augment())
-    ++e;
+	++e;
   BOOST_CHECK(e <= 2 * sqrt(2 * (n1 + n2)));
   BOOST_CHECK(m2.perfect());
   BOOST_CHECK(!m1.perfect());
@@ -139,16 +139,16 @@ BOOST_AUTO_TEST_CASE(global) {
   std::default_random_engine re;
   std::vector< std::pair<double, double> > v1, v2;
   for (int i = 0; i < n1; i++) {
-    double a = unif1(re);
-    double b = unif1(re);
-    double x = unif2(re);
-    double y = unif2(re);
-    v1.emplace_back(std::min(a, b), std::max(a, b));
-    v2.emplace_back(std::min(a, b) + std::min(x, y), std::max(a, b) + std::max(x, y));
-    if (i % 5 == 0)
-      v1.emplace_back(std::min(a, b), std::min(a, b) + x);
-    if (i % 3 == 0)
-      v2.emplace_back(std::max(a, b), std::max(a, b) + y);
+	double a = unif1(re);
+	double b = unif1(re);
+	double x = unif2(re);
+	double y = unif2(re);
+	v1.emplace_back(std::min(a, b), std::max(a, b));
+	v2.emplace_back(std::min(a, b) + std::min(x, y), std::max(a, b) + std::max(x, y));
+	if (i % 5 == 0)
+	  v1.emplace_back(std::min(a, b), std::min(a, b) + x);
+	if (i % 3 == 0)
+	  v2.emplace_back(std::max(a, b), std::max(a, b) + y);
   }
   BOOST_CHECK(bottleneck_distance(v1, v2, 0.) <= upper_bound / 100.);
   BOOST_CHECK(bottleneck_distance(v1, v2, upper_bound / 10000.) <= upper_bound / 100. + upper_bound / 10000.);
@@ -158,4 +158,82 @@ BOOST_AUTO_TEST_CASE(global) {
   std::vector< std::pair<double, double> > one = {{8, 10}};
   BOOST_CHECK(bottleneck_distance(empty, empty) == 0);
   BOOST_CHECK(bottleneck_distance(empty, one) == 1);
+}
+
+BOOST_AUTO_TEST_CASE(neg_global) {
+  std::uniform_real_distribution<double> unif1(0., upper_bound);
+  std::uniform_real_distribution<double> unif2(upper_bound / 10000., upper_bound / 100.);
+  std::default_random_engine re;
+  std::vector< std::pair<double, double> > v1, v2;
+  for (int i = 0; i < n1; i++) {
+	double a = std::log(unif1(re));
+	double b = std::log(unif1(re));
+	double x = std::log(unif2(re));
+	double y = std::log(unif2(re));
+	v1.emplace_back(std::min(a, b), std::max(a, b));
+	v2.emplace_back(std::min(a, b) + std::min(x, y), std::max(a, b) + std::max(x, y));
+	if (i % 5 == 0)
+	  v1.emplace_back(std::min(a, b), std::min(a, b) + x);
+	if (i % 3 == 0)
+	  v2.emplace_back(std::max(a, b), std::max(a, b) + y);
+  }
+  BOOST_CHECK(bottleneck_distance(v1, v2, 0.) <= upper_bound / 100.);
+  BOOST_CHECK(bottleneck_distance(v1, v2, upper_bound / 10000.) <= upper_bound / 100. + upper_bound / 10000.);
+  BOOST_CHECK(std::abs(bottleneck_distance(v1, v2, 0.) - bottleneck_distance(v1, v2, upper_bound / 10000.)) <= upper_bound / 10000.);
+
+  std::vector< std::pair<double, double> > empty;
+  std::vector< std::pair<double, double> > one = {{8, 10}};
+  BOOST_CHECK(bottleneck_distance(empty, empty) == 0);
+  BOOST_CHECK(bottleneck_distance(empty, one) == 1);
+}
+
+BOOST_AUTO_TEST_CASE(bottleneck_simple_test) {
+  std::vector< std::pair<double, double> > v1, v2;
+  double inf = std::numeric_limits<double>::infinity();
+  double neginf = -1 * inf;
+  double b;
+
+  v1.emplace_back(9.6, 14.);
+  v2.emplace_back(9.5, 14.1);
+
+  b = Gudhi::persistence_diagram::bottleneck_distance(v1, v2, 0.);
+  BOOST_CHECK(b > 0.09 && b < 0.11);
+
+  v1.emplace_back(-34.974, -34.2);
+
+  b = Gudhi::persistence_diagram::bottleneck_distance(v1, v2, 0.);
+  BOOST_CHECK(b > 0.386 && b < 0.388);
+
+  v1.emplace_back(neginf, 3.7);
+
+  b = Gudhi::persistence_diagram::bottleneck_distance(v1, v2, 0.);
+  BOOST_CHECK_EQUAL(b, inf);
+
+  v2.emplace_back(neginf, 4.45);
+
+  b = Gudhi::persistence_diagram::bottleneck_distance(v1, v2, 0.);
+  BOOST_CHECK(b > 0.74 && b < 0.76);
+
+  v1.emplace_back(-60.6, 52.1);
+  v2.emplace_back(-61.5, 53.);
+
+  b = Gudhi::persistence_diagram::bottleneck_distance(v1, v2, 0.);
+  BOOST_CHECK(b > 0.89 && b < 0.91);
+
+  v1.emplace_back(3., inf);
+  v2.emplace_back(3.2, inf);
+
+  b = Gudhi::persistence_diagram::bottleneck_distance(v1, v2, 0.);
+  BOOST_CHECK(b > 0.89 && b < 0.91);
+
+  v1.emplace_back(neginf, inf);
+  v2.emplace_back(neginf, inf);
+
+  b = Gudhi::persistence_diagram::bottleneck_distance(v1, v2, 0.);
+  BOOST_CHECK(b > 0.89 && b < 0.91);
+
+  v2.emplace_back(6, inf);
+
+  b = Gudhi::persistence_diagram::bottleneck_distance(v1, v2, 0.);
+  BOOST_CHECK_EQUAL(b, inf);
 }

--- a/src/Spatial_searching/example/example_spatial_searching.cpp
+++ b/src/Spatial_searching/example/example_spatial_searching.cpp
@@ -25,7 +25,7 @@ int main(void) {
   // 10-nearest neighbor query
   std::clog << "10 nearest neighbors from points[20]:\n";
   auto knn_range = points_ds.k_nearest_neighbors(points[20], 10, true);
-  for (auto const& nghb : knn_range)
+  for (auto const nghb : knn_range)
     std::clog << nghb.first << " (sq. dist. = " << nghb.second << ")\n";
 
   // Incremental nearest neighbor query
@@ -38,7 +38,7 @@ int main(void) {
   // 10-furthest neighbor query
   std::clog << "10 furthest neighbors from points[20]:\n";
   auto kfn_range = points_ds.k_furthest_neighbors(points[20], 10, true);
-  for (auto const& nghb : kfn_range)
+  for (auto const nghb : kfn_range)
     std::clog << nghb.first << " (sq. dist. = " << nghb.second << ")\n";
 
   // Incremental furthest neighbor query

--- a/src/Spatial_searching/test/test_Kd_tree_search.cpp
+++ b/src/Spatial_searching/test/test_Kd_tree_search.cpp
@@ -45,7 +45,7 @@ BOOST_AUTO_TEST_CASE(test_Kd_tree_search) {
 
   std::vector<std::size_t> knn_result;
   FT last_dist = -1.;
-  for (auto const& nghb : kns_range) {
+  for (auto const nghb : kns_range) {
     BOOST_CHECK(nghb.second > last_dist);
     knn_result.push_back(nghb.second);
     last_dist = nghb.second;
@@ -76,7 +76,7 @@ BOOST_AUTO_TEST_CASE(test_Kd_tree_search) {
 
   std::vector<std::size_t> kfn_result;
   last_dist = kfn_range.begin()->second;
-  for (auto const& nghb : kfn_range) {
+  for (auto const nghb : kfn_range) {
     BOOST_CHECK(nghb.second <= last_dist);
     kfn_result.push_back(nghb.second);
     last_dist = nghb.second;


### PR DESCRIPTION
Adds the possibility to use negative coordinates to compute the bottleneck distance between two diagrams, as requested in Issue #701.

Should I add an additional example and more unit tests? 

Also, I corrected two very small compilation warnings I missed last time, as I forgot that I didn't had CGAL installed.