### PR TITLE
KNearestNeighbors interface homogenization + empty DTMRipsComplex

### DIFF
--- a/src/python/gudhi/dtm_rips_complex.py
+++ b/src/python/gudhi/dtm_rips_complex.py
@@ -37,7 +37,7 @@ class DTMRipsComplex(WeightedRipsComplex):
         if distance_matrix is None:
             if points is None:
                 # Empty Rips construction
-                points=[]
+                points=[[]]
             distance_matrix = cdist(points,points)
         self.distance_matrix = distance_matrix
 

--- a/src/python/gudhi/dtm_rips_complex.py
+++ b/src/python/gudhi/dtm_rips_complex.py
@@ -12,40 +12,37 @@ from gudhi.weighted_rips_complex import WeightedRipsComplex
 from gudhi.point_cloud.dtm import DistanceToMeasure
 from scipy.spatial.distance import cdist
 
+
 class DTMRipsComplex(WeightedRipsComplex):
     """
-    Class to generate a DTM Rips complex from a distance matrix or a point set, 
+    Class to generate a DTM Rips complex from a distance matrix or a point set,
     in the way described in :cite:`dtmfiltrations`.
-    Remark that all the filtration values are doubled compared to the definition in the paper 
+    Remark that all the filtration values are doubled compared to the definition in the paper
     for the consistency with RipsComplex.
     :Requires: `SciPy <installation.html#scipy>`_
     """
-    def __init__(self, 
-                 points=None, 
-                 distance_matrix=None, 
-                 k=1, 
-                 q=2,
-                 max_filtration=float('inf')):
+
+    def __init__(self, points=None, distance_matrix=None, k=1, q=2, max_filtration=float("inf")):
         """
         Args:
             points (numpy.ndarray): array of points.
             distance_matrix (numpy.ndarray): full distance matrix.
-            k (int): number of neighbors for the computation of DTM. Defaults to 1, which is equivalent to the usual Rips complex.
+            k (int): number of neighbors for the computation of DTM. Defaults to 1, which is equivalent to the usual
+                Rips complex.
             q (float): order used to compute the distance to measure. Defaults to 2.
-            max_filtration (float): specifies the maximal filtration value to be considered.      
+            max_filtration (float): specifies the maximal filtration value to be considered.
         """
         if distance_matrix is None:
             if points is None:
                 # Empty Rips construction
-                points=[[]]
-            distance_matrix = cdist(points,points)
+                points = [[]]
+            distance_matrix = cdist(points, points)
         self.distance_matrix = distance_matrix
 
-        # TODO: address the error when k is too large 
+        # TODO: address the error when k is too large
         if k <= 1:
             self.weights = [0] * len(distance_matrix)
         else:
-            dtm = DistanceToMeasure(k, q=q, metric="precomputed")        
+            dtm = DistanceToMeasure(k, q=q, metric="precomputed")
             self.weights = dtm.fit_transform(distance_matrix)
         self.max_filtration = max_filtration
-        

--- a/src/python/gudhi/dtm_rips_complex.py
+++ b/src/python/gudhi/dtm_rips_complex.py
@@ -11,6 +11,7 @@
 from gudhi.weighted_rips_complex import WeightedRipsComplex
 from gudhi.point_cloud.dtm import DistanceToMeasure
 from scipy.spatial.distance import cdist
+import numpy as np
 
 
 class DTMRipsComplex(WeightedRipsComplex):
@@ -33,10 +34,11 @@ class DTMRipsComplex(WeightedRipsComplex):
             max_filtration (float): specifies the maximal filtration value to be considered.
         """
         if distance_matrix is None:
-            if points is None:
+            if points is not None:
+                distance_matrix = cdist(points, points)
+            else:
                 # Empty Rips construction
-                points = [[]]
-            distance_matrix = cdist(points, points)
+                distance_matrix = np.ndarray((0,0))
         self.distance_matrix = distance_matrix
 
         # TODO: address the error when k is too large

--- a/src/python/gudhi/point_cloud/knn.py
+++ b/src/python/gudhi/point_cloud/knn.py
@@ -34,10 +34,14 @@ class KNearestNeighbors:
             return_distance (bool): if True, return the distance to each neighbor.
             implementation (str): choice of the library that does the real work.
 
-                * 'keops' for a brute-force, CUDA implementation through pykeops. Useful when the dimension becomes large (10+) but the number of points remains low (less than a million). Only "minkowski" and its aliases are supported.
+                * 'keops' for a brute-force, CUDA implementation through pykeops. Useful when the dimension becomes
+                  large (10+) but the number of points remains low (less than a million). Only "minkowski" and its
+                  aliases are supported.
                 * 'ckdtree' for scipy's cKDTree. Only "minkowski" and its aliases are supported.
-                * 'sklearn' for scikit-learn's NearestNeighbors. Note that this provides in particular an option algorithm="brute".
-                * 'hnsw' for hnswlib.Index. It can be very fast but does not provide guarantees. Only supports "euclidean" for now.
+                * 'sklearn' for scikit-learn's NearestNeighbors. Note that this provides in particular an option
+                  algorithm="brute".
+                * 'hnsw' for hnswlib.Index. It can be very fast but does not provide guarantees. Only supports
+                  "euclidean" for now.
                 * None will try to select a sensible one (scipy if possible, scikit-learn otherwise).
             metric (str): see `sklearn.neighbors.NearestNeighbors`.
             eps (float): relative error when computing nearest neighbors with the cKDTree.
@@ -93,7 +97,9 @@ class KNearestNeighbors:
             X (numpy.array): coordinates for reference points.
         """
         if self.k > len(X):
-            raise ValueError(f"Expected number of neighbors (aka. 'k') <= number of samples, but k={self.k} and number of samples={len(X)}")
+            raise ValueError(
+                f"Expected number of neighbors (aka. 'k') <= number of samples, but k={self.k} and number of samples={len(X)}"
+            )
         self.ref_points = X
         if self.params.get("enable_autodiff", False):
             import eagerpy as ep
@@ -170,9 +176,7 @@ class KNearestNeighbors:
             assert self.metric == "minkowski"
             p = self.params["p"]
             Y = ep.astensor(self.ref_points)
-            neighbor_pts = Y[
-                neighbors,
-            ]
+            neighbor_pts = Y[neighbors,]
             diff = neighbor_pts - X[:, None, :]
             if isinstance(diff, ep.PyTorchTensor):
                 # https://github.com/jonasrauber/eagerpy/issues/6
@@ -188,7 +192,8 @@ class KNearestNeighbors:
         k = self.k
 
         if metric == "precomputed":
-            # scikit-learn could handle that, but they insist on calling fit() with an unused square array, which is too unnatural.
+            # scikit-learn could handle that, but they insist on calling fit() with an unused square array
+            # which is too unnatural.
             if self.return_index:
                 n_jobs = self.params.get("n_jobs", 1)
                 # Supposedly numpy can be compiled with OpenMP and handle this, but nobody does that?!
@@ -263,7 +268,7 @@ class KNearestNeighbors:
                 self.graph.set_ef(ef)
             neighbors, distances = self.graph.knn_query(X, k, num_threads=self.params["num_threads"])
             with warnings.catch_warnings():
-                if not(numpy.all(numpy.isfinite(distances))):
+                if not (numpy.all(numpy.isfinite(distances))):
                     warnings.warn("Overflow/infinite value encountered while computing 'distances'", RuntimeWarning)
             # The k nearest neighbors are always sorted. I couldn't find it in the doc, but the code calls searchKnn,
             # which returns a priority_queue, and then fills the return array backwards with top/pop on the queue.
@@ -299,8 +304,9 @@ class KNearestNeighbors:
                 if self.return_distance:
                     distances, neighbors = mat.Kmin_argKmin(k, dim=1)
                     with warnings.catch_warnings():
-                        if not(torch.isfinite(distances).all()):
-                            warnings.warn("Overflow/infinite value encountered while computing 'distances'", RuntimeWarning)
+                        if not (torch.isfinite(distances).all()):
+                            warnings.warn("Overflow/infinite value encountered while computing 'distances'",
+                                          RuntimeWarning)
                     if p != numpy.inf:
                         distances = distances ** (1.0 / p)
                     return neighbors, distances
@@ -310,8 +316,9 @@ class KNearestNeighbors:
             if self.return_distance:
                 distances = mat.Kmin(k, dim=1)
                 with warnings.catch_warnings():
-                    if not(torch.isfinite(distances).all()):
-                        warnings.warn("Overflow/infinite value encountered while computing 'distances'", RuntimeWarning)
+                    if not (torch.isfinite(distances).all()):
+                        warnings.warn("Overflow/infinite value encountered while computing 'distances'",
+                                      RuntimeWarning)
                 if p != numpy.inf:
                     distances = distances ** (1.0 / p)
                 return distances

--- a/src/python/gudhi/point_cloud/knn.py
+++ b/src/python/gudhi/point_cloud/knn.py
@@ -53,6 +53,8 @@ class KNearestNeighbors:
                 Defaults to False.
             kwargs: additional parameters are forwarded to the backends.
         """
+        if k < 1:
+            raise ValueError(f"Expected number of neighbors (aka. 'k') > 0. Got {k}")
         self.k = k
         self.return_index = return_index
         self.return_distance = return_distance
@@ -90,6 +92,8 @@ class KNearestNeighbors:
         Args:
             X (numpy.array): coordinates for reference points.
         """
+        if self.k > len(X):
+            raise ValueError(f"Expected number of neighbors (aka. 'k') <= number of samples, but k={self.k} and number of samples={len(X)}")
         self.ref_points = X
         if self.params.get("enable_autodiff", False):
             import eagerpy as ep

--- a/src/python/test/test_dtm_rips_complex.py
+++ b/src/python/test/test_dtm_rips_complex.py
@@ -14,14 +14,18 @@ import numpy as np
 from math import sqrt
 import pytest
 
+
 def test_dtm_rips_complex():
     pts = np.array([[2.0, 2.0], [0.0, 1.0], [3.0, 4.0]])
     dtm_rips = DTMRipsComplex(points=pts, k=2)
     st = dtm_rips.create_simplex_tree(max_dimension=2)
     st.persistence()
     persistence_intervals0 = st.persistence_intervals_in_dimension(0)
-    assert persistence_intervals0 == pytest.approx(np.array([[3.16227766, 5.39834564],[3.16227766, 5.39834564], [3.16227766, float("inf")]]))
-    
+    assert persistence_intervals0 == pytest.approx(
+        np.array([[3.16227766, 5.39834564], [3.16227766, 5.39834564], [3.16227766, float("inf")]])
+    )
+
+
 def test_compatibility_with_rips():
     distance_matrix = np.array([[0, 1, 1, sqrt(2)], [1, 0, sqrt(2), 1], [1, sqrt(2), 0, 1], [sqrt(2), 1, 1, 0]])
     dtm_rips = DTMRipsComplex(distance_matrix=distance_matrix, max_filtration=42)
@@ -30,8 +34,9 @@ def test_compatibility_with_rips():
     st_from_rips = rips_complex.create_simplex_tree(max_dimension=1)
     assert list(st.get_filtration()) == list(st_from_rips.get_filtration())
 
+
 def test_empty_dtm_rips_complex():
     dtm_rips = DTMRipsComplex()
     st = dtm_rips.create_simplex_tree(max_dimension=1)
     assert st.num_simplices() == 1
-    assert st.filtration([0]) == 0.
+    assert st.filtration([0]) == 0.0

--- a/src/python/test/test_dtm_rips_complex.py
+++ b/src/python/test/test_dtm_rips_complex.py
@@ -38,5 +38,5 @@ def test_compatibility_with_rips():
 def test_empty_dtm_rips_complex():
     dtm_rips = DTMRipsComplex()
     st = dtm_rips.create_simplex_tree(max_dimension=1)
-    assert st.num_simplices() == 1
-    assert st.filtration([0]) == 0.0
+    assert st.num_simplices() == 0
+    assert st.dimension() == -1

--- a/src/python/test/test_dtm_rips_complex.py
+++ b/src/python/test/test_dtm_rips_complex.py
@@ -30,3 +30,8 @@ def test_compatibility_with_rips():
     st_from_rips = rips_complex.create_simplex_tree(max_dimension=1)
     assert list(st.get_filtration()) == list(st_from_rips.get_filtration())
 
+def test_empty_dtm_rips_complex():
+    dtm_rips = DTMRipsComplex()
+    st = dtm_rips.create_simplex_tree(max_dimension=1)
+    assert st.num_simplices() == 1
+    assert st.filtration([0]) == 0.

--- a/src/python/test/test_knn.py
+++ b/src/python/test/test_knn.py
@@ -128,3 +128,16 @@ def test_knn_nop():
     assert None is KNearestNeighbors(
         k=1, return_index=False, return_distance=False, metric="precomputed"
     ).fit_transform(p)
+
+def test_knn_k_limits():
+    nb_sample = 1000
+    for impl in ["sklearn", "ckdtree", "hnsw", "keops"]:
+        data = np.random.rand(nb_sample, 4)
+        with pytest.raises(ValueError):
+            KNearestNeighbors(
+                k=0, return_index=False, return_distance=True, sort_results=False, implementation=impl
+            ).fit_transform(data)
+        with pytest.raises(ValueError):
+            KNearestNeighbors(
+                k=nb_sample+1, return_index=False, return_distance=True, sort_results=False, implementation=impl
+            ).fit_transform(data)

--- a/src/python/test/test_knn.py
+++ b/src/python/test/test_knn.py
@@ -33,7 +33,14 @@ def test_knn_explicit():
     )
     assert r == pytest.approx(np.array([[0.0, 1], [1, 1], [1, 2]]))
     r = (
-        KNearestNeighbors(2, metric="chebyshev", return_distance=True, return_index=False, implementation="keops", enable_autodiff=True)
+        KNearestNeighbors(
+            2,
+            metric="chebyshev",
+            return_distance=True,
+            return_index=False,
+            implementation="keops",
+            enable_autodiff=True,
+        )
         .fit(base)
         .transform(query)
     )
@@ -59,7 +66,9 @@ def test_knn_explicit():
     assert np.array_equal(r[0], [[0, 1], [1, 0], [2, 0]])
     assert np.array_equal(r[1], [[0, 3], [0, 1], [0, 1]])
     # Second time in parallel
-    knn = KNearestNeighbors(2, metric="precomputed", return_index=True, return_distance=False, n_jobs=2, sort_results=True)
+    knn = KNearestNeighbors(
+        2, metric="precomputed", return_index=True, return_distance=False, n_jobs=2, sort_results=True
+    )
     r = knn.fit_transform(dist)
     assert np.array_equal(r, [[0, 1], [1, 0], [2, 0]])
     knn = KNearestNeighbors(2, metric="precomputed", return_index=True, return_distance=True, n_jobs=2)
@@ -129,6 +138,7 @@ def test_knn_nop():
         k=1, return_index=False, return_distance=False, metric="precomputed"
     ).fit_transform(p)
 
+
 def test_knn_k_limits():
     nb_sample = 1000
     for impl in ["sklearn", "ckdtree", "hnsw", "keops"]:
@@ -139,5 +149,5 @@ def test_knn_k_limits():
             ).fit_transform(data)
         with pytest.raises(ValueError):
             KNearestNeighbors(
-                k=nb_sample+1, return_index=False, return_distance=True, sort_results=False, implementation=impl
+                k=nb_sample + 1, return_index=False, return_distance=True, sort_results=False, implementation=impl
             ).fit_transform(data)


### PR DESCRIPTION
Motivated by [this comment](https://github.com/GUDHI/gudhi-devel/blob/e49ca57f7cd2ad3cb85baded9e47cd16f8f21d7e/src/python/gudhi/dtm_rips_complex.py#L44)

## current behaviour
```python
from gudhi.point_cloud.dtm import DistanceToMeasure
import numpy as np
DistanceToMeasure(0, implementation="ckdtree").fit_transform(numpy.random.rand(1000, 4))
# ValueError: zero-size array to reduction operation maximum which has no identity
DistanceToMeasure(0, implementation="sklearn").fit_transform(numpy.random.rand(1000, 4))
# ValueError: Expected n_neighbors > 0. Got 0
DistanceToMeasure(0, implementation="hnsw").fit_transform(numpy.random.rand(1000, 4))
# /home/gailuron/workspace/gudhi/gudhi-devel/build/src/python/gudhi/point_cloud/dtm.py:67: RuntimeWarning: invalid value encountered in true_divide
#   dtm = distances.sum(-1) / self.k
# array([nan, ..., nan],
#       dtype=float32)

# ==========================================================================================

DistanceToMeasure(1001, implementation="ckdtree").fit_transform(numpy.random.rand(1000, 4))
# array([inf, ..., inf])
DistanceToMeasure(1001, implementation="sklearn").fit_transform(numpy.random.rand(1000, 4))
# ValueError: Expected n_neighbors <= n_samples,  but n_samples = 1000, n_neighbors = 1001
DistanceToMeasure(1001, implementation="hnsw").fit_transform(numpy.random.rand(1000, 4))
# RuntimeError: Cannot return the results in a contigious 2D array. Probably ef or M is too small
```
(This behaviour is inherited from `KNearestNeighbors` class)
## Proposal
To me, `sklearn` behaves the most appropriately from a user point of view and `KNearestNeighbors` class should stick to this user interface.