### PR TITLE
Build universal2 wheels on macos

### DIFF
--- a/.github/workflows/pip-build-osx.yml
+++ b/.github/workflows/pip-build-osx.yml
@@ -2,6 +2,11 @@ name: pip build osx
 
 on: [push, pull_request]
 
+env:
+  MACOSX_DEPLOYMENT_TARGET: 10.14
+  _PYTHON_HOST_PLATFORM: macosx-10.14-universal2
+  ARCHFLAGS: "-arch arm64 -arch x86_64"
+
 jobs:
   build:
     runs-on: macos-latest
@@ -24,14 +29,21 @@ jobs:
           brew install boost eigen gmp mpfr cgal || true
           python -m pip install --user -r ext/gudhi-deploy/build-requirements.txt
           python -m pip install --user twine delocate
+          ./scripts/build_osx_universal_gmpfr.sh
+          # Now the universal libraries are in $PWD/deps-uni/lib
       - name: Build python wheel
         run: |
+          export   GMP_LIB_DIR=$PWD/deps-uni/lib
+          export GMPXX_LIB_DIR=$PWD/deps-uni/lib
+          export  MPFR_LIB_DIR=$PWD/deps-uni/lib
           python --version
           mkdir build
           cd build
           cmake -DCMAKE_BUILD_TYPE=Release -DPython_ADDITIONAL_VERSIONS=3 ..
           cd src/python
           python setup.py bdist_wheel
+          export PATH="$PATH:`python -m site --user-base`/bin"
+          delocate-wheel --require-archs universal2 -v dist/*.whl
       - name: Install and test python wheel
         run: |
           python -m pip install --user pytest build/src/python/dist/*.whl

--- a/.github/workflows/pip-packaging-osx.yml
+++ b/.github/workflows/pip-packaging-osx.yml
@@ -4,6 +4,11 @@ on:
   release:
     types: [published]
 
+env:
+  MACOSX_DEPLOYMENT_TARGET: 10.15
+  _PYTHON_HOST_PLATFORM: macosx-10.15-universal2
+  ARCHFLAGS: "-arch arm64 -arch x86_64"
+
 jobs:
   build:
     runs-on: macos-latest
@@ -26,8 +31,13 @@ jobs:
           brew install boost eigen gmp mpfr cgal || true
           python -m pip install --user -r ext/gudhi-deploy/build-requirements.txt
           python -m pip install --user twine delocate
+          ./scripts/build_osx_universal_gmpfr.sh
+          # Now the universal libs are in $PWD/deps-uni/lib
       - name: Build python wheel
         run: |
+          export   GMP_LIB_DIR=$PWD/deps-uni/lib
+          export GMPXX_LIB_DIR=$PWD/deps-uni/lib
+          export  MPFR_LIB_DIR=$PWD/deps-uni/lib
           python --version
           mkdir build
           cd build
@@ -45,6 +55,7 @@ jobs:
           TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
         run: |
           mkdir wheelhouse
-          /Users/runner/.local/bin/delocate-listdeps build/src/python/dist/*
-          /Users/runner/.local/bin/delocate-wheel --require-archs x86_64 -w wheelhouse build/src/python/dist/*
+          export PATH="$PATH:`python -m site --user-base`/bin"
+          delocate-listdeps build/src/python/dist/*
+          delocate-wheel --require-archs universal2 -w wheelhouse build/src/python/dist/*
           python -m twine upload wheelhouse/*

--- a/scripts/build_osx_universal_gmpfr.sh
+++ b/scripts/build_osx_universal_gmpfr.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+set -e
+
+# In the working directory, creates deps-uni/lib/*
+# Assumes that the user has enough rights to run brew fetch
+
+# Downloading
+mkdir deps-amd64
+cd deps-amd64
+tar xf "`brew fetch --bottle-tag=big_sur gmp        | sed -ne 's/^Downloaded to: //p'`"
+tar xf "`brew fetch --bottle-tag=big_sur mpfr       | sed -ne 's/^Downloaded to: //p'`"
+cd ..
+mkdir deps-arm64
+cd deps-arm64
+tar xf "`brew fetch --bottle-tag=arm64_big_sur gmp  | sed -ne 's/^Downloaded to: //p'`"
+tar xf "`brew fetch --bottle-tag=arm64_big_sur mpfr | sed -ne 's/^Downloaded to: //p'`"
+cd ..
+
+# Merging
+mkdir -p deps-uni/lib
+GMP1=deps-amd64/gmp/*/lib/libgmp.*.dylib
+GMP=`basename $GMP1`
+GMPXX1=deps-amd64/gmp/*/lib/libgmpxx.*.dylib
+GMPXX=`basename $GMPXX1`
+MPFR1=deps-amd64/mpfr/*/lib/libmpfr.*.dylib
+MPFR=`basename $MPFR1`
+lipo -create $GMP1 deps-arm64/gmp/*/lib/$GMP -output deps-uni/lib/$GMP
+lipo -create $GMPXX1 deps-arm64/gmp/*/lib/$GMPXX -output deps-uni/lib/$GMPXX
+lipo -create $MPFR1 deps-arm64/mpfr/*/lib/$MPFR -output deps-uni/lib/$MPFR
+
+# Necessary even for libs created by lipo
+install_name_tool -id $PWD/deps-uni/lib/$GMP deps-uni/lib/$GMP
+install_name_tool -id $PWD/deps-uni/lib/$GMPXX deps-uni/lib/$GMPXX
+install_name_tool -id $PWD/deps-uni/lib/$MPFR deps-uni/lib/$MPFR
+# Also fix dependencies
+BADGMP=`otool -L deps-uni/lib/$MPFR|sed -ne 's/[[:space:]]*\(.*libgmp\..*dylib\).*/\1/p'`
+install_name_tool -change $BADGMP $PWD/deps-uni/lib/$GMP deps-uni/lib/$MPFR
+BADGMP=`otool -L deps-uni/lib/$GMPXX|sed -ne 's/[[:space:]]*\(.*libgmp\..*dylib\).*/\1/p'`
+install_name_tool -change $BADGMP $PWD/deps-uni/lib/$GMP deps-uni/lib/$GMPXX
+
+ln -s $GMP deps-uni/lib/libgmp.dylib
+ln -s $GMPXX deps-uni/lib/libgmpxx.dylib
+ln -s $MPFR deps-uni/lib/libmpfr.dylib
+
+# Debug
+ls -l deps-uni/lib
+otool -L deps-uni/lib/*.*.dylib


### PR DESCRIPTION
Use 10.15, old python complains if I try to use 10.14.
More robust location for pip package, apparently in CI for 3.11 they changed the location from $HOME/.local/bin (linux-style) to the usual location on Mac.

AFAIK there is no python 3.7 for Mac M1, but the build still succeeds, and it doesn't seem worth it to make a special case for old versions of python we will soon remove anyway.

Of course, alternative strategies to get a wheel for Mac arm64 are welcome if they work and are simpler.

Fix #682.