### PR TITLE
Fall back to Hera's bottleneck in Nerve_GIC

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,10 +9,11 @@ jobs:
       - image: gudhi/ci_for_gudhi:latest
     steps:
       - checkout
+      - run: git submodule sync
+      - run: git submodule update --init
       - run:
           name: Build and test examples
           command: |
-            git submodule update --init
             mkdir build
             cd build
             cmake -DCMAKE_BUILD_TYPE=Release -DWITH_GUDHI_EXAMPLE=ON -DWITH_GUDHI_TEST=OFF -DWITH_GUDHI_UTILITIES=OFF -DWITH_GUDHI_PYTHON=OFF ..
@@ -24,10 +25,11 @@ jobs:
       - image: gudhi/ci_for_gudhi:latest
     steps:
       - checkout
+      - run: git submodule sync
+      - run: git submodule update --init
       - run:
           name: Build and test unitary tests
           command: |
-            git submodule update --init
             mkdir build
             cd build
             cmake -DCMAKE_BUILD_TYPE=Release -DWITH_GUDHI_EXAMPLE=OFF -DWITH_GUDHI_TEST=ON -DWITH_GUDHI_UTILITIES=OFF -DWITH_GUDHI_PYTHON=OFF ..
@@ -39,10 +41,11 @@ jobs:
       - image: gudhi/ci_for_gudhi:latest
     steps:
       - checkout
+      - run: git submodule sync
+      - run: git submodule update --init
       - run:
           name: Build and test utilities
           command: |
-            git submodule update --init
             mkdir build
             cd build
             cmake -DCMAKE_BUILD_TYPE=Release -DWITH_GUDHI_EXAMPLE=OFF -DWITH_GUDHI_TEST=OFF -DWITH_GUDHI_UTILITIES=ON -DWITH_GUDHI_PYTHON=OFF ..
@@ -54,10 +57,11 @@ jobs:
       - image: gudhi/ci_for_gudhi:latest
     steps:
       - checkout
+      - run: git submodule sync
+      - run: git submodule update --init
       - run:
           name: Build and test python module. Generates and tests the python documentation
           command: |
-            git submodule update --init
             mkdir build
             cd build
             cmake -DWITH_GUDHI_THIRD_PARTY=OFF -DUSER_VERSION_DIR=version ..
@@ -84,10 +88,11 @@ jobs:
       - image: gudhi/doxygen_for_gudhi:latest
     steps:
       - checkout
+      - run: git submodule sync
+      - run: git submodule update --init
       - run:
           name: Generates the C++ documentation with doxygen
           command: |
-            git submodule update --init
             mkdir build
             cd build
             cmake -DWITH_GUDHI_THIRD_PARTY=OFF -DUSER_VERSION_DIR=version ..
@@ -114,10 +119,11 @@ jobs:
       - image: gudhi/ci_for_gudhi_wo_cgal:latest
     steps:
       - checkout
+      - run: git submodule sync
+      - run: git submodule update --init
       - run:
           name: Build and test examples without cgal and eigen
           command: |
-            git submodule update --init
             mkdir build
             cd build
             cmake -DCMAKE_BUILD_TYPE=Release -DWITH_GUDHI_EXAMPLE=ON -DWITH_GUDHI_TEST=OFF -DWITH_GUDHI_UTILITIES=OFF -DWITH_GUDHI_PYTHON=OFF ..
@@ -129,10 +135,11 @@ jobs:
       - image: gudhi/ci_for_gudhi_wo_cgal:latest
     steps:
       - checkout
+      - run: git submodule sync
+      - run: git submodule update --init
       - run:
           name: Build and test unitary tests without cgal and eigen
           command: |
-            git submodule update --init
             mkdir build
             cd build
             cmake -DCMAKE_BUILD_TYPE=Release -DWITH_GUDHI_EXAMPLE=OFF -DWITH_GUDHI_TEST=ON -DWITH_GUDHI_UTILITIES=OFF -DWITH_GUDHI_PYTHON=OFF ..
@@ -144,10 +151,11 @@ jobs:
       - image: gudhi/ci_for_gudhi_wo_cgal:latest
     steps:
       - checkout
+      - run: git submodule sync
+      - run: git submodule update --init
       - run:
           name: Build and test utilities without cgal and eigen
           command: |
-            git submodule update --init
             mkdir build
             cd build
             cmake -DCMAKE_BUILD_TYPE=Release -DWITH_GUDHI_EXAMPLE=OFF -DWITH_GUDHI_TEST=OFF -DWITH_GUDHI_UTILITIES=ON -DWITH_GUDHI_PYTHON=OFF ..
@@ -159,10 +167,11 @@ jobs:
       - image: gudhi/ci_for_gudhi_wo_cgal:latest
     steps:
       - checkout
+      - run: git submodule sync
+      - run: git submodule update --init
       - run:
           name: Build and test python module without cgal and eigen
           command: |
-            git submodule update --init
             mkdir build
             cd build
             cmake -DCMAKE_BUILD_TYPE=Release -DWITH_GUDHI_EXAMPLE=OFF -DWITH_GUDHI_UTILITIES=OFF -DWITH_GUDHI_PYTHON=ON -DPython_ADDITIONAL_VERSIONS=3 ..
@@ -178,10 +187,11 @@ jobs:
       - image: gudhi/ci_for_gudhi_wo_cgal:latest
     steps:
       - checkout
+      - run: git submodule sync
+      - run: git submodule update --init
       - run:
           name: Build and test examples without cgal
           command: |
-            git submodule update --init
             mkdir build
             cd build
             cmake -DCMAKE_BUILD_TYPE=Release -DEIGEN3_INCLUDE_DIR=/eigen-3.3.9 -DWITH_GUDHI_EXAMPLE=ON -DWITH_GUDHI_TEST=OFF -DWITH_GUDHI_UTILITIES=OFF -DWITH_GUDHI_PYTHON=OFF ..
@@ -193,10 +203,11 @@ jobs:
       - image: gudhi/ci_for_gudhi_wo_cgal:latest
     steps:
       - checkout
+      - run: git submodule sync
+      - run: git submodule update --init
       - run:
           name: Build and test unitary tests without cgal
           command: |
-            git submodule update --init
             mkdir build
             cd build
             cmake -DCMAKE_BUILD_TYPE=Release -DEIGEN3_INCLUDE_DIR=/eigen-3.3.9 -DWITH_GUDHI_EXAMPLE=OFF -DWITH_GUDHI_TEST=ON -DWITH_GUDHI_UTILITIES=OFF -DWITH_GUDHI_PYTHON=OFF ..
@@ -208,10 +219,11 @@ jobs:
       - image: gudhi/ci_for_gudhi_wo_cgal:latest
     steps:
       - checkout
+      - run: git submodule sync
+      - run: git submodule update --init
       - run:
           name: Build and test utilities without cgal
           command: |
-            git submodule update --init
             mkdir build
             cd build
             cmake -DCMAKE_BUILD_TYPE=Release -DEIGEN3_INCLUDE_DIR=/eigen-3.3.9 -DWITH_GUDHI_EXAMPLE=OFF -DWITH_GUDHI_TEST=OFF -DWITH_GUDHI_UTILITIES=ON -DWITH_GUDHI_PYTHON=OFF ..
@@ -223,10 +235,11 @@ jobs:
       - image: gudhi/ci_for_gudhi_wo_cgal:latest
     steps:
       - checkout
+      - run: git submodule sync
+      - run: git submodule update --init
       - run:
           name: Build and test python module without cgal
           command: |
-            git submodule update --init
             mkdir build
             cd build
             cmake -DCMAKE_BUILD_TYPE=Release -DEIGEN3_INCLUDE_DIR=/eigen-3.3.9 -DWITH_GUDHI_EXAMPLE=OFF -DWITH_GUDHI_UTILITIES=OFF -DWITH_GUDHI_PYTHON=ON -DPython_ADDITIONAL_VERSIONS=3 ..

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,7 @@ jobs:
       - run:
           name: Build and test examples
           command: |
+            git submodule update --init
             mkdir build
             cd build
             cmake -DCMAKE_BUILD_TYPE=Release -DWITH_GUDHI_EXAMPLE=ON -DWITH_GUDHI_TEST=OFF -DWITH_GUDHI_UTILITIES=OFF -DWITH_GUDHI_PYTHON=OFF ..
@@ -26,6 +27,7 @@ jobs:
       - run:
           name: Build and test unitary tests
           command: |
+            git submodule update --init
             mkdir build
             cd build
             cmake -DCMAKE_BUILD_TYPE=Release -DWITH_GUDHI_EXAMPLE=OFF -DWITH_GUDHI_TEST=ON -DWITH_GUDHI_UTILITIES=OFF -DWITH_GUDHI_PYTHON=OFF ..
@@ -40,6 +42,7 @@ jobs:
       - run:
           name: Build and test utilities
           command: |
+            git submodule update --init
             mkdir build
             cd build
             cmake -DCMAKE_BUILD_TYPE=Release -DWITH_GUDHI_EXAMPLE=OFF -DWITH_GUDHI_TEST=OFF -DWITH_GUDHI_UTILITIES=ON -DWITH_GUDHI_PYTHON=OFF ..
@@ -54,8 +57,7 @@ jobs:
       - run:
           name: Build and test python module. Generates and tests the python documentation
           command: |
-            git submodule init
-            git submodule update
+            git submodule update --init
             mkdir build
             cd build
             cmake -DWITH_GUDHI_THIRD_PARTY=OFF -DUSER_VERSION_DIR=version ..
@@ -85,8 +87,7 @@ jobs:
       - run:
           name: Generates the C++ documentation with doxygen
           command: |
-            git submodule init
-            git submodule update
+            git submodule update --init
             mkdir build
             cd build
             cmake -DWITH_GUDHI_THIRD_PARTY=OFF -DUSER_VERSION_DIR=version ..
@@ -116,6 +117,7 @@ jobs:
       - run:
           name: Build and test examples without cgal and eigen
           command: |
+            git submodule update --init
             mkdir build
             cd build
             cmake -DCMAKE_BUILD_TYPE=Release -DWITH_GUDHI_EXAMPLE=ON -DWITH_GUDHI_TEST=OFF -DWITH_GUDHI_UTILITIES=OFF -DWITH_GUDHI_PYTHON=OFF ..
@@ -130,6 +132,7 @@ jobs:
       - run:
           name: Build and test unitary tests without cgal and eigen
           command: |
+            git submodule update --init
             mkdir build
             cd build
             cmake -DCMAKE_BUILD_TYPE=Release -DWITH_GUDHI_EXAMPLE=OFF -DWITH_GUDHI_TEST=ON -DWITH_GUDHI_UTILITIES=OFF -DWITH_GUDHI_PYTHON=OFF ..
@@ -144,6 +147,7 @@ jobs:
       - run:
           name: Build and test utilities without cgal and eigen
           command: |
+            git submodule update --init
             mkdir build
             cd build
             cmake -DCMAKE_BUILD_TYPE=Release -DWITH_GUDHI_EXAMPLE=OFF -DWITH_GUDHI_TEST=OFF -DWITH_GUDHI_UTILITIES=ON -DWITH_GUDHI_PYTHON=OFF ..
@@ -158,8 +162,7 @@ jobs:
       - run:
           name: Build and test python module without cgal and eigen
           command: |
-            git submodule init
-            git submodule update
+            git submodule update --init
             mkdir build
             cd build
             cmake -DCMAKE_BUILD_TYPE=Release -DWITH_GUDHI_EXAMPLE=OFF -DWITH_GUDHI_UTILITIES=OFF -DWITH_GUDHI_PYTHON=ON -DPython_ADDITIONAL_VERSIONS=3 ..
@@ -178,6 +181,7 @@ jobs:
       - run:
           name: Build and test examples without cgal
           command: |
+            git submodule update --init
             mkdir build
             cd build
             cmake -DCMAKE_BUILD_TYPE=Release -DEIGEN3_INCLUDE_DIR=/eigen-3.3.9 -DWITH_GUDHI_EXAMPLE=ON -DWITH_GUDHI_TEST=OFF -DWITH_GUDHI_UTILITIES=OFF -DWITH_GUDHI_PYTHON=OFF ..
@@ -192,6 +196,7 @@ jobs:
       - run:
           name: Build and test unitary tests without cgal
           command: |
+            git submodule update --init
             mkdir build
             cd build
             cmake -DCMAKE_BUILD_TYPE=Release -DEIGEN3_INCLUDE_DIR=/eigen-3.3.9 -DWITH_GUDHI_EXAMPLE=OFF -DWITH_GUDHI_TEST=ON -DWITH_GUDHI_UTILITIES=OFF -DWITH_GUDHI_PYTHON=OFF ..
@@ -206,6 +211,7 @@ jobs:
       - run:
           name: Build and test utilities without cgal
           command: |
+            git submodule update --init
             mkdir build
             cd build
             cmake -DCMAKE_BUILD_TYPE=Release -DEIGEN3_INCLUDE_DIR=/eigen-3.3.9 -DWITH_GUDHI_EXAMPLE=OFF -DWITH_GUDHI_TEST=OFF -DWITH_GUDHI_UTILITIES=ON -DWITH_GUDHI_PYTHON=OFF ..
@@ -220,8 +226,7 @@ jobs:
       - run:
           name: Build and test python module without cgal
           command: |
-            git submodule init
-            git submodule update
+            git submodule update --init
             mkdir build
             cd build
             cmake -DCMAKE_BUILD_TYPE=Release -DEIGEN3_INCLUDE_DIR=/eigen-3.3.9 -DWITH_GUDHI_EXAMPLE=OFF -DWITH_GUDHI_UTILITIES=OFF -DWITH_GUDHI_PYTHON=ON -DPython_ADDITIONAL_VERSIONS=3 ..

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,8 +9,11 @@ jobs:
       - image: gudhi/ci_for_gudhi:latest
     steps:
       - checkout
-      - run: git submodule sync
-      - run: git submodule update --init
+      - run:
+          name: Checkout submodules
+          command: |
+            git submodule sync
+            git submodule update --init
       - run:
           name: Build and test examples
           command: |
@@ -25,8 +28,11 @@ jobs:
       - image: gudhi/ci_for_gudhi:latest
     steps:
       - checkout
-      - run: git submodule sync
-      - run: git submodule update --init
+      - run:
+          name: Checkout submodules
+          command: |
+            git submodule sync
+            git submodule update --init
       - run:
           name: Build and test unitary tests
           command: |
@@ -41,8 +47,11 @@ jobs:
       - image: gudhi/ci_for_gudhi:latest
     steps:
       - checkout
-      - run: git submodule sync
-      - run: git submodule update --init
+      - run:
+          name: Checkout submodules
+          command: |
+            git submodule sync
+            git submodule update --init
       - run:
           name: Build and test utilities
           command: |
@@ -57,8 +66,11 @@ jobs:
       - image: gudhi/ci_for_gudhi:latest
     steps:
       - checkout
-      - run: git submodule sync
-      - run: git submodule update --init
+      - run:
+          name: Checkout submodules
+          command: |
+            git submodule sync
+            git submodule update --init
       - run:
           name: Build and test python module. Generates and tests the python documentation
           command: |
@@ -88,8 +100,11 @@ jobs:
       - image: gudhi/doxygen_for_gudhi:latest
     steps:
       - checkout
-      - run: git submodule sync
-      - run: git submodule update --init
+      - run:
+          name: Checkout submodules
+          command: |
+            git submodule sync
+            git submodule update --init
       - run:
           name: Generates the C++ documentation with doxygen
           command: |
@@ -119,8 +134,11 @@ jobs:
       - image: gudhi/ci_for_gudhi_wo_cgal:latest
     steps:
       - checkout
-      - run: git submodule sync
-      - run: git submodule update --init
+      - run:
+          name: Checkout submodules
+          command: |
+            git submodule sync
+            git submodule update --init
       - run:
           name: Build and test examples without cgal and eigen
           command: |
@@ -135,8 +153,11 @@ jobs:
       - image: gudhi/ci_for_gudhi_wo_cgal:latest
     steps:
       - checkout
-      - run: git submodule sync
-      - run: git submodule update --init
+      - run:
+          name: Checkout submodules
+          command: |
+            git submodule sync
+            git submodule update --init
       - run:
           name: Build and test unitary tests without cgal and eigen
           command: |
@@ -151,8 +172,11 @@ jobs:
       - image: gudhi/ci_for_gudhi_wo_cgal:latest
     steps:
       - checkout
-      - run: git submodule sync
-      - run: git submodule update --init
+      - run:
+          name: Checkout submodules
+          command: |
+            git submodule sync
+            git submodule update --init
       - run:
           name: Build and test utilities without cgal and eigen
           command: |
@@ -167,8 +191,11 @@ jobs:
       - image: gudhi/ci_for_gudhi_wo_cgal:latest
     steps:
       - checkout
-      - run: git submodule sync
-      - run: git submodule update --init
+      - run:
+          name: Checkout submodules
+          command: |
+            git submodule sync
+            git submodule update --init
       - run:
           name: Build and test python module without cgal and eigen
           command: |
@@ -187,8 +214,11 @@ jobs:
       - image: gudhi/ci_for_gudhi_wo_cgal:latest
     steps:
       - checkout
-      - run: git submodule sync
-      - run: git submodule update --init
+      - run:
+          name: Checkout submodules
+          command: |
+            git submodule sync
+            git submodule update --init
       - run:
           name: Build and test examples without cgal
           command: |
@@ -203,8 +233,11 @@ jobs:
       - image: gudhi/ci_for_gudhi_wo_cgal:latest
     steps:
       - checkout
-      - run: git submodule sync
-      - run: git submodule update --init
+      - run:
+          name: Checkout submodules
+          command: |
+            git submodule sync
+            git submodule update --init
       - run:
           name: Build and test unitary tests without cgal
           command: |
@@ -219,8 +252,11 @@ jobs:
       - image: gudhi/ci_for_gudhi_wo_cgal:latest
     steps:
       - checkout
-      - run: git submodule sync
-      - run: git submodule update --init
+      - run:
+          name: Checkout submodules
+          command: |
+            git submodule sync
+            git submodule update --init
       - run:
           name: Build and test utilities without cgal
           command: |
@@ -235,8 +271,11 @@ jobs:
       - image: gudhi/ci_for_gudhi_wo_cgal:latest
     steps:
       - checkout
-      - run: git submodule sync
-      - run: git submodule update --init
+      - run:
+          name: Checkout submodules
+          command: |
+            git submodule sync
+            git submodule update --init
       - run:
           name: Build and test python module without cgal
           command: |

--- a/src/Nerve_GIC/example/CMakeLists.txt
+++ b/src/Nerve_GIC/example/CMakeLists.txt
@@ -1,25 +1,21 @@
 project(Nerve_GIC_examples)
 
-if (NOT CGAL_VERSION VERSION_LESS 4.11.0)
+add_executable ( CoordGIC CoordGIC.cpp )
+add_executable ( FuncGIC FuncGIC.cpp )
 
-  add_executable ( CoordGIC CoordGIC.cpp )
-  add_executable ( FuncGIC FuncGIC.cpp )
+if (TBB_FOUND)
+  target_link_libraries(CoordGIC ${TBB_LIBRARIES})
+  target_link_libraries(FuncGIC ${TBB_LIBRARIES})
+endif()
 
-  if (TBB_FOUND)
-    target_link_libraries(CoordGIC ${TBB_LIBRARIES})
-    target_link_libraries(FuncGIC ${TBB_LIBRARIES})
-  endif()
+# Copy files for not to pollute sources when testing
+file(COPY "${CMAKE_SOURCE_DIR}/data/points/tore3D_1307.off" DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/)
+file(COPY "${CMAKE_SOURCE_DIR}/data/points/COIL_database/lucky_cat.off" DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/)
+file(COPY "${CMAKE_SOURCE_DIR}/data/points/COIL_database/lucky_cat_PCA1" DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/)
 
-  # Copy files for not to pollute sources when testing
-  file(COPY "${CMAKE_SOURCE_DIR}/data/points/tore3D_1307.off" DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/)
-  file(COPY "${CMAKE_SOURCE_DIR}/data/points/COIL_database/lucky_cat.off" DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/)
-  file(COPY "${CMAKE_SOURCE_DIR}/data/points/COIL_database/lucky_cat_PCA1" DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/)
+add_test(NAME Nerve_GIC_example_CoordGIC COMMAND $<TARGET_FILE:CoordGIC>
+    "${CMAKE_CURRENT_BINARY_DIR}/tore3D_1307.off" "0")
 
-  add_test(NAME Nerve_GIC_example_CoordGIC COMMAND $<TARGET_FILE:CoordGIC>
-      "${CMAKE_CURRENT_BINARY_DIR}/tore3D_1307.off" "0")
-
-  add_test(NAME Nerve_GIC_example_FuncGIC COMMAND $<TARGET_FILE:FuncGIC>
-      "${CMAKE_CURRENT_BINARY_DIR}/lucky_cat.off"
-      "${CMAKE_CURRENT_BINARY_DIR}/lucky_cat_PCA1")
-
-endif (NOT CGAL_VERSION VERSION_LESS 4.11.0)
+add_test(NAME Nerve_GIC_example_FuncGIC COMMAND $<TARGET_FILE:FuncGIC>
+    "${CMAKE_CURRENT_BINARY_DIR}/lucky_cat.off"
+    "${CMAKE_CURRENT_BINARY_DIR}/lucky_cat_PCA1")

--- a/src/Nerve_GIC/include/gudhi/GIC.h
+++ b/src/Nerve_GIC/include/gudhi/GIC.h
@@ -20,9 +20,9 @@
 #if __has_include(<CGAL/version.h>)
 # define GUDHI_GIC_USE_CGAL 1
 # include <gudhi/Bottleneck.h>
-#elif __has_include(<bottleneck.h>)
+#elif __has_include(<hera/bottleneck.h>)
 # define GUDHI_GIC_USE_HERA 1
-# include <bottleneck.h>
+# include <hera/bottleneck.h>
 #endif
 
 #include <gudhi/Debug_utils.h>

--- a/src/Nerve_GIC/include/gudhi/GIC.h
+++ b/src/Nerve_GIC/include/gudhi/GIC.h
@@ -1238,6 +1238,7 @@ class Cover_complex {
 #elif defined GUDHI_GIC_USE_HERA
         double db = hera::bottleneckDistExact(this->PD, Cboot.PD);
 #else
+        double db;
         throw std::logic_error("This function requires CGAL or Hera for the bottleneck distance.");
 #endif
         if (verbose)  std::clog << db << std::endl;

--- a/src/Nerve_GIC/include/gudhi/GIC.h
+++ b/src/Nerve_GIC/include/gudhi/GIC.h
@@ -17,6 +17,14 @@
 #include <mutex>
 #endif
 
+#if __has_include(<CGAL/version.h>)
+# define GUDHI_GIC_USE_CGAL 1
+# include <gudhi/Bottleneck.h>
+#elif __has_include(<bottleneck.h>)
+# define GUDHI_GIC_USE_HERA 1
+# include <bottleneck.h>
+#endif
+
 #include <gudhi/Debug_utils.h>
 #include <gudhi/graph_simplicial_complex.h>
 #include <gudhi/reader_utils.h>
@@ -25,7 +33,6 @@
 #include <gudhi/Points_off_io.h>
 #include <gudhi/distance_functions.h>
 #include <gudhi/Persistent_cohomology.h>
-#include <gudhi/Bottleneck.h>
 
 #include <boost/config.hpp>
 #include <boost/graph/graph_traits.hpp>
@@ -34,8 +41,6 @@
 #include <boost/graph/dijkstra_shortest_paths.hpp>
 #include <boost/graph/subgraph.hpp>
 #include <boost/graph/graph_utility.hpp>
-
-#include <CGAL/version.h>  // for CGAL_VERSION_NR
 
 #include <iostream>
 #include <vector>
@@ -1228,7 +1233,13 @@ class Cover_complex {
         Cboot.set_cover_from_function();
         Cboot.find_simplices();
         Cboot.compute_PD();
+#ifdef GUDHI_GIC_USE_CGAL
         double db = Gudhi::persistence_diagram::bottleneck_distance(this->PD, Cboot.PD);
+#elif defined GUDHI_GIC_USE_HERA
+        double db = hera::bottleneckDistExact(this->PD, Cboot.PD);
+#else
+        throw std::logic_error("This function requires CGAL or Hera for the bottleneck distance.");
+#endif
         if (verbose)  std::clog << db << std::endl;
         distribution.push_back(db);
       }

--- a/src/Nerve_GIC/test/CMakeLists.txt
+++ b/src/Nerve_GIC/test/CMakeLists.txt
@@ -1,15 +1,12 @@
 project(Graph_induced_complex_tests)
 
-if (NOT CGAL_VERSION VERSION_LESS 4.11.0)
-  include(GUDHI_boost_test)
+include(GUDHI_boost_test)
 
-  add_executable ( Nerve_GIC_test_unit test_GIC.cpp )
-  if (TBB_FOUND)
-    target_link_libraries(Nerve_GIC_test_unit ${TBB_LIBRARIES})
-  endif()
+add_executable ( Nerve_GIC_test_unit test_GIC.cpp )
+if (TBB_FOUND)
+  target_link_libraries(Nerve_GIC_test_unit ${TBB_LIBRARIES})
+endif()
 
-  file(COPY data DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/)
+file(COPY data DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/)
 
-  gudhi_add_boost_test(Nerve_GIC_test_unit)
-
-endif (NOT CGAL_VERSION VERSION_LESS 4.11.0)
+gudhi_add_boost_test(Nerve_GIC_test_unit)

--- a/src/Nerve_GIC/utilities/CMakeLists.txt
+++ b/src/Nerve_GIC/utilities/CMakeLists.txt
@@ -1,27 +1,23 @@
 project(Nerve_GIC_examples)
 
-if (NOT CGAL_VERSION VERSION_LESS 4.11.0)
+add_executable ( Nerve Nerve.cpp )
+add_executable ( VoronoiGIC VoronoiGIC.cpp )
 
-  add_executable ( Nerve Nerve.cpp )
-  add_executable ( VoronoiGIC VoronoiGIC.cpp )
+if (TBB_FOUND)
+  target_link_libraries(Nerve ${TBB_LIBRARIES})
+  target_link_libraries(VoronoiGIC ${TBB_LIBRARIES})
+endif()
 
-  if (TBB_FOUND)
-    target_link_libraries(Nerve ${TBB_LIBRARIES})
-    target_link_libraries(VoronoiGIC ${TBB_LIBRARIES})
-  endif()
+file(COPY KeplerMapperVisuFromTxtFile.py km.py DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/)
+# Copy files for not to pollute sources when testing
+file(COPY "${CMAKE_SOURCE_DIR}/data/points/human.off" DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/)
 
-  file(COPY KeplerMapperVisuFromTxtFile.py km.py DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/)
-  # Copy files for not to pollute sources when testing
-  file(COPY "${CMAKE_SOURCE_DIR}/data/points/human.off" DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/)
+add_test(NAME Nerve_GIC_utilities_nerve COMMAND $<TARGET_FILE:Nerve>
+    "human.off" "2" "10" "0.3")
 
-  add_test(NAME Nerve_GIC_utilities_nerve COMMAND $<TARGET_FILE:Nerve>
-      "human.off" "2" "10" "0.3")
+add_test(NAME Nerve_GIC_utilities_VoronoiGIC COMMAND $<TARGET_FILE:VoronoiGIC>
+    "human.off" "100")
 
-  add_test(NAME Nerve_GIC_utilities_VoronoiGIC COMMAND $<TARGET_FILE:VoronoiGIC>
-      "human.off" "100")
-
-  install(TARGETS Nerve DESTINATION bin)
-  install(TARGETS VoronoiGIC DESTINATION bin)
-  install(FILES KeplerMapperVisuFromTxtFile.py km.py km.py.COPYRIGHT DESTINATION bin)
-
-endif (NOT CGAL_VERSION VERSION_LESS 4.11.0)
+install(TARGETS Nerve DESTINATION bin)
+install(TARGETS VoronoiGIC DESTINATION bin)
+install(FILES KeplerMapperVisuFromTxtFile.py km.py km.py.COPYRIGHT DESTINATION bin)

--- a/src/cmake/modules/GUDHI_submodules.cmake
+++ b/src/cmake/modules/GUDHI_submodules.cmake
@@ -1,3 +1,5 @@
 # For those who dislike bundled dependencies, this indicates where to find a preinstalled Hera.
 set(HERA_INTERNAL_INCLUDE_DIR ${CMAKE_SOURCE_DIR}/ext/hera/include)
 set(HERA_INCLUDE_DIR ${HERA_INTERNAL_INCLUDE_DIR} CACHE PATH "Directory where one can find hera/{wasserstein.h,bottleneck.h}")
+# since everything is cleanly under include/hera/, there is no harm always including it
+include_directories(${HERA_INCLUDE_DIR})

--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -163,10 +163,10 @@ if(PYTHONINTERP_FOUND)
     set(GUDHI_PYBIND11_MODULES "${GUDHI_PYBIND11_MODULES}'clustering/_tomato', ")
     set(GUDHI_PYBIND11_MODULES "${GUDHI_PYBIND11_MODULES}'hera/wasserstein', ")
     set(GUDHI_PYBIND11_MODULES "${GUDHI_PYBIND11_MODULES}'hera/bottleneck', ")
+    set(GUDHI_CYTHON_MODULES "${GUDHI_CYTHON_MODULES}'nerve_gic', ")
     if (NOT CGAL_VERSION VERSION_LESS 4.11.0)
       set(GUDHI_PYBIND11_MODULES "${GUDHI_PYBIND11_MODULES}'datasets/generators/_points', ")
       set(GUDHI_PYBIND11_MODULES "${GUDHI_PYBIND11_MODULES}'bottleneck', ")
-      set(GUDHI_CYTHON_MODULES "${GUDHI_CYTHON_MODULES}'nerve_gic', ")
     endif ()
     if (NOT CGAL_WITH_EIGEN3_VERSION VERSION_LESS 4.11.0)
       set(GUDHI_CYTHON_MODULES "${GUDHI_CYTHON_MODULES}'subsampling', ")
@@ -432,38 +432,38 @@ if(PYTHONINTERP_FOUND)
                ${PYTHON_EXECUTABLE} "${CMAKE_CURRENT_SOURCE_DIR}/example/bottleneck_basic_example.py")
 
       add_gudhi_py_test(test_bottleneck_distance)
-
-      # Cover complex
-      file(COPY ${CMAKE_SOURCE_DIR}/data/points/human.off DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/)
-      file(COPY ${CMAKE_SOURCE_DIR}/data/points/COIL_database/lucky_cat.off DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/)
-      file(COPY ${CMAKE_SOURCE_DIR}/data/points/COIL_database/lucky_cat_PCA1 DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/)
-      add_test(NAME cover_complex_nerve_example_py_test
-               WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-               COMMAND ${CMAKE_COMMAND} -E env "${GUDHI_PYTHON_PATH_ENV}"
-               ${PYTHON_EXECUTABLE} "${CMAKE_CURRENT_SOURCE_DIR}/example/nerve_of_a_covering.py"
-               -f human.off -c 2 -r 10 -g 0.3)
-
-      add_test(NAME cover_complex_coordinate_gic_example_py_test
-               WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-               COMMAND ${CMAKE_COMMAND} -E env "${GUDHI_PYTHON_PATH_ENV}"
-               ${PYTHON_EXECUTABLE} "${CMAKE_CURRENT_SOURCE_DIR}/example/coordinate_graph_induced_complex.py"
-               -f human.off -c 0 -v)
-
-      add_test(NAME cover_complex_functional_gic_example_py_test
-               WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-               COMMAND ${CMAKE_COMMAND} -E env "${GUDHI_PYTHON_PATH_ENV}"
-               ${PYTHON_EXECUTABLE} "${CMAKE_CURRENT_SOURCE_DIR}/example/functional_graph_induced_complex.py"
-               -o lucky_cat.off
-               -f lucky_cat_PCA1 -v)
-
-      add_test(NAME cover_complex_voronoi_gic_example_py_test
-               WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-               COMMAND ${CMAKE_COMMAND} -E env "${GUDHI_PYTHON_PATH_ENV}"
-               ${PYTHON_EXECUTABLE} "${CMAKE_CURRENT_SOURCE_DIR}/example/voronoi_graph_induced_complex.py"
-               -f human.off -n 700 -v)
-
-      add_gudhi_py_test(test_cover_complex)
     endif (NOT CGAL_VERSION VERSION_LESS 4.11.0)
+
+    # Cover complex
+    file(COPY ${CMAKE_SOURCE_DIR}/data/points/human.off DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/)
+    file(COPY ${CMAKE_SOURCE_DIR}/data/points/COIL_database/lucky_cat.off DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/)
+    file(COPY ${CMAKE_SOURCE_DIR}/data/points/COIL_database/lucky_cat_PCA1 DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/)
+    add_test(NAME cover_complex_nerve_example_py_test
+             WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+             COMMAND ${CMAKE_COMMAND} -E env "${GUDHI_PYTHON_PATH_ENV}"
+             ${PYTHON_EXECUTABLE} "${CMAKE_CURRENT_SOURCE_DIR}/example/nerve_of_a_covering.py"
+             -f human.off -c 2 -r 10 -g 0.3)
+
+    add_test(NAME cover_complex_coordinate_gic_example_py_test
+             WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+             COMMAND ${CMAKE_COMMAND} -E env "${GUDHI_PYTHON_PATH_ENV}"
+             ${PYTHON_EXECUTABLE} "${CMAKE_CURRENT_SOURCE_DIR}/example/coordinate_graph_induced_complex.py"
+             -f human.off -c 0 -v)
+
+    add_test(NAME cover_complex_functional_gic_example_py_test
+             WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+             COMMAND ${CMAKE_COMMAND} -E env "${GUDHI_PYTHON_PATH_ENV}"
+             ${PYTHON_EXECUTABLE} "${CMAKE_CURRENT_SOURCE_DIR}/example/functional_graph_induced_complex.py"
+             -o lucky_cat.off
+             -f lucky_cat_PCA1 -v)
+
+    add_test(NAME cover_complex_voronoi_gic_example_py_test
+             WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+             COMMAND ${CMAKE_COMMAND} -E env "${GUDHI_PYTHON_PATH_ENV}"
+             ${PYTHON_EXECUTABLE} "${CMAKE_CURRENT_SOURCE_DIR}/example/voronoi_graph_induced_complex.py"
+             -f human.off -n 700 -v)
+
+    add_gudhi_py_test(test_cover_complex)
 
     if (NOT CGAL_WITH_EIGEN3_VERSION VERSION_LESS 5.1.0)
       # Alpha

--- a/src/python/setup.py.in
+++ b/src/python/setup.py.in
@@ -27,7 +27,7 @@ extra_compile_args=[@GUDHI_PYTHON_EXTRA_COMPILE_ARGS@]
 extra_link_args=[@GUDHI_PYTHON_EXTRA_LINK_ARGS@]
 libraries=[@GUDHI_PYTHON_LIBRARIES@]
 library_dirs=[@GUDHI_PYTHON_LIBRARY_DIRS@]
-include_dirs = [numpy_get_include(), '@CMAKE_CURRENT_SOURCE_DIR@/gudhi/', @GUDHI_PYTHON_INCLUDE_DIRS@]
+include_dirs = [numpy_get_include(), '@CMAKE_CURRENT_SOURCE_DIR@/gudhi/', '@HERA_INCLUDE_DIR@', @GUDHI_PYTHON_INCLUDE_DIRS@]
 runtime_library_dirs=[@GUDHI_PYTHON_RUNTIME_LIBRARY_DIRS@]
 
 # Create ext_modules list from module list
@@ -48,8 +48,6 @@ ext_modules = cythonize(ext_modules, compiler_directives={'language_level': '3'}
 
 for module in pybind11_modules:
     my_include_dirs = include_dirs + [pybind11.get_include(False), pybind11.get_include(True)]
-    if module.startswith('hera/'):
-        my_include_dirs = ['@HERA_INCLUDE_DIR@'] + my_include_dirs
     ext_modules.append(Extension(
         'gudhi.' + module.replace('/', '.'),
         sources = [source_dir + module + '.cc'],

--- a/src/python/setup.py.in
+++ b/src/python/setup.py.in
@@ -27,7 +27,7 @@ extra_compile_args=[@GUDHI_PYTHON_EXTRA_COMPILE_ARGS@]
 extra_link_args=[@GUDHI_PYTHON_EXTRA_LINK_ARGS@]
 libraries=[@GUDHI_PYTHON_LIBRARIES@]
 library_dirs=[@GUDHI_PYTHON_LIBRARY_DIRS@]
-include_dirs = [numpy_get_include(), '@CMAKE_CURRENT_SOURCE_DIR@/gudhi/', '@HERA_INCLUDE_DIR@', @GUDHI_PYTHON_INCLUDE_DIRS@]
+include_dirs = [numpy_get_include(), '@CMAKE_CURRENT_SOURCE_DIR@/gudhi/', @GUDHI_PYTHON_INCLUDE_DIRS@]
 runtime_library_dirs=[@GUDHI_PYTHON_RUNTIME_LIBRARY_DIRS@]
 
 # Create ext_modules list from module list


### PR DESCRIPTION
It was inconvenient to disable the whole module for that.
Basing the decision on `__has_include` may not be the cleanest, but it looks ok for header-only libraries (the kd-tree should not use gmp/mpfr), and doesn't require users to mess with flags.

This also comes on top of #735.
Fix #712.