### PR TITLE
On OSX, '-mmacosx-version-min=XXX' compile and link options management

### DIFF
--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -255,7 +255,8 @@ if(PYTHONINTERP_FOUND)
 
     # Specific for Mac
     if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-      # if MACOSX_DEPLOYMENT_TARGET environment variable is set
+      # CMAKE_OSX_DEPLOYMENT_TARGET is always set on OSx
+      # but it can be modified by the user by setting MACOSX_DEPLOYMENT_TARGET environment variable
       if(CMAKE_OSX_DEPLOYMENT_TARGET)
         set(GUDHI_PYTHON_EXTRA_COMPILE_ARGS "${GUDHI_PYTHON_EXTRA_COMPILE_ARGS}'-mmacosx-version-min=${CMAKE_OSX_DEPLOYMENT_TARGET}', ")
         set(GUDHI_PYTHON_EXTRA_LINK_ARGS "${GUDHI_PYTHON_EXTRA_LINK_ARGS}'-mmacosx-version-min=${CMAKE_OSX_DEPLOYMENT_TARGET}', ")

--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -255,8 +255,11 @@ if(PYTHONINTERP_FOUND)
 
     # Specific for Mac
     if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-        set(GUDHI_PYTHON_EXTRA_COMPILE_ARGS "${GUDHI_PYTHON_EXTRA_COMPILE_ARGS}'-mmacosx-version-min=10.14', ")
-        set(GUDHI_PYTHON_EXTRA_LINK_ARGS "${GUDHI_PYTHON_EXTRA_LINK_ARGS}'-mmacosx-version-min=10.14', ")
+      # if MACOSX_DEPLOYMENT_TARGET environment variable is set
+      if(CMAKE_OSX_DEPLOYMENT_TARGET)
+        set(GUDHI_PYTHON_EXTRA_COMPILE_ARGS "${GUDHI_PYTHON_EXTRA_COMPILE_ARGS}'-mmacosx-version-min=${CMAKE_OSX_DEPLOYMENT_TARGET}', ")
+        set(GUDHI_PYTHON_EXTRA_LINK_ARGS "${GUDHI_PYTHON_EXTRA_LINK_ARGS}'-mmacosx-version-min=${CMAKE_OSX_DEPLOYMENT_TARGET}', ")
+      endif()
     endif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 
     # Strip dynamic libraries in release mode for smaller pip packages under linux


### PR DESCRIPTION
when asked by MACOSX_DEPLOYMENT_TARGET environment variable.
Fix #899 