### PR TITLE
Rename argument of expansion

### DIFF
--- a/src/python/gudhi/simplex_tree.pyx
+++ b/src/python/gudhi/simplex_tree.pyx
@@ -376,7 +376,7 @@ cdef class SimplexTree:
         """
         return self.get_ptr().prune_above_filtration(filtration)
 
-    def expansion(self, max_dim):
+    def expansion(self, max_dimension):
         """Expands the simplex tree containing only its one skeleton
         until dimension max_dim.
 
@@ -390,10 +390,10 @@ cdef class SimplexTree:
         The simplex tree must contain no simplex of dimension bigger than
         1 when calling the method.
 
-        :param max_dim: The maximal dimension.
-        :type max_dim: int
+        :param max_dimension: The maximal dimension.
+        :type max_dimension: int
         """
-        cdef int maxdim = max_dim
+        cdef int maxdim = max_dimension
         with nogil:
             self.get_ptr().expansion(maxdim)
 


### PR DESCRIPTION
Fix #739.
When we finally get cython3 which changes the default for always_allow_keywords, we'll be able to do some clean-ups and remove the meaningless default arguments of some functions. We could already do it without disabling keyword arguments by setting always_allow_keywords to True globally, or annotating selected functions with `@cython.always_allow_keywords(True)`.