### PR TITLE
Add to_file/from_file methods to the SimplexTree

### DIFF
--- a/src/Simplex_tree/include/gudhi/Simplex_tree.h
+++ b/src/Simplex_tree/include/gudhi/Simplex_tree.h
@@ -1757,7 +1757,7 @@ class Simplex_tree {
 // Print a Simplex_tree in os.
 template<typename...T>
 std::ostream& operator<<(std::ostream & os, Simplex_tree<T...> & st) {
-  for (auto sh : st.filtration_simplex_range()) {
+  for (auto sh : st.complex_simplex_range()) {
     os << st.dimension(sh) << " ";
     for (auto v : st.simplex_vertex_range(sh)) {
       os << v << " ";

--- a/src/python/gudhi/simplex_tree.pxd
+++ b/src/python/gudhi/simplex_tree.pxd
@@ -80,6 +80,8 @@ cdef extern from "Simplex_tree_interface.h" namespace "Gudhi":
         # Expansion with blockers
         ctypedef bool (*blocker_func_t)(vector[int], void *user_data)
         void expansion_with_blockers_callback(int dimension, blocker_func_t user_func, void *user_data)
+        void read(string file_name) nogil
+        void write(string file_name) nogil
 
 cdef extern from "Persistent_cohomology_interface.h" namespace "Gudhi":
     cdef cppclass Simplex_tree_persistence_interface "Gudhi::Persistent_cohomology_interface<Gudhi::Simplex_tree_interface<Gudhi::Simplex_tree_options_full_featured>>":

--- a/src/python/gudhi/simplex_tree.pyx
+++ b/src/python/gudhi/simplex_tree.pyx
@@ -798,5 +798,35 @@ cdef class SimplexTree:
         """
         return dereference(self.get_ptr()) == dereference(other.get_ptr())
 
+    def to_file(self, filename):
+        """This function writes the simplex tree in a user given file name.
+
+        :param filename: Name of the file.
+        :type filename: string
+
+        .. note::
+            Beware that if the :class:`~gudhi.SimplexTree` is not a valid filtration anymore, a simplex could have a
+            lower filtration value than one of its faces. As :meth:`from_file` is using :meth:`insert_simplex`, you may
+            not retrieve your non-valid filtration.
+            Callers are responsible for fixing this (with :meth:`make_filtration_non_decreasing` for instance) before
+            calling any function that relies on the filtration property.
+        """
+        self.get_ptr().write(filename.encode('utf-8'))
+
+    def from_file(self, filename):
+        """This function reads the simplex tree in a user given file name.
+
+        :param filename: Name of the file.
+        :type filename: string
+
+        .. note::
+            Beware that :meth:`from_file` is using :meth:`insert_simplex`. If the :class:`~gudhi.SimplexTree` defined
+            in the file is not a valid filtration (a simplex could have a lower filtration value than one of its
+            faces), you may not retrieve your non-valid filtration.
+            Callers are responsible for fixing this (with :meth:`make_filtration_non_decreasing` for instance) before
+            writting a file (with :meth:`from_file` for instance).
+        """
+        self.get_ptr().read(filename.encode('utf-8'))
+
 cdef intptr_t _get_copy_intptr(SimplexTree stree) nogil:
     return <intptr_t>(new Simplex_tree_interface_full_featured(dereference(stree.get_ptr())))

--- a/src/python/include/Simplex_tree_interface.h
+++ b/src/python/include/Simplex_tree_interface.h
@@ -233,6 +233,18 @@ class Simplex_tree_interface : public Simplex_tree<SimplexTreeOptions> {
     auto boundary_srange = Base::boundary_simplex_range(bd_sh);
     return std::make_pair(boundary_srange.begin(), boundary_srange.end());
   }
+
+  void read(std::string filename) {
+    std::ifstream ifs(filename.c_str());
+    ifs >> *this;
+    ifs.close();
+  }
+
+  void write(std::string filename) {
+    std::ofstream ofs(filename.c_str());
+    ofs << *this;
+    ofs.close();
+  }
 };
 
 }  // namespace Gudhi

--- a/src/python/include/Simplex_tree_interface.h
+++ b/src/python/include/Simplex_tree_interface.h
@@ -235,13 +235,13 @@ class Simplex_tree_interface : public Simplex_tree<SimplexTreeOptions> {
   }
 
   void read(std::string filename) {
-    std::ifstream ifs(filename.c_str());
+    std::ifstream ifs(filename);
     ifs >> *this;
     ifs.close();
   }
 
   void write(std::string filename) {
-    std::ofstream ofs(filename.c_str());
+    std::ofstream ofs(filename);
     ofs << *this;
     ofs.close();
   }

--- a/src/python/test/test_simplex_tree.py
+++ b/src/python/test/test_simplex_tree.py
@@ -652,6 +652,5 @@ def test_read_write_methods():
     st.make_filtration_non_decreasing()
     st.expansion(2)
     st.to_file('random.st')
-    st_copy = SimplexTree()
-    st_copy.from_file('random.st')
+    st_copy = SimplexTree.create_from_file('random.st')
     assert st == st_copy

--- a/src/python/test/test_simplex_tree.py
+++ b/src/python/test/test_simplex_tree.py
@@ -644,3 +644,14 @@ def test_expansion_with_blocker():
     assert st.filtration([0, 2, 3]) == 6.0
     assert st.filtration([1, 2, 3]) == 6.0
     assert st.filtration([0, 1, 2, 3]) == 7.0
+
+def test_read_write_methods():
+    a = np.random.randint(10, size=(50, 50))
+    st = SimplexTree.create_from_array(a, max_filtration=9.0)
+    # Because of randomness, simplex tree can be inconsistent and from_file is not guaranteed when insert_simplex
+    st.make_filtration_non_decreasing()
+    st.expansion(2)
+    st.to_file('random.st')
+    st_copy = SimplexTree()
+    st_copy.from_file('random.st')
+    assert st == st_copy


### PR DESCRIPTION
This is a first naive python implementation that uses C++ `operator>>` and `operator<<`.

To be discussed:
* should the file format be described in [C++ file format](https://gudhi.inria.fr/doc/latest/fileformats.html) and [python file format](https://gudhi.inria.fr/python/latest/fileformats.html)
* should it be implemented through `__show__`/`__str__`/`__repr__` python magic methods ?
* should it use `pandas get_handle` that can compress files on the fly based on the file name, like:
```
from pandas.io.common import get_handle

handles = get_handle('my_file.xz', 'w', compression = "infer")
handles.handle.write("something")
handles.handle.close() # my_file.xz is saved as a compresssed text file
```