### PR TITLE
Make RipsComplex construction less confusing

### DIFF
--- a/.github/next_release.md
+++ b/.github/next_release.md
@@ -9,6 +9,9 @@ Below is a list of changes made since GUDHI 3.6.0:
 - [Module](link)
      - ...
 
+- [Rips complex](https://gudhi.inria.fr/python/latest/rips_complex_user.html)
+     - Construction now rejects positional arguments, you need to specify `points=X`.
+
 - Installation
      - c++17 is the new minimal standard to compile the library. This implies Visual Studio minimal version is now 2017.
 

--- a/src/python/gudhi/rips_complex.pyx
+++ b/src/python/gudhi/rips_complex.pyx
@@ -45,20 +45,19 @@ cdef class RipsComplex:
                  max_edge_length=float('inf'), sparse=None):
         """RipsComplex constructor.
 
-        :param max_edge_length: Rips value.
-        :type max_edge_length: float
-
         :param points: A list of points in d-Dimension.
-        :type points: list of list of float
+        :type points: List[List[float]]
 
         Or
 
         :param distance_matrix: A distance matrix (full square or lower
             triangular).
-        :type points: list of list of float
+        :type distance_matrix: List[List[float]]
 
         And in both cases
 
+        :param max_edge_length: Rips value.
+        :type max_edge_length: float
         :param sparse: If this is not None, it switches to building a sparse
             Rips and represents the approximation parameter epsilon.
         :type sparse: float

--- a/src/python/gudhi/rips_complex.pyx
+++ b/src/python/gudhi/rips_complex.pyx
@@ -41,7 +41,7 @@ cdef class RipsComplex:
     cdef Rips_complex_interface thisref
 
     # Fake constructor that does nothing but documenting the constructor
-    def __init__(self, points=None, distance_matrix=None,
+    def __init__(self, *, points=None, distance_matrix=None,
                  max_edge_length=float('inf'), sparse=None):
         """RipsComplex constructor.
 
@@ -64,7 +64,7 @@ cdef class RipsComplex:
         """
 
     # The real cython constructor
-    def __cinit__(self, points=None, distance_matrix=None,
+    def __cinit__(self, *, points=None, distance_matrix=None,
                   max_edge_length=float('inf'), sparse=None):
         if sparse is not None:
           if distance_matrix is not None:

--- a/src/python/test/test_simplex_generators.py
+++ b/src/python/test/test_simplex_generators.py
@@ -14,7 +14,7 @@ import numpy as np
 
 def test_flag_generators():
     pts = np.array([[0, 0], [0, 1.01], [1, 0], [1.02, 1.03], [100, 0], [100, 3.01], [103, 0], [103.02, 3.03]])
-    r = gudhi.RipsComplex(pts, max_edge_length=4)
+    r = gudhi.RipsComplex(points=pts, max_edge_length=4)
     st = r.create_simplex_tree(max_dimension=50)
     st.persistence()
     g = st.flag_persistence_generators()


### PR DESCRIPTION
* Clarify the doc.
* Mandate the use of named arguments: `points=X` or `distance_matrix=X`, since `RipsComplex(X)` was ambiguous.

The modified test was giving me
> E   TypeError: __cinit__() takes exactly 0 positional arguments (1 given)

As discussed in #723, clarifying the doc is obviously good, while the second patch is more questionable.