### PR TITLE
Guard fix for stable simplex handles

### DIFF
--- a/src/Simplex_tree/include/gudhi/Simplex_tree.h
+++ b/src/Simplex_tree/include/gudhi/Simplex_tree.h
@@ -1241,7 +1241,8 @@ class Simplex_tree {
       dimension_ = 1;
     }
 
-    root_.members_.reserve(num_vertices(skel_graph)); // probably useless in most cases
+    if constexpr (!Options::stable_simplex_handles)
+      root_.members_.reserve(num_vertices(skel_graph)); // probably useless in most cases
     auto verts = vertices(skel_graph) | boost::adaptors::transformed([&](auto v){
         return Dit_value_t(v, Node(&root_, get(vertex_filtration_t(), skel_graph, v))); });
     root_.members_.insert(boost::begin(verts), boost::end(verts));


### PR DESCRIPTION
A `reserve` which needs a guard `if constexpr (!Options::stable_simplex_handles)` was missed in the merged pull request about stable simplex handles.