### PR TITLE
Use autodoc_class_signature to document __init__

### DIFF
--- a/src/python/doc/alpha_complex_ref.rst
+++ b/src/python/doc/alpha_complex_ref.rst
@@ -9,5 +9,3 @@ Alpha complex reference manual
 .. autoclass:: gudhi.AlphaComplex
    :members:
    :undoc-members:
-
-   .. automethod:: gudhi.AlphaComplex.__init__

--- a/src/python/doc/clustering.rst
+++ b/src/python/doc/clustering.rst
@@ -69,4 +69,3 @@ Since the algorithm essentially computes basins of attraction, it is also encour
 
 .. autoclass:: gudhi.clustering.tomato.Tomato
    :members:
-   :special-members: __init__

--- a/src/python/doc/conf.py
+++ b/src/python/doc/conf.py
@@ -19,6 +19,8 @@ extensions = [
     "sphinx_paramlinks",
 ]
 
+autodoc_class_signature = "separated"
+
 bibtex_bibfiles = ["../../biblio/bibliography.bib"]
 
 templates_path = ["_templates"]

--- a/src/python/doc/cubical_complex_ref.rst
+++ b/src/python/doc/cubical_complex_ref.rst
@@ -9,5 +9,3 @@ Cubical complex reference manual
    :members:
    :undoc-members:
    :show-inheritance:
-
-   .. automethod:: gudhi.CubicalComplex.__init__

--- a/src/python/doc/cubical_complex_sklearn_itf_ref.rst
+++ b/src/python/doc/cubical_complex_sklearn_itf_ref.rst
@@ -98,5 +98,4 @@ Cubical complex persistence scikit-learn like interface reference
 
 .. autoclass:: gudhi.sklearn.cubical_persistence.CubicalPersistence
    :members:
-   :special-members: __init__
    :show-inheritance:

--- a/src/python/doc/cubical_complex_tflow_itf_ref.rst
+++ b/src/python/doc/cubical_complex_tflow_itf_ref.rst
@@ -36,5 +36,4 @@ Documentation for CubicalLayer
 
 .. autoclass:: gudhi.tensorflow.CubicalLayer
    :members:
-   :special-members: __init__
    :show-inheritance:

--- a/src/python/doc/euclidean_strong_witness_complex_ref.rst
+++ b/src/python/doc/euclidean_strong_witness_complex_ref.rst
@@ -10,5 +10,3 @@ Euclidean strong witness complex reference manual
    :members:
    :undoc-members:
    :show-inheritance:
-
-   .. automethod:: gudhi.EuclideanStrongWitnessComplex.__init__

--- a/src/python/doc/euclidean_witness_complex_ref.rst
+++ b/src/python/doc/euclidean_witness_complex_ref.rst
@@ -10,5 +10,3 @@ Euclidean witness complex reference manual
    :members:
    :undoc-members:
    :show-inheritance:
-
-   .. automethod:: gudhi.EuclideanWitnessComplex.__init__

--- a/src/python/doc/ls_simplex_tree_tflow_itf_ref.rst
+++ b/src/python/doc/ls_simplex_tree_tflow_itf_ref.rst
@@ -49,5 +49,4 @@ Documentation for LowerStarSimplexTreeLayer
 
 .. autoclass:: gudhi.tensorflow.LowerStarSimplexTreeLayer
    :members:
-   :special-members: __init__
    :show-inheritance:

--- a/src/python/doc/nerve_gic_complex_ref.rst
+++ b/src/python/doc/nerve_gic_complex_ref.rst
@@ -10,5 +10,3 @@ Cover complexes reference manual
    :members:
    :undoc-members:
    :show-inheritance:
-
-   .. automethod:: gudhi.CoverComplex.__init__

--- a/src/python/doc/periodic_cubical_complex_ref.rst
+++ b/src/python/doc/periodic_cubical_complex_ref.rst
@@ -9,5 +9,3 @@ Periodic cubical complex reference manual
    :members:
    :undoc-members:
    :show-inheritance:
-
-   .. automethod:: gudhi.PeriodicCubicalComplex.__init__

--- a/src/python/doc/point_cloud.rst
+++ b/src/python/doc/point_cloud.rst
@@ -39,7 +39,6 @@ K nearest neighbors
 .. automodule:: gudhi.point_cloud.knn
    :members:
    :undoc-members:
-   :special-members: __init__
 
 Distance to measure
 -------------------
@@ -47,4 +46,3 @@ Distance to measure
 .. automodule:: gudhi.point_cloud.dtm
    :members:
    :undoc-members:
-   :special-members: __init__

--- a/src/python/doc/rips_complex_ref.rst
+++ b/src/python/doc/rips_complex_ref.rst
@@ -11,8 +11,6 @@ Rips complex reference manual
    :undoc-members:
    :show-inheritance:
 
-   .. automethod:: gudhi.RipsComplex.__init__
-
 ======================================
 Weighted Rips complex reference manual
 ======================================
@@ -22,8 +20,6 @@ Weighted Rips complex reference manual
    :undoc-members:
    :show-inheritance:
 
-   .. automethod:: gudhi.weighted_rips_complex.WeightedRipsComplex.__init__
-
 =================================
 DTM Rips complex reference manual
 =================================
@@ -32,5 +28,3 @@ DTM Rips complex reference manual
    :members:
    :undoc-members:
    :show-inheritance:
-
-   .. automethod:: gudhi.dtm_rips_complex.DTMRipsComplex.__init__

--- a/src/python/doc/rips_complex_tflow_itf_ref.rst
+++ b/src/python/doc/rips_complex_tflow_itf_ref.rst
@@ -44,5 +44,4 @@ Documentation for RipsLayer
 
 .. autoclass:: gudhi.tensorflow.RipsLayer
    :members:
-   :special-members: __init__
    :show-inheritance:

--- a/src/python/doc/simplex_tree_ref.rst
+++ b/src/python/doc/simplex_tree_ref.rst
@@ -9,5 +9,3 @@ Simplex tree reference manual
 .. autoclass:: gudhi.SimplexTree
    :members:
    :show-inheritance:
-
-   .. automethod:: gudhi.SimplexTree.__init__

--- a/src/python/doc/strong_witness_complex_ref.rst
+++ b/src/python/doc/strong_witness_complex_ref.rst
@@ -10,5 +10,3 @@ Strong witness complex reference manual
    :members:
    :undoc-members:
    :show-inheritance:
-
-   .. automethod:: gudhi.StrongWitnessComplex.__init__

--- a/src/python/doc/tangential_complex_ref.rst
+++ b/src/python/doc/tangential_complex_ref.rst
@@ -10,5 +10,3 @@ Tangential complex reference manual
    :members:
    :undoc-members:
    :show-inheritance:
-
-   .. automethod:: gudhi.TangentialComplex.__init__

--- a/src/python/doc/witness_complex_ref.rst
+++ b/src/python/doc/witness_complex_ref.rst
@@ -10,5 +10,3 @@ Witness complex reference manual
    :members:
    :undoc-members:
    :show-inheritance:
-
-   .. automethod:: gudhi.WitnessComplex.__init__


### PR DESCRIPTION
I was trying to avoid the repetition of the arguments
```
class gudhi.representations.preprocessing.Clamping(minimum=-inf, maximum=inf)
__init__(minimum=-inf, maximum=inf)
```
and it came with side benefits.

We should still check that the doc looks ok with this change.