### PR TITLE
Correct bracket for exponential

### DIFF
--- a/src/python/test/test_representations.py
+++ b/src/python/test/test_representations.py
@@ -93,7 +93,7 @@ def test_kernel_from_distance():
         kernelClass, kernelParams, tolerance = kernel_dict[kernelName]
         f1 = kernelClass.fit_transform(l1)
         d1 = pairwise_persistence_diagram_distances(l1, metric=kernelName, **kernelParams)
-        assert np.exp(-d1/kernelClass.bandwidth == pytest.approx(f1, **tolerance))
+        assert np.exp(-d1/kernelClass.bandwidth) == pytest.approx(f1, **tolerance)
 
 def test_kernel_distance_consistency():
     l1, l2 = _n_diags(9), _n_diags(11)


### PR DESCRIPTION
This PR aims to fix two issues noticed after #755 :
- Incorrect [bracket](https://github.com/wreise/gudhi-devel/blob/20116fbf0d9608a766c056cd689be7cece6705a2/src/python/test/test_representations.py#L96) in exponential makes tests pass almost always. 
- Many lines are marked as tested only because they are covered by `src/python/example/diagram_vectorizations_distances_kernels.py`.