### PR TITLE
pyupgrade --py3-plus

### DIFF
--- a/src/python/doc/conf.py
+++ b/src/python/doc/conf.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-#
 # GUDHI documentation build configuration file, created by
 # sphinx-quickstart on Thu Jun 30 09:55:51 2016.
 #

--- a/src/python/example/euclidean_strong_witness_complex_diagram_persistence_from_off_file_example.py
+++ b/src/python/example/euclidean_strong_witness_complex_diagram_persistence_from_off_file_example.py
@@ -44,7 +44,7 @@ parser.add_argument(
 
 args = parser.parse_args()
 
-with open(args.file, "r") as f:
+with open(args.file) as f:
     first_line = f.readline()
     if (first_line == "OFF\n") or (first_line == "nOFF\n"):
         print("##############################################################")

--- a/src/python/example/euclidean_witness_complex_diagram_persistence_from_off_file_example.py
+++ b/src/python/example/euclidean_witness_complex_diagram_persistence_from_off_file_example.py
@@ -43,7 +43,7 @@ parser.add_argument(
 
 args = parser.parse_args()
 
-with open(args.file, "r") as f:
+with open(args.file) as f:
     first_line = f.readline()
     if (first_line == "OFF\n") or (first_line == "nOFF\n"):
         print("#####################################################################")

--- a/src/python/example/rips_complex_diagram_persistence_from_off_file_example.py
+++ b/src/python/example/rips_complex_diagram_persistence_from_off_file_example.py
@@ -42,7 +42,7 @@ parser.add_argument(
 
 args = parser.parse_args()
 
-with open(args.file, "r") as f:
+with open(args.file) as f:
     first_line = f.readline()
     if (first_line == "OFF\n") or (first_line == "nOFF\n"):
         print("##############################################################")

--- a/src/python/example/tangential_complex_plain_homology_from_off_file_example.py
+++ b/src/python/example/tangential_complex_plain_homology_from_off_file_example.py
@@ -41,7 +41,7 @@ parser.add_argument(
 
 args = parser.parse_args()
 
-with open(args.file, "r") as f:
+with open(args.file) as f:
     first_line = f.readline()
     if (first_line == "OFF\n") or (first_line == "nOFF\n"):
         print("##############################################################")

--- a/src/python/gudhi/datasets/remote.py
+++ b/src/python/gudhi/datasets/remote.py
@@ -110,7 +110,7 @@ def _fetch_remote(url, file_path, file_checksum = None):
         if file_checksum != checksum:
             # Remove file and raise error
             remove(file_path)
-            raise IOError("{} has a SHA256 checksum : {}, "
+            raise OSError("{} has a SHA256 checksum : {}, "
                         "different from expected : {}."
                         "The file may be corrupted or the given url may be wrong !".format(file_path, checksum, file_checksum))
 
@@ -217,7 +217,7 @@ def fetch_bunny(file_path = None, accept_license = False):
         # Print license terms unless accept_license is set to True
         if not accept_license:
             if exists(license_path):
-                with open(license_path, 'r') as f:
+                with open(license_path) as f:
                     print(f.read())
 
     return np.load(archive_path, mmap_mode='r')

--- a/src/python/gudhi/persistence_graphical_tools.py
+++ b/src/python/gudhi/persistence_graphical_tools.py
@@ -208,7 +208,7 @@ def plot_persistence_barcode(
             legend = True
 
         if legend:
-            dimensions = set(item[0] for item in persistence)
+            dimensions = {item[0] for item in persistence}
             axes.legend(
                 handles=[mpatches.Patch(color=colormap[dim], label=str(dim)) for dim in dimensions],
                 loc="best",
@@ -240,7 +240,7 @@ def plot_persistence_diagram(
     fontsize=16,
     greyblock=True,
 ):
-    """This function plots the persistence diagram from persistence values
+    r"""This function plots the persistence diagram from persistence values
     list, a np.array of shape (N x 2) representing a diagram in a single
     homology dimension, or from a `persistence diagram <fileformats.html#persistence-diagram>`_ file`.
 
@@ -361,7 +361,7 @@ def plot_persistence_diagram(
             legend = True
 
         if legend:
-            dimensions = list(set(item[0] for item in persistence))
+            dimensions = list({item[0] for item in persistence})
             axes.legend(
                 handles=[mpatches.Patch(color=colormap[dim], label=str(dim)) for dim in dimensions],
                 loc="lower right",

--- a/src/python/gudhi/representations/metrics.py
+++ b/src/python/gudhi/representations/metrics.py
@@ -240,7 +240,7 @@ class SlicedWassersteinDistance(BaseEstimator, TransformerMixin):
         return _sliced_wasserstein_distance(diag1, diag2, num_directions=self.num_directions)
 
 class BottleneckDistance(BaseEstimator, TransformerMixin):
-    """
+    r"""
     This is a class for computing the bottleneck distance matrix from a list of persistence diagrams.
 
     :Requires: `CGAL <installation.html#cgal>`_ :math:`\geq` 4.11.0

--- a/src/python/gudhi/representations/preprocessing.py
+++ b/src/python/gudhi/representations/preprocessing.py
@@ -194,7 +194,7 @@ class Padding(BaseEstimator, TransformerMixin):
             X (list of n x 2 or n x 1 numpy arrays): input persistence diagrams.
             y (n x 1 array): persistence diagram labels (unused).
         """
-        self.max_pts = max([len(diag) for diag in X])
+        self.max_pts = max(len(diag) for diag in X)
         return self
 
     def transform(self, X):


### PR DESCRIPTION
Some cleanups suggested by this tool. For more modern Python (I don't think we should bother with 3.5 and 3.6 anymore), the only extra change it suggests is in src/python/gudhi/datasets/generators/points.py
```diff
-        raise ValueError("Sample type '{}' is not supported".format(sample))
+        raise ValueError(f"Sample type '{sample}' is not supported")
```

Some reasons:
* utf-8 is the default
* open(..., "r") is the default
* Strings with \geq or \leq are a bit dangerous, \g or \l could be something special (like \n), they should be safer as raw strings.

We don't have to take everything, but I thought I'd post the full diff it generates. I didn't test anything.