### PR TITLE
Translate n_jobs to workers for SciPy

### DIFF
--- a/src/python/doc/installation.rst
+++ b/src/python/doc/installation.rst
@@ -391,7 +391,7 @@ The :doc:`persistence graphical tools </persistence_graphical_tools_user>` and
 mathematics, science, and engineering.
 
 :class:`~gudhi.point_cloud.knn.KNearestNeighbors` can use the Python package
-`SciPy <http://scipy.org>`_ as a backend if explicitly requested.
+`SciPy <http://scipy.org>`_ :math:`\geq` 1.6.0 as a backend if explicitly requested.
 
 TensorFlow
 ----------

--- a/src/python/gudhi/point_cloud/knn.py
+++ b/src/python/gudhi/point_cloud/knn.py
@@ -314,7 +314,9 @@ class KNearestNeighbors:
             return None
 
         if self.params["implementation"] == "ckdtree":
-            qargs = {key: val for key, val in self.params.items() if key in {"p", "eps", "n_jobs"}}
+            qargs = {key: val for key, val in self.params.items() if key in {"p", "eps"}}
+            # SciPy renamed n_jobs to workers
+            qargs["workers"] = self.params.get("workers") or self.params.get("n_jobs") or 1
             distances, neighbors = self.kdtree.query(X, k=self.k, **qargs)
             if k == 1:
                 # SciPy decided to squeeze the last dimension for k=1


### PR DESCRIPTION
Fix #662.
This is incompatible with versions of SciPy older than 1.6.0 (2 years old). We don't document a lot of minimal versions for Python dependencies, so I am tempted to ignore this small issue.