### PR TITLE
Qt vs TBB conflict about `emit`

### DIFF
--- a/src/GudhUI/CMakeLists.txt
+++ b/src/GudhUI/CMakeLists.txt
@@ -32,6 +32,7 @@ if (OPENGL_FOUND)
         target_link_libraries( GudhUI ${QGLVIEWER_LIBRARIES} )
         target_link_libraries( GudhUI ${OPENGL_gl_LIBRARY} ${OPENGL_glu_LIBRARY} )
         if(TARGET TBB::tbb)
+          add_compile_definitions( QT_NO_EMIT )
           target_link_libraries( GudhUI TBB::tbb)
         endif()
 

--- a/src/GudhUI/gui/MainWindow.cpp
+++ b/src/GudhUI/gui/MainWindow.cpp
@@ -120,7 +120,7 @@ MainWindow::init_view() const {
 
 void
 MainWindow::update_view() const {
-  emit(sceneChanged());
+  /*emit*/ sceneChanged();
 }
 
 /**

--- a/src/GudhUI/gui/Menu_edge_contraction.cpp
+++ b/src/GudhUI/gui/Menu_edge_contraction.cpp
@@ -66,7 +66,7 @@ Menu_edge_contraction::update_gui_numbers(int new_value) {
 
 void
 Menu_edge_contraction::send_contract_edges() {
-  emit(contract_edges(num_collapses()));
+  /*emit*/ contract_edges(num_collapses());
   update_gui_numbers();
 }
 

--- a/src/GudhUI/gui/Menu_k_nearest_neighbors.cpp
+++ b/src/GudhUI/gui/Menu_k_nearest_neighbors.cpp
@@ -32,7 +32,7 @@ void Menu_k_nearest_neighbors::connectActions(QMainWindow* parent) {
 }
 
 void Menu_k_nearest_neighbors::send_compute_k_nearest_neighbors() {
-  emit(compute_k_nearest_neighbors((unsigned) spinBoxK->value()));
+  /*emit*/ compute_k_nearest_neighbors((unsigned) spinBoxK->value());
 }
 
 void Menu_k_nearest_neighbors::accept() {
@@ -41,7 +41,7 @@ void Menu_k_nearest_neighbors::accept() {
 
 void Menu_k_nearest_neighbors::update_k(int new_k_value) {
   if (checkBoxAutoUpdate->isChecked())
-    emit(compute_k_nearest_neighbors((unsigned) spinBoxK->value()));
+    /*emit*/ compute_k_nearest_neighbors((unsigned) spinBoxK->value());
 }
 
 #include "Menu_k_nearest_neighbors.moc"

--- a/src/GudhUI/gui/Menu_persistence.cpp
+++ b/src/GudhUI/gui/Menu_persistence.cpp
@@ -24,8 +24,8 @@ void Menu_persistence::connectActions(QMainWindow* parent) {
 }
 
 void Menu_persistence::send_compute_persistence() {
-  emit(compute_persistence(p_spinBox->value(), threshold_doubleSpinBox->value(),
-                           maxdimension_spinBox->value(), minpersistence_doubleSpinBox->value()));
+  /*emit*/ compute_persistence(p_spinBox->value(), threshold_doubleSpinBox->value(),
+                           maxdimension_spinBox->value(), minpersistence_doubleSpinBox->value());
 }
 
 void Menu_persistence::accept() {
@@ -34,7 +34,7 @@ void Menu_persistence::accept() {
 
 // void Menu_persistence::compute_persistence(int p_fied,double threshold,int dim_max,double min_persistence) {
 //  if(checkBoxAutoUpdate->isChecked())
-//    emit(compute_k_nearest_neighbors((unsigned)spinBoxK->value()));
+//    /*emit*/ compute_k_nearest_neighbors((unsigned)spinBoxK->value());
 // }
 
 #include "Menu_persistence.moc"

--- a/src/GudhUI/gui/Menu_uniform_neighbors.cpp
+++ b/src/GudhUI/gui/Menu_uniform_neighbors.cpp
@@ -32,7 +32,7 @@ void Menu_uniform_neighbors::connectActions(QMainWindow* parent) {
 }
 
 void Menu_uniform_neighbors::send_compute_uniform_neighbors() {
-  emit(compute_uniform_neighbors(doubleSpinBoxAlpha->value()));
+  /*emit*/ compute_uniform_neighbors(doubleSpinBoxAlpha->value());
 }
 
 void Menu_uniform_neighbors::accept() {
@@ -41,7 +41,7 @@ void Menu_uniform_neighbors::accept() {
 
 void Menu_uniform_neighbors::update_alpha(double alpha) {
   if (checkBoxAutoUpdate->isChecked())
-    emit(compute_uniform_neighbors(doubleSpinBoxAlpha->value()));
+    /*emit*/ compute_uniform_neighbors(doubleSpinBoxAlpha->value());
 }
 
 #include "Menu_uniform_neighbors.moc"

--- a/src/GudhUI/view/Viewer.cpp
+++ b/src/GudhUI/view/Viewer.cpp
@@ -77,7 +77,7 @@ void Viewer::postSelection(const QPoint& point) {
 
   if (found) {
     Point_3 position(vec[0], vec[1], vec[2]);
-    emit(click(position));
+    /*emit*/ click(position);
   }
 }
 


### PR DESCRIPTION
Fix #841.
From what I can read, `emit` exists purely for decoration, so a comment should work just as well.