### PR TITLE
Minimum enclosing ball filtration values

### DIFF
--- a/src/Cech_complex/concept/SimplicialComplexForMEB.h
+++ b/src/Cech_complex/concept/SimplicialComplexForMEB.h
@@ -35,7 +35,7 @@ struct SimplicialComplexForMEB {
   /** \brief Assigns this 'filtration' value to the 'simplex'. */
   int assign_filtration(Simplex_handle simplex, Filtration_value filtration);
 
-  /** \brief Returns the key assigned to the 'simplex' with `assign_key`. */
+  /** \brief Returns the key assigned to the 'simplex' with `assign_key()`. */
   Simplex_key key(Simplex_handle simplex);
   /** \brief Assigns this 'key' to the 'simplex'. */
   void assign_key(Simplex_handle simplex, Simplex_key key);

--- a/src/Cech_complex/concept/SimplicialComplexForMEB.h
+++ b/src/Cech_complex/concept/SimplicialComplexForMEB.h
@@ -1,0 +1,58 @@
+/*    This file is part of the Gudhi Library - https://gudhi.inria.fr/ - which is released under MIT.
+ *    See file LICENSE or go to https://gudhi.inria.fr/licensing/ for full license details.
+ *    Author(s):       Marc Glisse
+ *
+ *    Copyright (C) 2018 Inria
+ *
+ *    Modification(s):
+ *      - YYYY/MM Author: Description of the modification
+ */
+
+#ifndef CONCEPT_CECH_COMPLEX_SIMPLICIAL_COMPLEX_FOR_MEB_H_
+#define CONCEPT_CECH_COMPLEX_SIMPLICIAL_COMPLEX_FOR_MEB_H_
+
+namespace Gudhi {
+
+namespace cech_complex {
+
+/** The concept SimplicialComplexForMEB describes the requirements for a type to implement a simplicial
+ * complex that can be filled by `assign_MEB_filtration()`. It is typically satisfied by `Simplex_tree` if
+ * `SimplexTreeOptions::store_key` is true.
+ */
+struct SimplicialComplexForMEB {
+  /** \brief Handle for a simplex. */
+  typedef unspecified Simplex_handle;
+  /** \brief Handle for a vertex. Must be a non-negative integer,
+   * it is also used as an index into the input list of points. */
+  typedef unspecified Vertex_handle;
+  /** \brief Type of filtration values. */
+  typedef unspecified Filtration_value;
+  /** \brief Integer type large enough to index all simplices. */
+  typedef unspecified Simplex_key;
+
+  /** \brief Returns the filtration value to the 'simplex'. */
+  Filtration_value filtration(Simplex_handle simplex);
+  /** \brief Assigns this 'filtration' value to the 'simplex'. */
+  int assign_filtration(Simplex_handle simplex, Filtration_value filtration);
+
+  /** \brief Returns the key assigned to the 'simplex' with `assign_key`. */
+  Simplex_key key(Simplex_handle simplex);
+  /** \brief Assigns this 'key' to the 'simplex'. */
+  void assign_key(Simplex_handle simplex, Simplex_key key);
+
+  /** \brief Returns a range over vertices (as Vertex_handle) of a given simplex. */
+  Simplex_vertex_range simplex_vertex_range(Simplex_handle simplex);
+
+  /** \brief Returns a range of the pairs (simplex, opposite vertex) of the boundary of the 'simplex'. */
+  Boundary_opposite_vertex_simplex_range boundary_opposite_vertex_simplex_range(Simplex_handle simplex);
+
+  /** \brief Calls `callback(simplex, dim)` for every simplex of the complex,
+   * with the guarantee that faces are visited before cofaces. */
+  void for_each_simplex(auto callback);
+};
+
+}  // namespace cech_complex
+
+}  // namespace Gudhi
+
+#endif  // CONCEPT_CECH_COMPLEX_SIMPLICIAL_COMPLEX_FOR_MEB_H_

--- a/src/Cech_complex/doc/Intro_cech_complex.h
+++ b/src/Cech_complex/doc/Intro_cech_complex.h
@@ -17,7 +17,7 @@ namespace cech_complex {
 
 /**  \defgroup cech_complex Čech complex
  * 
- * \author    Vincent Rouvreau, Hind montassif
+ * \author    Vincent Rouvreau, Hind montassif, Marc Glisse
  * 
  * @{
  * 
@@ -61,6 +61,11 @@ namespace cech_complex {
  *
  * This radius computation is the reason why the Cech_complex is taking much more time to be computed than the
  * \ref rips_complex but it offers more topological guarantees.
+ *
+ * If you already have a simplicial complex, it is possible to assign to each simplex a filtration value corresponding
+ * to the squared radius of its minimal enclosing ball using `assign_MEB_filtration()`. This can provide an alternate
+ * way of computing a Čech filtration, or it can be used on a Delaunay triangulation to compute a Delaunay-Čech
+ * filtration.
  *
  * \subsection cechpointscloudexample Example from a point cloud
  * 

--- a/src/Cech_complex/include/gudhi/Cech_complex_blocker.h
+++ b/src/Cech_complex/include/gudhi/Cech_complex_blocker.h
@@ -48,7 +48,7 @@ class Cech_blocker {
   // Numeric type of coordinates in the kernel
   using FT = typename Kernel::FT;
   // Sphere is a pair of point and squared radius.
-  using Sphere = typename std::pair<Point_d, FT>;
+  using Sphere = std::pair<Point_d, FT>;
 
  private:
 

--- a/src/Cech_complex/include/gudhi/MEB_filtration.h
+++ b/src/Cech_complex/include/gudhi/MEB_filtration.h
@@ -16,6 +16,7 @@ namespace Gudhi::cech_complex {
 /**
  * \ingroup cech_complex
  *
+ * \brief
  * Given a simplicial complex and an embedding of its vertices, this assigns to
  * each simplex a filtration value equal to the squared radius of its minimal
  * enclosing ball.
@@ -23,11 +24,11 @@ namespace Gudhi::cech_complex {
  * Applied on a Cech complex, it recomputes the same values (squared). Applied on a Delaunay triangulation, it computes the Delaunay-Cech filtration.
  *
  * \tparam Kernel CGAL kernel: either Epick_d or Epeck_d.
- * \tparam SimplicialComplexForMEB Simplex_tree with Simplex_key an integer type large enough to store the number of simplices.
  * \tparam PointRange Random access range of `Kernel::Point_d`.
  *
- * @param[in] points Embedding of the vertices of the complex.
+ * @param[in] k The geometric kernel.
  * @param[in] complex The simplicial complex.
+ * @param[in] points Embedding of the vertices of the complex.
  * @param[in] exact If true and `Kernel` is <a href="https://doc.cgal.org/latest/Kernel_d/structCGAL_1_1Epeck__d.html">CGAL::Epeck_d</a>, the filtration values are computed exactly. Default is false.
  */
 

--- a/src/Cech_complex/include/gudhi/MEB_filtration.h
+++ b/src/Cech_complex/include/gudhi/MEB_filtration.h
@@ -1,0 +1,95 @@
+/*    This file is part of the Gudhi Library - https://gudhi.inria.fr/ - which is released under MIT.
+ *    See file LICENSE or go to https://gudhi.inria.fr/licensing/ for full license details.
+ *    Author(s):       Marc Glisse
+ *
+ *    Copyright (C) 2023 Inria
+ *
+ *    Modification(s):
+ *      - YYYY/MM Author: Description of the modification
+ */
+
+#ifndef MEB_FILTRATION_H_
+#define MEB_FILTRATION_H_
+
+namespace Gudhi::cech_complex {
+
+/**
+ * \ingroup cech_complex
+ *
+ * Given a simplicial complex and an embedding of its vertices, this assigns to
+ * each simplex a filtration value equal to the squared radius of its minimal
+ * enclosing ball.
+ *
+ * Applied on a Cech complex, it recomputes the same values (squared). Applied on a Delaunay triangulation, it computes the Delaunay-Cech filtration.
+ *
+ * \tparam Kernel CGAL kernel: either Epick_d or Epeck_d.
+ * \tparam SimplicialComplexForMEB Simplex_tree with Simplex_key an integer type large enough to store the number of simplices.
+ * \tparam PointRange Random access range of `Kernel::Point_d`.
+ *
+ * @param[in] points Embedding of the vertices of the complex.
+ * @param[in] complex The simplicial complex.
+ * @param[in] exact If true and `Kernel` is <a href="https://doc.cgal.org/latest/Kernel_d/structCGAL_1_1Epeck__d.html">CGAL::Epeck_d</a>, the filtration values are computed exactly. Default is false.
+ */
+
+template<typename Kernel, typename SimplicialComplexForMEB, typename PointRange>
+void assign_MEB_filtration(Kernel&&k, SimplicialComplexForMEB& complex, PointRange points, bool exact = false) {
+  using Point_d = typename Kernel::Point_d;
+  using FT = typename Kernel::FT;
+  using Sphere = std::pair<Point_d, FT>;
+
+  using Vertex_handle = typename SimplicialComplexForMEB::Vertex_handle;
+  using Simplex_handle = typename SimplicialComplexForMEB::Simplex_handle;
+  using Filtration_value = typename SimplicialComplexForMEB::Filtration_value;
+
+  std::vector<Sphere> cache_;
+  std::vector<Point_d> pts;
+  CGAL::NT_converter<FT, Filtration_value> cvt;
+
+  auto fun = [&](Simplex_handle sh, int dim){
+    if (dim == 0) complex.assign_filtration(sh, 0);
+    else if (dim == 1) {
+      // Vertex_handle u = sh->first;
+      // Vertex_handle v = self_siblings(sh)->parent();
+      auto verts = complex.simplex_vertex_range(sh);
+      auto vert_it = verts.begin();
+      Vertex_handle u = *vert_it;
+      Vertex_handle v = *++vert_it;
+      auto&& pu = points[u];
+      Point_d m = k.midpoint_d_object()(pu, points[v]);
+      FT r = k.squared_distance_d_object()(m, pu);
+      if (exact) CGAL::exact(r);
+      complex.assign_key(sh, cache_.size()); // TODO: use a map if complex does not provide key?
+      complex.assign_filtration(sh, std::max(cvt(r), Filtration_value(0)));
+      cache_.emplace_back(std::move(m), std::move(r));
+    } else {
+      for (auto face_opposite_vertex : complex.boundary_opposite_vertex_simplex_range(sh)) {
+        auto key = complex.key(face_opposite_vertex.first);
+        Sphere const& sph = cache_[key];
+        if (k.squared_distance_d_object()(sph.first, points[face_opposite_vertex.second]) > sph.second) continue;
+        complex.assign_key(sh, key);
+        complex.assign_filtration(sh, complex.filtration(face_opposite_vertex.first));
+        return;
+      }
+      // None of the faces are good enough, MEB must be the circumsphere.
+      pts.clear();
+      for (auto vertex : complex.simplex_vertex_range(sh))
+        pts.push_back(points[vertex]);
+      Point_d c = k.construct_circumcenter_d_object()(pts.begin(), pts.end());
+      FT r = k.squared_distance_d_object()(c, pts.front());
+      if (exact) CGAL::exact(r);
+      complex.assign_key(sh, cache_.size()); // TODO: use a map if complex does not provide key?
+      complex.assign_filtration(sh, cvt(r));
+      cache_.emplace_back(std::move(c), std::move(r));
+    }
+  };
+  complex.for_each_simplex_with_dim(fun);
+  // TODO: when !exact, how do we ensure that the value is indeed larger
+  // than for the faces? Cech_complex also looks at the max of the faces,
+  // given by expansion. We would need to do compute this max as well, and
+  // in particular not short-circuit when we find a good face. For now, the
+  // simplest:
+  if (!exact) complex.make_filtration_non_decreasing();
+}
+}  // namespace Gudhi::cech_complex
+
+#endif  // MEB_FILTRATION_H_

--- a/src/Cech_complex/include/gudhi/MEB_filtration.h
+++ b/src/Cech_complex/include/gudhi/MEB_filtration.h
@@ -82,7 +82,7 @@ void assign_MEB_filtration(Kernel&&k, SimplicialComplexForMEB& complex, PointRan
       cache_.emplace_back(std::move(c), std::move(r));
     }
   };
-  complex.for_each_simplex_with_dim(fun);
+  complex.for_each_simplex(fun);
   // TODO: when !exact, how do we ensure that the value is indeed larger
   // than for the faces? Cech_complex also looks at the max of the faces,
   // given by expansion. We would need to do compute this max as well, and

--- a/src/Cech_complex/include/gudhi/MEB_filtration.h
+++ b/src/Cech_complex/include/gudhi/MEB_filtration.h
@@ -21,7 +21,7 @@ namespace Gudhi::cech_complex {
  * each simplex a filtration value equal to the squared radius of its minimal
  * enclosing ball.
  *
- * Applied on a Cech complex, it recomputes the same values (squared). Applied on a Delaunay triangulation, it computes the Delaunay-Cech filtration.
+ * Applied on a Čech complex, it recomputes the same values (squared). Applied on a Delaunay triangulation, it computes the Delaunay-Čech filtration.
  *
  * \tparam Kernel CGAL kernel: either Epick_d or Epeck_d.
  * \tparam PointRange Random access range of `Kernel::Point_d`.

--- a/src/Cech_complex/include/gudhi/MEB_filtration.h
+++ b/src/Cech_complex/include/gudhi/MEB_filtration.h
@@ -19,7 +19,7 @@ namespace Gudhi::cech_complex {
  * \brief
  * Given a simplicial complex and an embedding of its vertices, this assigns to
  * each simplex a filtration value equal to the squared radius of its minimal
- * enclosing ball.
+ * enclosing ball (MEB).
  *
  * Applied on a Čech complex, it recomputes the same values (squared). Applied on a Delaunay triangulation, it computes the Delaunay-Čech filtration.
  *

--- a/src/Cech_complex/test/test_cech_complex.cpp
+++ b/src/Cech_complex/test/test_cech_complex.cpp
@@ -19,6 +19,7 @@
 #include <algorithm>  // std::max
 
 #include <gudhi/Cech_complex.h>
+#include <gudhi/MEB_filtration.h>
 // to construct Cech_complex from a OFF file of points
 #include <gudhi/Points_off_io.h>
 #include <gudhi/Simplex_tree.h>
@@ -167,6 +168,13 @@ BOOST_AUTO_TEST_CASE(Cech_complex_for_documentation) {
 
   BOOST_CHECK((st2.find({6, 7, 8}) == st2.null_simplex()));
   BOOST_CHECK((st2.find({3, 5, 7}) == st2.null_simplex()));
+
+  auto st2_save = st2;
+  st2.reset_filtration(-1); // unnecessary, but ensures we don't cheat
+  Gudhi::cech_complex::assign_MEB_filtration(Kernel(), st2, points);
+  for (auto sh : st2.complex_simplex_range())
+    st2.assign_filtration(sh, std::sqrt(st2.filtration(sh)));
+  BOOST_CHECK(st2 == st2_save); // Should only be an approximate test
 }
 
 BOOST_AUTO_TEST_CASE(Cech_complex_from_points) {


### PR DESCRIPTION
Another use case for #912. In particular, if you give it a Delaunay triangulation, you get the filtration values of the Delaunay-Cech (squared).
In some cases we may want to compute it only up to some dimension, but I expect we would want to `prune_above_dimension` in that case, so the new function doesn't need to handle it explicitly.

@VincentRouvreau Either after this branch is merged or during the review, it would be good to make some comparison between alpha-complex and Delaunay-Cech (i.e. computing the Delaunay triangulation and calling the new function to assign filtration values).
- the 2 should have the same persistence diagram up to rounding errors (a good test that things are working properly)
- benchmark: IIRC in the alpha-complex most of the time is spent in geometric computations for the filtration values. It would be interesting to see how the running-time of the Delaunay-Cech compares.

Doc: https://output.circle-artifacts.com/output/job/3c348709-ec0c-46c2-81f7-5ef27a5cc918/artifacts/0/doxygen/group__cech__complex.html