### PR TITLE
Check if filtration value is finite before recursively prune above filtration value

### DIFF
--- a/src/Simplex_tree/include/gudhi/Simplex_tree.h
+++ b/src/Simplex_tree/include/gudhi/Simplex_tree.h
@@ -52,7 +52,6 @@
 #include <iterator>  // for std::distance
 #include <type_traits>  // for std::conditional
 #include <unordered_map>
-#include <cmath>  // for std::isfinite
 
 namespace Gudhi {
 
@@ -1577,8 +1576,6 @@ class Simplex_tree {
    */
   bool prune_above_filtration(Filtration_value filtration) {
     if (std::numeric_limits<Filtration_value>::has_infinity && filtration == std::numeric_limits<Filtration_value>::infinity())
-      return false;  // ---->>
-    if (std::numeric_limits<Filtration_value>::has_quiet_NaN && std::isnan(filtration))
       return false;  // ---->>
     bool modified = rec_prune_above_filtration(root(), filtration);
     if(modified)

--- a/src/Simplex_tree/include/gudhi/Simplex_tree.h
+++ b/src/Simplex_tree/include/gudhi/Simplex_tree.h
@@ -1576,7 +1576,9 @@ class Simplex_tree {
    * bound. If you care, you can call `dimension()` to recompute the exact dimension.
    */
   bool prune_above_filtration(Filtration_value filtration) {
-    if (!std::isfinite(filtration))
+    if (std::numeric_limits<Filtration_value>::has_infinity && filtration == std::numeric_limits<Filtration_value>::infinity())
+      return false;  // ---->>
+    if (std::numeric_limits<Filtration_value>::has_quiet_NaN && std::isnan(filtration))
       return false;  // ---->>
     bool modified = rec_prune_above_filtration(root(), filtration);
     if(modified)

--- a/src/Simplex_tree/include/gudhi/Simplex_tree.h
+++ b/src/Simplex_tree/include/gudhi/Simplex_tree.h
@@ -52,6 +52,7 @@
 #include <iterator>  // for std::distance
 #include <type_traits>  // for std::conditional
 #include <unordered_map>
+#include <cmath>  // for std::isfinite
 
 namespace Gudhi {
 
@@ -1575,6 +1576,8 @@ class Simplex_tree {
    * bound. If you care, you can call `dimension()` to recompute the exact dimension.
    */
   bool prune_above_filtration(Filtration_value filtration) {
+    if (!std::isfinite(filtration))
+      return false;  // ---->>
     bool modified = rec_prune_above_filtration(root(), filtration);
     if(modified)
       clear_filtration(); // Drop the cache.

--- a/src/Simplex_tree/test/simplex_tree_remove_unit_test.cpp
+++ b/src/Simplex_tree/test/simplex_tree_remove_unit_test.cpp
@@ -436,6 +436,52 @@ BOOST_AUTO_TEST_CASE(mini_prune_above_filtration) {
 
 }
 
+BOOST_AUTO_TEST_CASE(prune_above_filtration_limits) {
+  std::clog << "********************************************************************" << std::endl;
+  std::clog << "PRUNE ABOVE FILTRATION TEST TO THE LIMITS" << std::endl;
+
+  Stree st;
+
+  st.insert_simplex_and_subfaces({0, 1, 6, 7}, 1.0);
+  st.insert_simplex_and_subfaces({3, 4, 5}, 2.0);
+
+  st.insert_simplex_and_subfaces({3, 0}, std::numeric_limits<Stree::Filtration_value>::quiet_NaN());
+  st.insert_simplex_and_subfaces({2, 1, 0}, 4.0);
+
+  // st:
+  //    1   6
+  //    o---o
+  //   /X\7/
+  //  o---o---o---o
+  //  2   0   3\X/4
+  //            o
+  //            5
+  st.initialize_filtration();
+
+  std::clog << "The complex contains " << st.num_simplices() << " simplices" << std::endl;
+  std::clog << " - dimension " << st.dimension() << std::endl;
+  std::clog << "Iterator on Simplices in the filtration, with [filtration value]:" << std::endl;
+  for (auto f_simplex : st.filtration_simplex_range()) {
+    std::clog << "   " << "[" << st.filtration(f_simplex) << "] ";
+    for (auto vertex : st.simplex_vertex_range(f_simplex)) {
+      std::clog << (int) vertex << " ";
+    }
+    std::clog << std::endl;
+  }
+  BOOST_CHECK(st.num_simplices() == 27);
+
+  // Test case to the limit
+  bool simplex_is_changed = st.prune_above_filtration(std::numeric_limits<Stree::Filtration_value>::infinity());
+  BOOST_CHECK(simplex_is_changed == false);
+
+  // Another test case to the limit
+  simplex_is_changed = st.prune_above_filtration(std::numeric_limits<Stree::Filtration_value>::quiet_NaN());
+  BOOST_CHECK(simplex_is_changed == false);
+
+  std::clog << "The complex contains " << st.num_simplices() << " simplices" << std::endl;
+  BOOST_CHECK(st.num_simplices() == 27);
+}
+
 BOOST_AUTO_TEST_CASE(mini_prune_above_dimension) {
   std::clog << "********************************************************************" << std::endl;
   std::clog << "MINI PRUNE ABOVE DIMENSION" << std::endl;

--- a/src/Simplex_tree/test/simplex_tree_remove_unit_test.cpp
+++ b/src/Simplex_tree/test/simplex_tree_remove_unit_test.cpp
@@ -445,6 +445,8 @@ BOOST_AUTO_TEST_CASE(prune_above_filtration_limits) {
   st.insert_simplex_and_subfaces({0, 1, 6, 7}, 1.0);
   st.insert_simplex_and_subfaces({3, 4, 5}, 2.0);
 
+  // As NaN is not yet managed in prune_above_filtration, this simplex would be removed if the Simplex tree is browsed
+  // when prune_above_filtration(+Inf)
   st.insert_simplex_and_subfaces({3, 0}, std::numeric_limits<Stree::Filtration_value>::quiet_NaN());
   st.insert_simplex_and_subfaces({2, 1, 0}, 4.0);
 
@@ -474,9 +476,7 @@ BOOST_AUTO_TEST_CASE(prune_above_filtration_limits) {
   bool simplex_is_changed = st.prune_above_filtration(std::numeric_limits<Stree::Filtration_value>::infinity());
   BOOST_CHECK(simplex_is_changed == false);
 
-  // Another test case to the limit
-  simplex_is_changed = st.prune_above_filtration(std::numeric_limits<Stree::Filtration_value>::quiet_NaN());
-  BOOST_CHECK(simplex_is_changed == false);
+  // Here we cannot test with a copy, because NaN != NaN
 
   std::clog << "The complex contains " << st.num_simplices() << " simplices" << std::endl;
   BOOST_CHECK(st.num_simplices() == 27);


### PR DESCRIPTION
Fix #926
~~TBD, but I used [std::isfinite](https://en.cppreference.com/w/cpp/numeric/math/isfinite).~~ (not a good idea, I didn't think about -Inf case)
~~Maybe not conform with [Filtration value concept](https://github.com/GUDHI/gudhi-devel/blob/master/src/Simplex_tree/concept/FiltrationValue.h)~~ (cf. comments)
Check if it is equal to `std::numeric_limits<Filtration_value>::infinity()`.
~~NaN case management (and UT)~~
