### PR TITLE
New function to insert several vertices in a Simplex_tree

### DIFF
--- a/src/Simplex_tree/test/simplex_tree_unit_test.cpp
+++ b/src/Simplex_tree/test/simplex_tree_unit_test.cpp
@@ -1038,3 +1038,17 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(simplex_tree_boundaries_and_opposite_vertex_iterat
       BOOST_CHECK(opposite_vertices.size() == 0);
   }
 }
+
+BOOST_AUTO_TEST_CASE(batch_vertices) {
+  typedef Simplex_tree<> typeST;
+  std::clog << "********************************************************************" << std::endl;
+  std::clog << "TEST BATCH VERTEX INSERTION" << std::endl;
+  typeST st;
+  st.insert_simplex_and_subfaces({3}, 1.5);
+  std::vector verts { 2, 3, 5, 6 };
+  st.insert_batch_vertices(verts);
+  BOOST_CHECK(st.num_vertices() == 4);
+  BOOST_CHECK(st.num_simplices() == 4);
+  BOOST_CHECK(st.filtration(st.find({2})) == 0.);
+  BOOST_CHECK(st.filtration(st.find({3})) == 1.5);
+}


### PR DESCRIPTION
If I replace the new code in Alpha_complex.h with `complex.insert_batch_vertices(vertices_, std::numeric_limits<Filtration_value>::quiet_NaN());`, the testsuite passes. I didn't include that here because it would also require changing the concept SimplicialComplexForAlpha.