### PR TITLE
safer Cech for dim > ambient

### DIFF
--- a/src/Cech_complex/include/gudhi/Cech_complex_blocker.h
+++ b/src/Cech_complex/include/gudhi/Cech_complex_blocker.h
@@ -74,7 +74,12 @@ class Cech_blocker {
     Filtration_value radius = 0;
     bool is_min_enclos_ball = false;
     Point_cloud points;
-    points.reserve(sc_ptr_->dimension(sh)+1);
+    auto dim = sc_ptr_->dimension(sh);
+    if (dim > kernel_.point_dimension_d_object()(cc_ptr_->get_point(0))) {
+      // A sphere is always determined by at most d+1 points
+      return false;
+    }
+    points.reserve(dim + 1);
 
     // for each face of simplex sh, test outsider point is indeed inside enclosing ball, if yes, take it and exit loop, otherwise, new sphere is circumsphere of all vertices
     for (auto face_opposite_vertex : sc_ptr_->boundary_opposite_vertex_simplex_range(sh)) {

--- a/src/Cech_complex/include/gudhi/MEB_filtration.h
+++ b/src/Cech_complex/include/gudhi/MEB_filtration.h
@@ -101,6 +101,10 @@ void assign_MEB_filtration(Kernel&&k, SimplicialComplexForMEB& complex, PointRan
         Point_d c = k.construct_circumcenter_d_object()(pts.begin(), pts.end());
         FT r = k.squared_distance_d_object()(c, pts.front());
         if (exact) CGAL::exact(r);
+        // For Epick_d, if the circumcenter computation is too unstable, we could compute
+        //   int d2 = dim * dim;
+        //   Filtration_value max_sanity = maxf * d2 / (d2 - 1);
+        // and use min(max_sanity, ...), which would limit how bad numerical errors can be.
         maxf = max(maxf, cvt(r)); // maxf = cvt(r) except for rounding errors
         complex.assign_key(sh, cache_.size());
         // We could check if the simplex is maximal and avoiding adding it to the cache in that case.

--- a/src/Cech_complex/include/gudhi/MEB_filtration.h
+++ b/src/Cech_complex/include/gudhi/MEB_filtration.h
@@ -46,7 +46,15 @@ void assign_MEB_filtration(Kernel&&k, SimplicialComplexForMEB& complex, PointRan
   std::vector<Point_d> pts;
   CGAL::NT_converter<FT, Filtration_value> cvt;
 
+  // This block is only needed to get ambient_dim
+  if(std::begin(points) == std::end(points)) {
+    // assert(complex.is_empty());
+    return;
+  }
+  int ambient_dim = k.point_dimension_d_object()(*std::begin(points));
+
   auto fun = [&](Simplex_handle sh, int dim){
+    using std::max;
     if (dim == 0) complex.assign_filtration(sh, 0);
     else if (dim == 1) {
       // For a Simplex_tree, this would be a bit faster, but that's probably negligible
@@ -60,12 +68,18 @@ void assign_MEB_filtration(Kernel&&k, SimplicialComplexForMEB& complex, PointRan
       FT r = k.squared_distance_d_object()(m, pu);
       if (exact) CGAL::exact(r);
       complex.assign_key(sh, cache_.size());
-      complex.assign_filtration(sh, std::max(cvt(r), Filtration_value(0)));
+      complex.assign_filtration(sh, max(cvt(r), Filtration_value(0)));
       cache_.emplace_back(std::move(m), std::move(r));
+    } else if (dim > ambient_dim) {
+      // The sphere is always defined by at most d+1 points
+      Filtration_value maxf = 0; // max filtration of the faces
+      for (auto face : complex.boundary_simplex_range(sh)) {
+	maxf = max(maxf, complex.filtration(face));
+      }
+      complex.assign_filtration(sh, maxf);
     } else {
       Filtration_value maxf = 0; // max filtration of the faces
       bool found = false;
-      using std::max;
       for (auto face_opposite_vertex : complex.boundary_opposite_vertex_simplex_range(sh)) {
         maxf = max(maxf, complex.filtration(face_opposite_vertex.first));
         if (!found) {

--- a/src/Cech_complex/include/gudhi/MEB_filtration.h
+++ b/src/Cech_complex/include/gudhi/MEB_filtration.h
@@ -33,7 +33,7 @@ namespace Gudhi::cech_complex {
  */
 
 template<typename Kernel, typename SimplicialComplexForMEB, typename PointRange>
-void assign_MEB_filtration(Kernel&&k, SimplicialComplexForMEB& complex, PointRange points, bool exact = false) {
+void assign_MEB_filtration(Kernel&&k, SimplicialComplexForMEB& complex, PointRange const& points, bool exact = false) {
   using Point_d = typename Kernel::Point_d;
   using FT = typename Kernel::FT;
   using Sphere = std::pair<Point_d, FT>;

--- a/src/Cech_complex/include/gudhi/MEB_filtration.h
+++ b/src/Cech_complex/include/gudhi/MEB_filtration.h
@@ -74,7 +74,7 @@ void assign_MEB_filtration(Kernel&&k, SimplicialComplexForMEB& complex, PointRan
       // The sphere is always defined by at most d+1 points
       Filtration_value maxf = 0; // max filtration of the faces
       for (auto face : complex.boundary_simplex_range(sh)) {
-	maxf = max(maxf, complex.filtration(face));
+        maxf = max(maxf, complex.filtration(face));
       }
       complex.assign_filtration(sh, maxf);
     } else {

--- a/src/Cech_complex/test/test_cech_complex.cpp
+++ b/src/Cech_complex/test/test_cech_complex.cpp
@@ -169,12 +169,16 @@ BOOST_AUTO_TEST_CASE(Cech_complex_for_documentation) {
   BOOST_CHECK((st2.find({6, 7, 8}) == st2.null_simplex()));
   BOOST_CHECK((st2.find({3, 5, 7}) == st2.null_simplex()));
 
-  auto st2_save = st2;
-  st2.reset_filtration(-1); // unnecessary, but ensures we don't cheat
-  Gudhi::cech_complex::assign_MEB_filtration(Kernel(), st2, points);
-  for (auto sh : st2.complex_simplex_range())
-    st2.assign_filtration(sh, std::sqrt(st2.filtration(sh)));
-  BOOST_CHECK(st2 == st2_save); // Should only be an approximate test
+  Simplex_tree st3;
+  Cech_complex cech5(points, 1e50);
+  cech5.create_complex(st3, 5);
+  BOOST_CHECK(st3.dimension() == 5);
+  auto st3_save = st3;
+  st3.reset_filtration(-1); // unnecessary, but ensures we don't cheat
+  Gudhi::cech_complex::assign_MEB_filtration(Kernel(), st3, points);
+  for (auto sh : st3.complex_simplex_range())
+    st3.assign_filtration(sh, std::sqrt(st3.filtration(sh)));
+  BOOST_CHECK(st3 == st3_save); // Should only be an approximate test
 }
 
 BOOST_AUTO_TEST_CASE(Cech_complex_from_points) {


### PR DESCRIPTION
Fix #1030.
After that, I think (could be wrong though) the problems caused by Epick_d are no worse for Cech than for the alpha-complex. That is, we could investigate more numerically stable ways to compute a circumradius (especially since for the Cech we can assume that the center is inside the triangle), or mitigation strategies (like the one suggested in the new comment), to get a *better* balance between speed and safety, but nothing urgent.

- [ ] Check the impact on performance. I would expect a negligible slowdown if maxdim ≤ ambient dimension, and possibly a small speed up if maxdim is larger.