### PR TITLE
ignore simplices of infinite filtration values during persistence computation

### DIFF
--- a/src/Persistent_cohomology/include/gudhi/Persistent_cohomology.h
+++ b/src/Persistent_cohomology/include/gudhi/Persistent_cohomology.h
@@ -115,6 +115,7 @@ class Persistent_cohomology {
     }
     Simplex_key idx_fil = 0;
     for (auto sh : cpx_->filtration_simplex_range()) {
+      if (cpx_->filtration(sh) == std::numeric_limits<Filtration_value>::infinity()) break;
       cpx_->assign_key(sh, idx_fil);
       ++idx_fil;
       dsets_.make_set(cpx_->key(sh));
@@ -175,6 +176,7 @@ class Persistent_cohomology {
     // Compute all finite intervals
     for (auto sh : cpx_->filtration_simplex_range()) {
       int dim_simplex = cpx_->dimension(sh);
+      if (cpx_->filtration(sh) == std::numeric_limits<Filtration_value>::infinity()) break;
       switch (dim_simplex) {
         case 0:
           break;
@@ -189,6 +191,7 @@ class Persistent_cohomology {
     // Compute infinite intervals of dimension 0
     Simplex_key key;
     for (auto v_sh : cpx_->skeleton_simplex_range(0)) {  // for all 0-dimensional simplices
+    if (cpx_->filtration(v_sh) == std::numeric_limits<Filtration_value>::infinity()) continue;
       key = cpx_->key(v_sh);
 
       if (ds_parent_[key] == key  // root of its tree


### PR DESCRIPTION
**Changes:** 
Skips the simplices with infinite filtration value in the persistence computations. 

**Usecase:**
When computing persistence of different subcomplexes of the same simplicial complex, it is inefficient to recreate the simplextree for every computation, so setting values to infinity with this patch allows to skip the simplicies that are not in the subcomplex, avoiding some persistence computation.
Typically, computing the homology of the restriction to an horizontal line in 2-parameter persistence can be sped up with such strategy.
As far as I'm aware, homology at infinity is not taken into account, so this will not affect the results.
