### PR TITLE
Cohomology Betti numbers unit test fix

### DIFF
--- a/src/Persistent_cohomology/test/betti_numbers_unit_test.cpp
+++ b/src/Persistent_cohomology/test/betti_numbers_unit_test.cpp
@@ -249,12 +249,12 @@ BOOST_AUTO_TEST_CASE( betti_numbers )
   BOOST_CHECK(st.filtration(get<0>(persistent_pairs[0])) == 4);
   BOOST_CHECK(get<1>(persistent_pairs[0]) == st.null_simplex());
 
-  // persistent_pairs[1] = 2  0 2 inf
+  // persistent_pairs[1] = 2  0 1 inf
   BOOST_CHECK(st.dimension(get<0>(persistent_pairs[1])) == 0);
   BOOST_CHECK(st.filtration(get<0>(persistent_pairs[1])) == 1);
   BOOST_CHECK(get<1>(persistent_pairs[1]) == st.null_simplex());
 
-  // persistent_pairs[2] = 2  0 1 inf
+  // persistent_pairs[2] = 2  0 2 inf
   BOOST_CHECK(st.dimension(get<0>(persistent_pairs[2])) == 0);
   BOOST_CHECK(st.filtration(get<0>(persistent_pairs[2])) == 2);
   BOOST_CHECK(get<1>(persistent_pairs[2]) == st.null_simplex());

--- a/src/Persistent_cohomology/test/betti_numbers_unit_test.cpp
+++ b/src/Persistent_cohomology/test/betti_numbers_unit_test.cpp
@@ -166,7 +166,7 @@ BOOST_AUTO_TEST_CASE( betti_numbers )
   const short vertex5[] = {5};
   st.insert_simplex_and_subfaces(tetra0123, 4.0);
   st.insert_simplex_and_subfaces(edge04, 2.0);
-  st.insert_simplex(edge14, 2.0);
+  st.insert_simplex_and_subfaces(edge14, 2.0);
   st.insert_simplex(vertex5, 1.0);
 
   // Sort the simplices in the order of the filtration
@@ -251,12 +251,12 @@ BOOST_AUTO_TEST_CASE( betti_numbers )
 
   // persistent_pairs[1] = 2  0 2 inf
   BOOST_CHECK(st.dimension(get<0>(persistent_pairs[1])) == 0);
-  BOOST_CHECK(st.filtration(get<0>(persistent_pairs[1])) == 2);
+  BOOST_CHECK(st.filtration(get<0>(persistent_pairs[1])) == 1);
   BOOST_CHECK(get<1>(persistent_pairs[1]) == st.null_simplex());
 
   // persistent_pairs[2] = 2  0 1 inf
   BOOST_CHECK(st.dimension(get<0>(persistent_pairs[2])) == 0);
-  BOOST_CHECK(st.filtration(get<0>(persistent_pairs[2])) == 1);
+  BOOST_CHECK(st.filtration(get<0>(persistent_pairs[2])) == 2);
   BOOST_CHECK(get<1>(persistent_pairs[2]) == st.null_simplex());
 
   std::clog << "INTERVALS IN DIMENSION" << std::endl;
@@ -267,9 +267,9 @@ BOOST_AUTO_TEST_CASE( betti_numbers )
     std::clog << "intervals_in_dimension_0[" << i << "] = [" << intervals_in_dimension_0[i].first << "," <<
                  intervals_in_dimension_0[i].second << "]" << std::endl;
   BOOST_CHECK(intervals_in_dimension_0.size() == 2);
-  BOOST_CHECK(intervals_in_dimension_0[0].first == 2);
+  BOOST_CHECK(intervals_in_dimension_0[0].first == 1);
   BOOST_CHECK(intervals_in_dimension_0[0].second == std::numeric_limits<Mini_simplex_tree::Filtration_value>::infinity());
-  BOOST_CHECK(intervals_in_dimension_0[1].first == 1);
+  BOOST_CHECK(intervals_in_dimension_0[1].first == 2);
   BOOST_CHECK(intervals_in_dimension_0[1].second == std::numeric_limits<Mini_simplex_tree::Filtration_value>::infinity());
 
   auto intervals_in_dimension_1 = pcoh.intervals_in_dimension(1);


### PR DESCRIPTION
The example used for one of the Betti numbers unit tests is strictly speaking not a valid simplicial filtration:
```C++
/* Complex to build. */
/*    1   4          */
/*    o---o          */
/*   /3\ /           */
/*  o---o   o        */
/*  2   0   5        */
const short tetra0123[] = {0, 1, 2, 3};
const short edge04[] = {0, 4};
const short edge14[] = {1, 4};
const short vertex5[] = {5};
st.insert_simplex_and_subfaces(tetra0123, 4.0);
st.insert_simplex_and_subfaces(edge04, 2.0);
st.insert_simplex(edge14, 2.0);
st.insert_simplex(vertex5, 1.0);
```
Because of the line `st.insert_simplex(edge14, 2.0);` the vertex `1` has filtration value 4, while edge `1 4` has filtration value 2.

So nothing dramatic, but still good to correct.