### PR TITLE
pytest.warns(None) deprecated

### DIFF
--- a/src/python/test/test_persistence_graphical_tools.py
+++ b/src/python/test/test_persistence_graphical_tools.py
@@ -12,6 +12,7 @@ import gudhi as gd
 import numpy as np
 import matplotlib as plt
 import pytest
+import warnings
 
 
 def test_array_handler():
@@ -71,13 +72,13 @@ def test_limit_to_max_intervals():
         (0, (0.0, 0.106382)),
     ]
     # check no warnings if max_intervals equals to the diagrams number
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
         truncated_diags = gd.persistence_graphical_tools._limit_to_max_intervals(
             diags, 10, key=lambda life_time: life_time[1][1] - life_time[1][0]
         )
         # check diagrams are not sorted
         assert truncated_diags == diags
-    assert len(record) == 0
 
     # check warning if max_intervals lower than the diagrams number
     with pytest.warns(UserWarning) as record:


### PR DESCRIPTION
The warnings points to
https://docs.pytest.org/en/latest/how-to/capture-warnings.html#additional-use-cases-of-warnings-in-tests