### PR TITLE
add GudhUI compilation flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,7 +56,7 @@ foreach(GUDHI_MODULE ${GUDHI_MODULES})
   endforeach()
 endforeach()
 
-if (WITH_GUDHI_THIRD_PARTY)
+if (WITH_GUDHI_GUDHUI)
   add_subdirectory(src/GudhUI)
 endif()
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -71,7 +71,7 @@ foreach(GUDHI_MODULE ${GUDHI_MODULES})
   endforeach()
 endforeach()
 
-if (WITH_GUDHI_THIRD_PARTY)
+if (WITH_GUDHI_GUDHUI)
   add_subdirectory(GudhUI)
 endif()
 

--- a/src/cmake/modules/GUDHI_options.cmake
+++ b/src/cmake/modules/GUDHI_options.cmake
@@ -4,6 +4,7 @@ option(WITH_GUDHI_REMOTE_TEST "Activate/deactivate datasets fetching test which 
 option(WITH_GUDHI_PYTHON "Activate/deactivate python module compilation and installation" ON)
 option(WITH_GUDHI_TEST "Activate/deactivate examples compilation and installation" ON)
 option(WITH_GUDHI_UTILITIES "Activate/deactivate utilities compilation and installation" ON)
+option(WITH_GUDHI_GUDHUI "Activate/deactivate GudhUI" ON)
 option(WITH_GUDHI_THIRD_PARTY "Activate/deactivate third party libraries cmake detection. When set to OFF, it is useful for doxygen or user_version i.e." ON)
 
 if (NOT WITH_GUDHI_THIRD_PARTY)
@@ -12,4 +13,5 @@ if (NOT WITH_GUDHI_THIRD_PARTY)
   set (WITH_GUDHI_PYTHON OFF)
   set (WITH_GUDHI_TEST OFF)
   set (WITH_GUDHI_UTILITIES OFF)
+  set (WITH_GUDHI_GUDHUI OFF)
 endif()


### PR DESCRIPTION
This adds a flag `WITH_GUDHI_GUDHUI` to disable GudhUI compilation, without disabling everything.
This is very useful as **Gudhi doesn't compile** on a conda environment without qgl libraries, such as the following one :
```
channels:
- conda-forge
dependencies:
- auditwheel
- boost
- boost-cpp
- cgal-cpp
- cxx-compiler
- cython
- gudhi
- jupyterlab
- matplotlib
- numpy
- pybind11
- pytest
- python=3.11
- scikit-learn
- scipy
- sympy
- tbb
- tbb-devel
- tqdm
```
I suppose that cmake doesn't like some of the flags that comes with the cxx-compiler package, which gives the following error
```
[ 15%] Building CXX object src/GudhUI/CMakeFiles/GudhUI.dir/GudhUI_autogen/mocs_compilation.cpp.o
In file included from /user/dloiseau/home/git/gudhi-devel/build/src/GudhUI/GudhUI_autogen/include/ui_main_window.h:22,
                 from /user/dloiseau/home/git/gudhi-devel/build/src/GudhUI/GudhUI_autogen/DMHXEJ42XS/../../../../../src/GudhUI/gui/MainWindow.h:18,
                 from /user/dloiseau/home/git/gudhi-devel/build/src/GudhUI/GudhUI_autogen/DMHXEJ42XS/moc_MainWindow.cpp:10,
                 from /user/dloiseau/home/git/gudhi-devel/build/src/GudhUI/GudhUI_autogen/mocs_compilation.cpp:2:
/user/dloiseau/home/git/gudhi-devel/src/GudhUI/view/Viewer.h:14:10: fatal error: QGLViewer/qglviewer.h: No such file or directory
   14 | #include <QGLViewer/qglviewer.h>
      |          ^~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
```

