### PR TITLE
use 'is not' instead of '!=' when comparing to None

### DIFF
--- a/src/python/gudhi/alpha_complex.pyx
+++ b/src/python/gudhi/alpha_complex.pyx
@@ -87,14 +87,14 @@ cdef class AlphaComplex:
             points = read_points_from_off_file(off_file = off_file)
 
         # weights are set but is inconsistent with the number of points
-        if weights != None and len(weights) != len(points):
+        if weights is not None and len(weights) != len(points):
             raise ValueError("Inconsistency between the number of points and weights")
 
         # need to copy the points to use them without the gil
         cdef vector[vector[double]] pts
         cdef vector[double] wgts
         pts = points
-        if weights != None:
+        if weights is not None:
             wgts = weights
         with nogil:
             self.this_ptr = new Alpha_complex_interface(pts, wgts, fast, exact)

--- a/src/python/test/test_alpha_complex.py
+++ b/src/python/test/test_alpha_complex.py
@@ -313,3 +313,12 @@ def test_float_relative_precision():
         assert filtrations[idx][0] == filtrations_better_resolution[idx][0]
         # check filtration is about the same with a relative precision of the worst case
         assert filtrations[idx][1] == pytest.approx(filtrations_better_resolution[idx][1], rel=1e-5)
+
+def test_numpy_arrays():
+    points=np.array([[ 1., -1., -1.],
+                    [-1.,  1., -1.],
+                    [-1., -1.,  1.],
+                    [ 1.,  1.,  1.],
+                    [ 2.,  2.,  2.]])
+    weights=np.array([4., 4., 4., 4., 1.])
+    alpha = AlphaComplex(points=points, weights=weights)


### PR DESCRIPTION
This fixes a problem in the weighted alpha complex where the construction fails if the weights are passed as a numpy array. This was not being caught in the tests, since the weights are being passed as a list instead of an array.