### PR TITLE
Handle clang warnings

### DIFF
--- a/src/Tangential_complex/include/gudhi/Tangential_complex.h
+++ b/src/Tangential_complex/include/gudhi/Tangential_complex.h
@@ -345,10 +345,11 @@ class Tangential_complex {
     m_stars.resize(m_points.size());
     m_squared_star_spheres_radii_incl_margin.resize(m_points.size(), FT(-1));
 #ifdef GUDHI_TC_PERTURB_POSITION
-    if (m_points.empty())
+    if (m_points.empty()) {
       m_translations.clear();
-    else
+    } else {
       m_translations.resize(m_points.size(), m_k.construct_vector_d_object()(m_ambient_dim));
+    }
 #if defined(GUDHI_USE_TBB)
     delete[] m_p_perturb_mutexes;
     m_p_perturb_mutexes = new Mutex_for_perturb[m_points.size()];

--- a/src/python/include/Alpha_complex_factory.h
+++ b/src/python/include/Alpha_complex_factory.h
@@ -106,7 +106,7 @@ class Exact_alpha_complex_dD final : public Abstract_alpha_complex {
     return alpha_complex_.create_complex(*simplex_tree, max_alpha_square, exact_version_, default_filtration_value);
   }
 
-  virtual std::size_t num_vertices() const {
+  virtual std::size_t num_vertices() const override {
     return alpha_complex_.num_vertices();
   }
 
@@ -141,7 +141,7 @@ class Inexact_alpha_complex_dD final : public Abstract_alpha_complex {
     return alpha_complex_.create_complex(*simplex_tree, max_alpha_square, false, default_filtration_value);
   }
 
-  virtual std::size_t num_vertices() const {
+  virtual std::size_t num_vertices() const override {
     return alpha_complex_.num_vertices();
   }
 


### PR DESCRIPTION
The other virtual functions already had override.

`#if` ended up presenting the compiler with preprocessed code that admittedly looked suspicious, although it is obviously fine if you look at the original source. Still, the brackets don't hurt much.