### PR TITLE
bibliography clean up

### DIFF
--- a/biblio/bibliography.bib
+++ b/biblio/bibliography.bib
@@ -163,7 +163,7 @@
 % D
 %-----------------------------
 
-@inproceedings{dtmdtmfiltrations,
+@inproceedings{dtmfiltrations,
   author    = {Anai, Hirokazu
                and Chazal, Fr{\'e}d{\'e}ric
                and Glisse, Marc

--- a/biblio/bibliography.bib
+++ b/biblio/bibliography.bib
@@ -1,119 +1,680 @@
-@inproceedings{gudhilibrary_ICMS14,
-  author    = {Cl\'ement Maria and Jean-Daniel Boissonnat and
-              Marc Glisse and Mariette Yvinec},
-  title     = {The {G}udhi Library: Simplicial Complexes and Persistent Homology},
-  booktitle = {ICMS},
+%-----------------------------
+% A
+%-----------------------------
+
+@inproceedings{cavanna15geometric,
+  author    = {Nicholas J. Cavanna and Mahmoodreza Jahanseir and Donald R. Sheehy},
+  booktitle = {Proceedings of the Canadian Conference on Computational Geometry},
+  title     = {A Geometric Perspective on Sparse Filtrations},
+  url       = {https://arxiv.org/abs/1506.03797},
+  year      = {2015}
+}
+
+@article{DBLP:journals/corr/BoissonnatS16,
+  author        = {Jean{-}Daniel Boissonnat and
+                   {Karthik {C. S.}}},
+  title         = {An Efficient Representation for Filtrations of Simplicial Complexes},
+  journal       = {CoRR},
+  volume        = {abs/1607.08449},
+  year          = {2016},
+  url           = {https://arxiv.org/abs/1607.08449},
+  archiveprefix = {arXiv},
+  eprint        = {1607.08449},
+  timestamp     = {Mon, 13 Aug 2018 16:46:26 +0200},
+  biburl        = {https://dblp.org/rec/bib/journals/corr/BoissonnatS16},
+  bibsource     = {dblp computer science bibliography, https://dblp.org}
+}
+
+@article{bubenik_dlotko_landscapes_2016,
+  author  = {P. Bubenik and P. Dlotko},
+  title   = {A persistence landscapes toolbox for topological statistics.},
+  journal = {Journal of Symbolic Computation.},
+  year    = {2016},
+  url     = {https://doi.org/10.1016/j.jsc.2016.03.009}
+}
+
+@article{Reininghaus_Huber_ALL_PSSK,
+  author  = {J. Reininghaus and S. Huber and U. Bauer and R. Kwitt},
+  title   = {A Stable Multi-Scale Kernel for Topological Machine Learning.},
+  journal = {Proc. 2015 IEEE Conf. Comp. Vision \& Pat. Rec. (CVPR '15)},
+  year    = {2015},
+  url     = {https://doi.org/10.1109/CVPR.2015.7299106}
+}
+
+@misc{royer2019atol,
+  title         = {ATOL: Measure Vectorisation for Automatic Topologically-Oriented Learning},
+  author        = {Martin Royer and Frédéric Chazal and Clément Levrard and Yuichi Ike and Yuhei Umeda},
+  year          = {2019},
+  eprint        = {1909.13472},
+  archiveprefix = {arXiv},
+  primaryclass  = {cs.CG}
+}
+
+@article{dtmdensity,
+  author    = {Biau, Gérard and Chazal, Frédéric and Cohen-Steiner, David and Devroye, Luc and Rodríguez, Carlos},
+  doi       = {10.1214/11-EJS606},
+  fjournal  = {Electronic Journal of Statistics},
+  journal   = {Electron. J. Statist.},
+  pages     = {204--237},
+  publisher = {The Institute of Mathematical Statistics and the Bernoulli Society},
+  title     = {A weighted k-nearest neighbor density estimate for geometric inference},
+  url       = {https://doi.org/10.1214/11-EJS606},
+  volume    = {5},
+  year      = {2011}
+}
+
+%-----------------------------
+% B
+%-----------------------------
+
+@inproceedings{boissonnat_et_al:LIPIcs:2015:5098,
+  author    = {Jean-Daniel Boissonnat and Karthik C. S. and S{\'e}bastien Tavenas},
+  title     = {{Building Efficient and Compact Data Structures for Simplicial Complexes}},
+  booktitle = {31st International Symposium on Computational Geometry (SoCG 2015)},
+  pages     = {642--656},
+  series    = {Leibniz International Proceedings in Informatics (LIPIcs)},
+  isbn      = {978-3-939897-83-5},
+  issn      = {1868-8969},
+  year      = {2015},
+  volume    = {34},
+  editor    = {Lars Arge and J{\'a}nos Pach},
+  publisher = {Schloss Dagstuhl--Leibniz-Zentrum fuer Informatik},
+  address   = {Dagstuhl, Germany},
+  url       = {https://drops.dagstuhl.de/opus/volltexte/2015/5098/},
+  urn       = {urn:nbn:de:0030-drops-50981},
+  doi       = {10.4230/LIPIcs.SOCG.2015.642},
+  annote    = {Keywords: Simplicial complex, Compact data structures, Automaton, NP-hard}
+}
+
+%-----------------------------
+% C
+%-----------------------------
+
+@book{kaczynski2004computational,
+  title     = {Computational Homology},
+  author    = {Kaczynski, T. and Mischaikow, K. and Mrozek, M.},
+  isbn      = {9780387408538},
+  lccn      = {03061109},
+  series    = {Applied Mathematical Sciences},
+  url       = {https://books.google.fr/books?id=AShKtpi3GecC},
+  year      = {2004},
+  publisher = {Springer New York}
+}
+
+@book{DBLP:books/daglib/0025666,
+  author    = {Herbert Edelsbrunner and
+               John Harer},
+  title     = {Computational Topology - an Introduction},
+  publisher = {American Mathematical Society},
+  year      = {2010},
+  isbn      = {978-0-8218-4925-5},
+  pages     = {I-XII, 1-241},
+  ee        = {http://www.ams.org/bookstore-getitem/item=MBK-69},
+  bibsource = {DBLP, http://dblp.uni-trier.de},
+  url       = {http://www.ams.org/bookstore-getitem/item=MBK-69}
+}
+
+@article{DBLP:journals/dcg/ZomorodianC05,
+  author    = {Afra Zomorodian and
+               Gunnar E. Carlsson},
+  title     = {Computing Persistent Homology},
+  journal   = {Discrete {\&} Computational Geometry},
+  volume    = {33},
+  number    = {2},
+  year      = {2005},
+  pages     = {249-274},
+  ee        = {http://www.springerlink.com/index/10.1007/s00454-004-1146-y},
+  bibsource = {DBLP, http://dblp.uni-trier.de},
+  url       = {https://doi.org/10.1007/s00454-004-1146-y}
+}
+
+@techreport{boissonnat:hal-00922572,
+  hal_id      = {hal-00922572},
+  url         = {https://hal.inria.fr/hal-00922572},
+  title       = {Computing Persistent Homology with Various Coefficient Fields in a Single Pass},
+  author      = {Boissonnat, Jean-Daniel and Maria, Cl{\'e}ment},
+  keywords    = {Computational Topology, Persistent homology, Modular reconstruction},
+  language    = {Anglais},
+  affiliation = {GEOMETRICA - INRIA Sophia Antipolis / INRIA Saclay - Ile de France},
+  pages       = {19},
+  type        = {Rapport de recherche},
+  institution = {INRIA},
+  number      = {RR-8436},
+  year        = {2013},
+  month       = Dec,
+  pdf         = {https://hal.inria.fr/hal-00922572v5/document}
+}
+
+@inproceedings{DBLP:conf/compgeom/DeyFW14,
+  author    = {Tamal K. Dey and
+               Fengtao Fan and
+               Yusu Wang},
+  title     = {Computing Topological Persistence for Simplicial Maps},
+  booktitle = {Symposium on Computational Geometry},
   year      = {2014},
+  pages     = {345},
+  doi       = {10.1145/2582112.2582165},
+  ee        = {http://doi.acm.org/10.1145/2582112.2582165},
+  bibsource = {DBLP, http://dblp.uni-trier.de},
+  url       = {https://doi.org/10.1145/2582112.2582165}
 }
 
-@article{Carriere17c,
-author = {Carri{\`{e}}re, Mathieu and Michel, Bertrand and Oudot, Steve},
-journal = {Journal of Machine Learning Research},
-pages = {1--39},
-publisher = {JMLR.org},
-title = {{Statistical analysis and parameter selection for Mapper}},
-volume = {19},
-year = {2018},
-url = {https://jmlr.org/papers/v19/17-291.html},
+%-----------------------------
+% D
+%-----------------------------
+
+@inproceedings{dtmdtmfiltrations,
+  author    = {Anai, Hirokazu
+               and Chazal, Fr{\'e}d{\'e}ric
+               and Glisse, Marc
+               and Ike, Yuichi
+               and Inakoshi, Hiroya
+               and Tinarrage, Rapha{\"e}l
+               and Umeda, Yuhei},
+  editor    = {Baas, Nils A.
+               and Carlsson, Gunnar E.
+               and Quick, Gereon
+               and Szymik, Markus
+               and Thaule, Marius},
+  title     = {DTM-Based Filtrations},
+  booktitle = {Topological Data Analysis},
+  year      = {2020},
+  publisher = {Springer International Publishing},
+  address   = {Cham},
+  pages     = {33--66},
+  isbn      = {978-3-030-43408-3},
+  doi       = {10.1007/978-3-030-43408-3_2},
+  url       = {https://doi.org/10.4230/LIPIcs.SoCG.2019.58}
 }
 
-@inproceedings{Dey13,
- author = {Dey, Tamal and Fan, Fengtao and Wang, Yusu},
- title = {Graph Induced Complex on Point Data},
- booktitle = {Proceedings of the Twenty-ninth Annual Symposium on Computational Geometry},
- year = {2013},
- pages = {107--116},
- doi = {10.1145/2462356.2462387}
+%-----------------------------
+% E
+%-----------------------------
+
+@article{buchet16efficient,
+  title   = {Efficient and Robust Persistent Homology for Measures},
+  author  = {Micka\"{e}l Buchet and Fr\'{e}d\'{e}ric Chazal and Steve Y. Oudot and Donald Sheehy},
+  journal = {Computational Geometry: Theory and Applications},
+  volume  = {58},
+  pages   = {70--96},
+  doi     = {10.1016/j.comgeo.2016.07.001},
+  year    = {2016},
+  url     = {https://doi.org/10.1016/j.comgeo.2016.07.001}
 }
 
-@article{Carriere16,
-author = {Carri{\`{e}}re, Mathieu and Oudot, Steve},
-journal = {Foundations of Computational Mathematics},
-number = {6},
-pages = {1333--1396},
-publisher = {Springer-Verlag},
-doi = {10.1007/s10208-017-9370-z},
-title = {{Structure and stability of the one-dimensional Mapper}},
-volume = {18},
-year = {2017}
+@inbook{peikert2012topological,
+  year      = {2012},
+  isbn      = {978-3-642-23174-2},
+  booktitle = {Topological Methods in Data Analysis and Visualization II},
+  series    = {Mathematics and Visualization},
+  editor    = {Peikert, Ronald and Hauser, Helwig and Carr, Hamish and Fuchs, Raphael},
+  doi       = {10.1007/978-3-642-23175-9_7},
+  title     = {Efficient Computation of Persistent Homology for Cubical Data},
+  url       = {http://dx.doi.org/10.1007/978-3-642-23175-9_7},
+  publisher = {Springer Berlin Heidelberg},
+  author    = {Wagner, Hubert and Chen, Chao and Vucini, Erald},
+  pages     = {91-106},
+  language  = {English}
 }
 
-@inproceedings{zigzag_reflection,
-  author    = {Jean-Daniel Boissonnat and Cl\'ement Maria and Steve Oudot},
-  title     = {Zigzag Persistent Homology Algorithm via Reflections},
-  year      = {2014 $\ \ \ \ \ \ \ \ \ \ \ $ \emph{In Preparation}},
+@article{blockers2012,
+  author    = {Dominique Attali and
+               Andr{\'e} Lieutier and
+               David Salinas},
+  title     = {Efficient Data Structure for Representing and Simplifying
+               Simplicial complexes in High Dimensions},
+  journal   = {Int. J. Comput. Geometry Appl.},
+  volume    = {22},
+  number    = {4},
+  year      = {2012},
+  pages     = {279-304},
+  ee        = {http://dx.doi.org/10.1142/S0218195912600060},
+  bibsource = {DBLP, http://dblp.uni-trier.de},
+  url       = {https://doi.org/10.1142/S0218195912600060}
+}
+
+@inproceedings{socg_blockers_2011,
+  author    = {Attali, Dominique and Lieutier, Andr{\'e} and Salinas, David},
+  title     = {Efficient data structure for representing and simplifying simplicial complexes in high dimensions},
+  booktitle = {Proceedings of the 27th annual ACM symposium on Computational geometry},
+  series    = {SoCG '11},
+  year      = {2011},
+  location  = {Paris, France},
+  pages     = {501--509},
+  numpages  = {9},
+  keywords  = {clique complexes, data structure, edge contraction, flag complexes, high dimensions, homotopy equivalence, shape reconstruction, shape simplification, simplicial complexes, vietoris-rips complexes},
+  url       = {https://doi.org/10.1145/1998196.1998277}
+}
+
+@book{Munkres-elementsalgtop1984,
+  author    = {James R. Munkres},
+  title     = {Elements of algebraic topology},
+  publisher = {Addison-Wesley},
+  year      = {1984},
+  isbn      = {978-0-201-04586-4},
+  pages     = {I-IX, 1-454},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
 }
 
 @article{Cohen-Steiner2009,
-author = {Cohen-Steiner, David and Edelsbrunner, Herbert and Harer, John},
-journal = {Foundations of Computational Mathematics},
-number = {1},
-pages = {79--103},
-publisher = {Springer-Verlag},
-doi = {10.1007/s10208-008-9027-z},
-title = {{Extending persistence using Poincar{\'{e}} and Lefschetz duality}},
-volume = {9},
-year = {2009}
+  author    = {Cohen-Steiner, David and Edelsbrunner, Herbert and Harer, John},
+  journal   = {Foundations of Computational Mathematics},
+  number    = {1},
+  pages     = {79--103},
+  publisher = {Springer-Verlag},
+  doi       = {10.1007/s10208-008-9027-z},
+  title     = {{Extending persistence using Poincar{\'{e}} and Lefschetz duality}},
+  volume    = {9},
+  year      = {2009},
+  url       = {https://doi.org/10.1007/s10208-008-9027-z}
 }
 
-@misc{gudhi_stpcoh,
-  author = {Cl\'ement Maria},
-  title = "\textsc{Gudhi}, Simplex Tree and Persistent Cohomology Packages",
-  note  = "\href{https://project.inria.fr/gudhi/software/}{\url{https://project.inria.fr/gudhi/software/}}"
+%-----------------------------
+% F
+%-----------------------------
+
+@inproceedings{Lindstrom,
+  author    = {Lindstrom, Peter and Turk, Greg},
+  title     = {Fast and Memory Efficient Polygonal Simplification},
+  booktitle = {Proceedings of the Conference on Visualization '98},
+  series    = {VIS '98},
+  year      = {1998},
+  isbn      = {1-58113-106-2},
+  location  = {Research Triangle Park, North Carolina, USA},
+  pages     = {279--286},
+  numpages  = {8},
+  publisher = {IEEE Computer Society Press},
+  address   = {Los Alamitos, CA, USA},
+  url       = {https://doi.org/10.1109/VISUAL.1998.745314}
 }
 
-%ARTICLES
-%------------------------------------------------------------------
-@article{boissonnatmariasimplextreealgorithmica,
-year={2014},
-issn={0178-4617},
-journal={Algorithmica},
-doi={10.1007/s00453-014-9887-3},
-title={The Simplex Tree: An Efficient Data Structure for General Simplicial Complexes},
-url={http://dx.doi.org/10.1007/s00453-014-9887-3},
-publisher={Springer US},
-keywords={Simplicial complexes; Data structure; Computational topology; Flag complexes; Witness complexes},
-author={Boissonnat, Jean-Daniel and Maria, Cl\'ement},
-pages={1-22},
-language={English}
+@misc{arxivpers1d,
+  doi       = {10.48550/ARXIV.2301.04745},
+  url       = {https://arxiv.org/abs/2301.04745},
+  author    = {Glisse, Marc},
+  keywords  = {Computational Geometry (cs.CG), Algebraic Topology (math.AT), FOS: Computer and information sciences, FOS: Computer and information sciences, FOS: Mathematics, FOS: Mathematics},
+  title     = {Fast persistent homology computation for functions on $\mathbb{R}$},
+  publisher = {arXiv},
+  year      = {2023},
+  copyright = {arXiv.org perpetual, non-exclusive license}
+}
+
+@article{turner2014frechet,
+  title     = {Fr{\'e}chet means for distributions of persistence diagrams},
+  author    = {Turner, Katharine and Mileyko, Yuriy and Mukherjee, Sayan and Harer, John},
+  journal   = {Discrete \& Computational Geometry},
+  doi       = {10.1007/s00454-014-9604-7},
+  volume    = {52},
+  number    = {1},
+  pages     = {44--70},
+  year      = {2014},
+  publisher = {Springer},
+  url       = {https://doi.org/10.1007/s00454-014-9604-7}
+}
+
+%-----------------------------
+% G
+%-----------------------------
+
+@article{dtm,
+  author   = {Chazal, Fr{\'e}d{\'e}ric
+              and Cohen-Steiner, David
+              and M{\'e}rigot, Quentin},
+  title    = {Geometric Inference for Probability Measures},
+  journal  = {Foundations of Computational Mathematics},
+  year     = {2011},
+  volume   = {11},
+  number   = {6},
+  pages    = {733-751},
+  issn     = {1615-3383},
+  doi      = {10.1007/s10208-011-9098-0},
+  url      = {https://doi.org/10.1007/s10208-011-9098-0}
+}
+
+@article{DBLP:journals/algorithmica/EfratIK01,
+  author    = {Alon Efrat and
+               Alon Itai and
+               Matthew J. Katz},
+  title     = {Geometry Helps in Bottleneck Matching and Related Problems},
+  journal   = {Algorithmica},
+  volume    = {31},
+  number    = {1},
+  year      = {2001},
+  pages     = {1-28},
+  ee        = {http://dx.doi.org/10.1007/s00453-001-0016-8},
+  bibsource = {DBLP, http://dblp.uni-trier.de},
+  url       = {https://doi.org/10.1007/s00453-001-0016-8}
+}
+
+@article{Kerber:2017:GHC:3047249.3064175,
+  author     = {Kerber, Michael and Morozov, Dmitriy and Nigmetov, Arnur},
+  title      = {Geometry Helps to Compare Persistence Diagrams},
+  journal    = {J. Exp. Algorithmics},
+  issue_date = {2017},
+  volume     = {22},
+  month      = sep,
+  year       = {2017},
+  issn       = {1084-6654},
+  pages      = {1.4:1--1.4:20},
+  articleno  = {1.4},
+  numpages   = {20},
+  url        = {http://doi.acm.org/10.1145/3064175},
+  doi        = {10.1145/3064175},
+  acmid      = {3064175},
+  publisher  = {ACM},
+  address    = {New York, NY, USA},
+  keywords   = {Assignment problems, bipartite matching, k-d tree, persistent homology}
+}
+
+@inproceedings{Dey13,
+  author    = {Dey, Tamal and Fan, Fengtao and Wang, Yusu},
+  title     = {Graph Induced Complex on Point Data},
+  booktitle = {Proceedings of the Twenty-ninth Annual Symposium on Computational Geometry},
+  year      = {2013},
+  pages     = {107--116},
+  doi       = {10.1145/2462356.2462387},
+  url       = {https://doi.org/10.1016/j.comgeo.2015.04.003}
+}
+
+@inproceedings{chubet_et_al:LIPIcs.SoCG.2023.64,
+  author    = {Chubet, Oliver A. and Macnichol, Paul and Parikh, Parth and Sheehy, Donald R. and Sheth, Siddharth S.},
+  title     = {{Greedy Permutations and Finite Voronoi Diagrams}},
+  booktitle = {39th International Symposium on Computational Geometry (SoCG 2023)},
+  pages     = {64:1--64:5},
+  series    = {Leibniz International Proceedings in Informatics (LIPIcs)},
+  isbn      = {978-3-95977-273-0},
+  issn      = {1868-8969},
+  year      = {2023},
+  volume    = {258},
+  editor    = {Chambers, Erin W. and Gudmundsson, Joachim},
+  publisher = {Schloss Dagstuhl -- Leibniz-Zentrum f{\"u}r Informatik},
+  address   = {Dagstuhl, Germany},
+  url       = {https://drops.dagstuhl.de/opus/volltexte/2023/17914},
+  urn       = {urn:nbn:de:0030-drops-179146},
+  doi       = {10.4230/LIPIcs.SoCG.2023.64},
+  annote    = {Keywords: greedy permutation, Voronoi diagrams}
+}
+
+%-----------------------------
+% H
+%-----------------------------
+
+
+
+%-----------------------------
+% I
+%-----------------------------
+
+@article{Fasy_Kim_Lecci_Maria_tda,
+  author  = {B. Fasy and J. Kim and F. Lecci and C. Maria},
+  title   = {Introduction to the R package TDA.},
+  journal = {arXiv:1411.1830.},
+  year    = {2016},
+  url     = {http://arxiv.org/abs/1411.1830}
+}
+
+%-----------------------------
+% J
+%-----------------------------
+
+
+
+%-----------------------------
+% K
+%-----------------------------
+
+
+
+%-----------------------------
+% L
+%-----------------------------
+
+@inproceedings{10.5555/3327546.3327645,
+  author    = {Lacombe, Th\'{e}o and Cuturi, Marco and Oudot, Steve},
+  title     = {Large Scale Computation of Means and Clusters for Persistence Diagrams Using Optimal Transport},
+  year      = {2018},
+  publisher = {Curran Associates Inc.},
+  address   = {Red Hook, NY, USA},
+  booktitle = {Proceedings of the 32nd International Conference on Neural Information Processing Systems},
+  pages     = {9792–9802},
+  numpages  = {11},
+  location  = {Montr\'{e}al, Canada},
+  series    = {NIPS’18},
+  url       = {https://proceedings.neurips.cc/paper/2018/hash/b58f7d184743106a8a66028b7a28937c-Abstract.html}
+}
+
+@article{sheehy13linear,
+  title   = {Linear-Size Approximations to the {V}ietoris-{R}ips Filtration},
+  author  = {Donald R. Sheehy},
+  journal = {Discrete \& Computational Geometry},
+  volume  = {49},
+  number  = {4},
+  pages   = {778--796},
+  doi     = {10.1007/s00454-013-9513-1},
+  year    = {2013},
+  url     = {https://doi.org/10.1007/s00454-013-9513-1}
+}
+
+%-----------------------------
+% M
+%-----------------------------
+
+@article{tangentialcomplex2014,
+  author   = {Boissonnat, Jean-Daniel and Ghosh, Arijit},
+  title    = {Manifold Reconstruction Using Tangential Delaunay Complexes},
+  journal  = {Discrete {\&} Computational Geometry},
+  year     = {2014},
+  volume   = {51},
+  number   = {1},
+  pages    = {221--267},
+  issn     = {1432-0444},
+  doi      = {10.1007/s00454-013-9557-2},
+  url      = {http://dx.doi.org/10.1007/s00454-013-9557-2}
+}
+
+@phdthesis{KachanovichThesis,
+  title       = {{Meshing submanifolds using Coxeter triangulations}},
+  author      = {Kachanovich, Siargey},
+  url         = {https://hal.inria.fr/tel-02419148},
+  number      = {2019AZUR4072},
+  school      = {{COMUE Universit{\'e} C{\^o}te d'Azur (2015 - 2019)}},
+  year        = {2019},
+  month       = Oct,
+  keywords    = {Mesh generation ; Coxeter triangulations ; Simplex quality ; Triangulations of the Euclidean space ; Freudenthal-Kuhn triangulations ; G{\'e}n{\'e}ration de maillages ; Triangulations de Coxeter ; Qualit{\'e} des simplexes ; Triangulations de l'espace euclidien ; Triangulations de Freudenthal-Kuhn},
+  type        = {Theses},
+  pdf         = {https://hal.inria.fr/tel-02419148v2/file/2019AZUR4072.pdf},
+  hal_id      = {tel-02419148},
+  hal_version = {v2}
+}
+
+%-----------------------------
+% N
+%-----------------------------
+
+
+
+%-----------------------------
+% O
+%-----------------------------
+
+
+
+%-----------------------------
+% P
+%-----------------------------
+
+@article{tomato,
+  author     = {Chazal, Fr\'{e}d\'{e}ric and Guibas, Leonidas J. and Oudot, Steve Y. and Skraba, Primoz},
+  title      = {Persistence-Based Clustering in Riemannian Manifolds},
+  year       = {2013},
+  issue_date = {November 2013},
+  publisher  = {Association for Computing Machinery},
+  address    = {New York, NY, USA},
+  volume     = {60},
+  number     = {6},
+  issn       = {0004-5411},
+  url        = {https://doi.org/10.1145/2535927},
+  doi        = {10.1145/2535927},
+  journal    = {J. ACM},
+  month      = nov,
+  articleno  = {Article 41},
+  numpages   = {38},
+  keywords   = {mode seeking, Unsupervised learning, computational topology, clustering, Morse theory, topological persistence}
+}
+
+@article{Persistence_Images_2017,
+  author  = {H. Adams and S. Chepushtanova and T. Emerson and E. Hanson and M. Kirby and F. Motta and R. Neville and C. Peterson and P. Shipman and L. Ziegelmeier},
+  title   = {Persistence Images: A Stable Vector Representation of Persistent Homology.},
+  journal = {Journal of Machine Learning Research},
+  year    = {2017},
+  url     = {http://jmlr.org/papers/v18/16-337.html}
+}
+
+@article{Kusano_Fukumizu_Hiraoka_PWGK,
+  author  = {G. Kusano and K. Fukumizu and Y. Hiraoka},
+  title   = {Persistence weighted Gaussian kernel for topological data analysis.},
+  journal = {ICML'16 Proceedings of the 33rd International Conference on International Conference on Machine Learning - Volume 48},
+  year    = {2016},
+  url     = {http://proceedings.mlr.press/v48/kusano16.html}
+}
+
+@article{DBLP:journals/dcg/SilvaMV11,
+  author    = {Vin de Silva and
+               Dmitriy Morozov and
+               Mikael Vejdemo-Johansson},
+  title     = {Persistent Cohomology and Circular Coordinates},
+  journal   = {Discrete {\&} Computational Geometry},
+  volume    = {45},
+  number    = {4},
+  year      = {2011},
+  pages     = {737-759},
+  ee        = {http://dx.doi.org/10.1007/s00454-011-9344-x},
+  bibsource = {DBLP, http://dblp.uni-trier.de},
+  url       = {https://doi.org/10.1007/s00454-011-9344-x}
+}
+
+@article{Ferri_Frosini_comparision_sheme_2,
+  author  = {M. Ferri and P. Frosini and A. Lovato and C. Zambelli},
+  title   = {Point selection: A new comparison scheme for size functions (With an application to monogram recognition).},
+  journal = {Proceedings Third Asian Conference on Computer Vision, Lecture Notes in Computer Science 1351.},
+  year    = {1998},
+  url     = {https://doi.org/10.1007/3-540-63930-6\_138}
+}
+
+%-----------------------------
+% Q
+%-----------------------------
+
+
+
+%-----------------------------
+% R
+%-----------------------------
+
+
+
+%-----------------------------
+% S
+%-----------------------------
+
+@article{Ferri_Frosini_comparision_sheme_1,
+  author  = {P. Donatini and P. Frosini and A. Lovato},
+  title   = {Size functions for signature recognition.},
+  journal = {Proceedings of SPIE, Vision Geometry VII, vol. 3454},
+  year    = {1998},
+  url     = {https://doi.org/10.1117/12.323253}
+}
+
+@inproceedings{pmlr-v70-carriere17a,
+  title     = {Sliced {W}asserstein Kernel for Persistence Diagrams},
+  author    = {Mathieu Carri{\`e}re and Marco Cuturi and Steve Oudot},
+  booktitle = {Proceedings of the 34th International Conference on Machine Learning},
+  pages     = {664--673},
+  year      = {2017},
+  editor    = {Doina Precup and Yee Whye Teh},
+  volume    = {70},
+  series    = {Proceedings of Machine Learning Research},
+  address   = {International Convention Centre, Sydney, Australia},
+  month     = {06--11 Aug},
+  publisher = {PMLR},
+  url       = {http://proceedings.mlr.press/v70/carriere17a.html}
+}
+
+@article{Carriere_Oudot_Ovsjanikov_top_signatures_3d,
+  author  = {M. Carri\`ere and S. Oudot and M. Ovsjanikov},
+  title   = {Stable Topological Signatures for Points on 3D Shapes.},
+  journal = {Proc. Sympos. on Geometry Processing},
+  year    = {2015},
+  url     = {https://doi.org/10.1111/cgf.12692}
+}
+
+@article{Carriere17c,
+  author    = {Carri{\`{e}}re, Mathieu and Michel, Bertrand and Oudot, Steve},
+  journal   = {Journal of Machine Learning Research},
+  pages     = {1--39},
+  publisher = {JMLR.org},
+  title     = {{Statistical analysis and parameter selection for Mapper}},
+  volume    = {19},
+  year      = {2018},
+  url       = {https://jmlr.org/papers/v19/17-291.html}
+}
+
+@article{bubenik_landscapes_2015,
+  author  = {P. Bubenik},
+  title   = {Statistical topological data analysis using persistence landscapes.},
+  journal = {Journal of Machine Learning Research},
+  year    = {2015},
+  url     = {https://dl.acm.org/doi/10.5555/2789272.2789275}
+}
+
+@article{Carriere16,
+  author    = {Carri{\`{e}}re, Mathieu and Oudot, Steve},
+  journal   = {Foundations of Computational Mathematics},
+  number    = {6},
+  pages     = {1333--1396},
+  publisher = {Springer-Verlag},
+  doi       = {10.1007/s10208-017-9370-z},
+  title     = {{Structure and stability of the one-dimensional Mapper}},
+  volume    = {18},
+  year      = {2017},
+  url       = {https://doi.org/10.1007/s10208-017-9370-z}
+}
+
+@misc{icml2014,
+  doi       = {10.48550/ARXIV.1406.1901},
+  url       = {https://arxiv.org/abs/1406.1901},
+  author    = {Chazal, Frédéric and Fasy, Brittany Terese and Lecci, Fabrizio and Michel, Bertrand and Rinaldo, Alessandro and Wasserman, Larry},
+  keywords  = {Algebraic Topology (math.AT), Computational Geometry (cs.CG), Applications (stat.AP), FOS: Mathematics, FOS: Mathematics, FOS: Computer and information sciences, FOS: Computer and information sciences},
+  title     = {Subsampling Methods for Persistent Homology},
+  publisher = {arXiv},
+  year      = {2014},
+  copyright = {arXiv.org perpetual, non-exclusive license}
 }
 
 @inproceedings{Garland,
- author = {Garland, Michael and Heckbert, Paul S.},
- title = {Surface simplification using quadric error metrics},
- booktitle = {Proceedings of the 24th annual conference on Computer graphics and interactive techniques},
- series = {SIGGRAPH '97},
- year = {1997},
- isbn = {0-89791-896-7},
- pages = {209--216},
- numpages = {8},
- publisher = {ACM Press/Addison-Wesley Publishing Co.},
- address = {New York, NY, USA},
- keywords = {level of detail, mutiresolution modeling, non-manifold, pair contraction, surface simplification},
+  author    = {Garland, Michael and Heckbert, Paul S.},
+  title     = {Surface simplification using quadric error metrics},
+  booktitle = {Proceedings of the 24th annual conference on Computer graphics and interactive techniques},
+  series    = {SIGGRAPH '97},
+  year      = {1997},
+  isbn      = {0-89791-896-7},
+  pages     = {209--216},
+  numpages  = {8},
+  publisher = {ACM Press/Addison-Wesley Publishing Co.},
+  address   = {New York, NY, USA},
+  keywords  = {level of detail, mutiresolution modeling, non-manifold, pair contraction, surface simplification},
+  url       = {https://doi.org/10.1145/258734.258849}
 }
 
-
-@inproceedings{Lindstrom,
- author = {Lindstrom, Peter and Turk, Greg},
- title = {Fast and Memory Efficient Polygonal Simplification},
- booktitle = {Proceedings of the Conference on Visualization '98},
- series = {VIS '98},
- year = {1998},
- isbn = {1-58113-106-2},
- location = {Research Triangle Park, North Carolina, USA},
- pages = {279--286},
- numpages = {8},
- publisher = {IEEE Computer Society Press},
- address = {Los Alamitos, CA, USA},
+@misc{edgecollapsearxiv,
+  author = {Marc Glisse and Siddharth Pritam},
+  title  = {{Swap, Shift and Trim to Edge Collapse a Filtration}},
+  url    = {https://arxiv.org/abs/2203.07022}
 }
 
-
-@article{boissonnatmariacamalgorithmica,
-journal={Submitted to Algorithmica},
-title={The Compressed Annotation Matrix: An Efficient Data Structure for Computing Persistent Cohomology},
-author={Jean-Daniel Boissonnat and Tamal K. Dey and Cl{\'e}ment Maria},
-language={English},
-}
+%-----------------------------
+% T
+%-----------------------------
 
 @inproceedings{DBLP:conf/esa/BoissonnatDM13,
   author    = {Jean-Daniel Boissonnat and
@@ -128,168 +689,119 @@ language={English},
   bibsource = {DBLP, http://dblp.uni-trier.de}
 }
 
-@inproceedings{boissonnatmariaesa2014,
-  author    = {Jean-Daniel Boissonnat and
-               Cl{\'e}ment Maria},
-  title     = {Computing Persistent Homology with Various Coefficient Fields in a Single Pass},
-  booktitle = {ESA},
-  year      = {2014}
-}
-
-@inproceedings{DBLP:conf/esa/BoissonnatM12,
-  author    = {Jean-Daniel Boissonnat and
-               Cl{\'e}ment Maria},
-  title     = {The Simplex Tree: An Efficient Data Structure for General Simplicial Complexes},
-  url       = {http://dx.doi.org/10.1007/978-3-642-33090-2_63},
-  doi       = {10.1007/978-3-642-33090-2_63},
-  booktitle = {ESA},
-  year      = {2012},
-  pages     = {731-742},
-  bibsource = {DBLP, http://dblp.uni-trier.de}
-}
-
-
-
-%% hal-00922572, version 2
-%% https://hal.inria.fr/hal-00922572
-@techreport{boissonnat:hal-00922572,
-    hal_id = {hal-00922572},
-    url = {https://hal.inria.fr/hal-00922572},
-    title = {Computing Persistent Homology with Various Coefficient Fields in a Single Pass},
-    author = {Boissonnat, Jean-Daniel and Maria, Cl{\'e}ment},
-    abstract = {{In this article, we introduce the multi-field persistence diagram for the persistence homology of a filtered complex. It encodes compactly the superimposition of the persistence diagrams of the complex with several field coefficients, and provides a substantially more precise description of the topology of the filtered complex. Specifically, the multi-field persistence diagram encodes the Betti numbers of integral homology and the prime divisors of the torsion coefficients of the underlying shape. Moreover, it enjoys similar stability properties as the ones of standard persistence diagrams, with the appropriate notion of distance. These properties make the multi-field persistence diagram a useful tool in computational topology.}},
-    keywords = {Computational Topology, Persistent homology, Modular reconstruction},
-    language = {Anglais},
-    affiliation = {GEOMETRICA - INRIA Sophia Antipolis / INRIA Saclay - Ile de France},
-    pages = {19},
-    type = {Rapport de recherche},
-    institution = {INRIA},
-    number = {RR-8436},
-    year = {2013},
-    month = Dec,
-    pdf = {https://hal.inria.fr/hal-00922572v5/document},
-}
-
-
-
-
-
-
-@inproceedings{DBLP:conf/compgeom/CarlssonSM09,
-  author    = {Gunnar E. Carlsson and
-               Vin de Silva and
-               Dmitriy Morozov},
-  title     = {Zigzag persistent homology and real-valued functions},
-  booktitle = {Symposium on Computational Geometry},
-  year      = {2009},
-  pages     = {247-256},
-  ee        = {http://doi.acm.org/10.1145/1542362.1542408},
-  bibsource = {DBLP, http://dblp.uni-trier.de}
-}
-@inproceedings{DBLP:conf/compgeom/Cohen-SteinerEM06,
-  author    = {David Cohen-Steiner and
-               Herbert Edelsbrunner and
-               Dmitriy Morozov},
-  title     = {Vines and vineyards by updating persistence in linear time},
-  booktitle = {Symposium on Computational Geometry},
-  year      = {2006},
-  pages     = {119-126},
-  ee        = {http://doi.acm.org/10.1145/1137856.1137877},
-  bibsource = {DBLP, http://dblp.uni-trier.de}
-}
-
-@article{quiverrepresentations_derksenweyman,
-  author  = {Harm Derksen and Jerzy Weyman},
-  title   = {Quiver Representations},
-  journal = {Notices of the AMS},
-  volume  = {52},
-  number  = {2},
-  year    = {2005},
-  pages   = {200-206}
-}
-@article{DBLP:journals/dcg/SilvaMV11,
-  author    = {Vin de Silva and
-               Dmitriy Morozov and
-               Mikael Vejdemo-Johansson},
-  title     = {Persistent Cohomology and Circular Coordinates},
-  journal   = {Discrete {\&} Computational Geometry},
-  volume    = {45},
-  number    = {4},
-  year      = {2011},
-  pages     = {737-759},
-  ee        = {http://dx.doi.org/10.1007/s00454-011-9344-x},
-  bibsource = {DBLP, http://dblp.uni-trier.de}
-}
-@article{RS62,
-        author={J. B. Rosser and L. Schoenfeld},
-        title={Approximate Formulas for some Functions of Prime Numbers},
-        journal= {ijm},
-        volume= 6,
-        year= 1962,
-        pages={64-94},
-        mrnumber={25 \#1139}
-}
-@article{DBLP:journals/siamcomp/Furer09,
-  author    = {Martin F{\"u}rer},
-  title     = {Faster Integer Multiplication},
-  journal   = {SIAM J. Comput.},
-  volume    = {39},
-  number    = {3},
-  year      = {2009},
-  pages     = {979-1005},
-  ee        = {http://dx.doi.org/10.1137/070711761},
-  bibsource = {DBLP, http://dblp.uni-trier.de}
-}
-@article{DBLP:journals/dcg/ZomorodianC05,
-  author    = {Afra Zomorodian and
-               Gunnar E. Carlsson},
-  title     = {Computing Persistent Homology},
-  journal   = {Discrete {\&} Computational Geometry},
-  volume    = {33},
-  number    = {2},
-  year      = {2005},
-  pages     = {249-274},
-  ee        = {http://www.springerlink.com/index/10.1007/s00454-004-1146-y},
-  bibsource = {DBLP, http://dblp.uni-trier.de}
-}
-@article{DBLP:journals/dcg/Cohen-SteinerEH07,
-  author    = {David Cohen-Steiner and
-               Herbert Edelsbrunner and
-               John Harer},
-  title     = {Stability of Persistence Diagrams},
-  journal   = {Discrete {\&} Computational Geometry},
-  volume    = {37},
-  number    = {1},
-  year      = {2007},
-  pages     = {103-120},
-  ee        = {http://dx.doi.org/10.1007/s00454-006-1276-5},
-  bibsource = {DBLP, http://dblp.uni-trier.de}
-}
-@article{DBLP:journals/siamcomp/HafnerM91,
-  author    = {James L. Hafner and
-               Kevin S. McCurley},
-  title     = {Asymptotically Fast Triangularization of Matrices Over Rings},
-  journal   = {SIAM J. Comput.},
-  volume    = {20},
-  number    = {6},
-  year      = {1991},
-  pages     = {1068-1083},
-  ee        = {http://dx.doi.org/10.1137/0220067},
-  bibsource = {DBLP, http://dblp.uni-trier.de}
-}
-@article{DBLP:journals/algorithmica/EfratIK01,
-  author    = {Alon Efrat and
-               Alon Itai and
-               Matthew J. Katz},
-  title     = {Geometry Helps in Bottleneck Matching and Related Problems},
+@article{boissonnatmariasimplextreealgorithmica,
+  year      = {2014},
+  issn      = {0178-4617},
   journal   = {Algorithmica},
-  volume    = {31},
-  number    = {1},
-  year      = {2001},
-  pages     = {1-28},
-  ee        = {http://dx.doi.org/10.1007/s00453-001-0016-8},
+  doi       = {10.1007/s00453-014-9887-3},
+  title     = {The Simplex Tree: An Efficient Data Structure for General Simplicial Complexes},
+  url       = {http://dx.doi.org/10.1007/s00453-014-9887-3},
+  publisher = {Springer US},
+  keywords  = {Simplicial complexes; Data structure; Computational topology; Flag complexes; Witness complexes},
+  author    = {Boissonnat, Jean-Daniel and Maria, Cl\'ement},
+  pages     = {1-22},
+  language  = {English}
+}
+
+@article{de2004topological,
+  title   = {Topological estimation using witness complexes},
+  author  = {De Silva, Vin and Carlsson, Gunnar},
+  journal = {Proc. Sympos. Point-Based Graphics},
+  pages   = {157-166},
+  year    = {2004},
+  url     = {https://doi.org/10.2312/SPBG/SPBG04/157-166}
+}
+
+%-----------------------------
+% U
+%-----------------------------
+
+
+
+%-----------------------------
+% V
+%-----------------------------
+
+@inproceedings{cavanna15visualizing,
+  author    = {Nicholas J. Cavanna and Mahmoodreza Jahanseir and Donald R. Sheehy},
+  booktitle = {Proceedings of the 31st International Symposium on Computational Geometry},
+  title     = {Visualizing Sparse Filtrations},
+  year      = {2015},
+  doi       = {10.4230/LIPIcs.SOCG.2015.23},
+  url       = {https://doi.org/10.4230/LIPIcs.SOCG.2015.23}
+}
+
+%-----------------------------
+% W
+%-----------------------------
+
+
+
+%-----------------------------
+% X
+%-----------------------------
+
+
+
+%-----------------------------
+% Y
+%-----------------------------
+
+
+
+%-----------------------------
+% Z
+%-----------------------------
+
+@article{DBLP:journals/focm/CarlssonS10,
+  author    = {Gunnar E. Carlsson and
+               Vin de Silva},
+  title     = {Zigzag Persistence},
+  journal   = {Foundations of Computational Mathematics},
+  volume    = {10},
+  number    = {4},
+  year      = {2010},
+  pages     = {367-405},
+  doi       = {10.1007/s10208-010-9066-0},
+  ee        = {http://dx.doi.org/10.1007/s10208-010-9066-0},
+  bibsource = {DBLP, http://dblp.uni-trier.de},
+  url       = {https://doi.org/10.1007/s10208-010-9066-0}
+}
+
+%-----------------------------
+% UNUSED
+%-----------------------------
+
+@book{Hatcher-algebraictopology2001,
+  author       = {Hatcher, Allen},
+  day          = {03},
+  edition      = {1},
+  howpublished = {Paperback},
+  isbn         = {0521795400},
+  keywords     = {topology},
+  month        = dec,
+  posted-at    = {2008-06-25 09:53:39},
+  priority     = {2},
+  publisher    = {Cambridge University Press},
+  title        = {{Algebraic Topology}},
+  url          = {http://www.math.cornell.edu/\~{}hatcher/AT/AT.pdf},
+  year         = {2001}
+}
+
+@article{DBLP:journals/cagd/DelfinadoE95,
+  author    = {Cecil Jose A. Delfinado and
+               Herbert Edelsbrunner},
+  title     = {An incremental algorithm for {B}etti numbers of simplicial
+               complexes on the 3-sphere},
+  journal   = {Computer Aided Geometric Design},
+  volume    = {12},
+  number    = {7},
+  year      = {1995},
+  pages     = {771-784},
+  ee        = {http://dx.doi.org/10.1016/0167-8396(95)00016-Y},
   bibsource = {DBLP, http://dblp.uni-trier.de}
 }
+
 @article{DBLP:journals/siamcomp/HopcroftK73,
   author    = {John E. Hopcroft and
                Richard M. Karp},
@@ -304,43 +816,91 @@ language={English},
   bibsource = {DBLP, http://dblp.uni-trier.de}
 }
 
-%------------------------------------------------------------------
-@article{blockers2012,
-  author    = {Dominique Attali and
-               Andr{\'e} Lieutier and
-               David Salinas},
-  title     = {Efficient Data Structure for Representing and Simplifying
-               Simplicial complexes in High Dimensions},
-  journal   = {Int. J. Comput. Geometry Appl.},
-  volume    = {22},
+@misc{ann_mount,
+  author = {David M. Mount
+            and Sunil Arya},
+  title  = {\textsc{ANN}, {A}pproximate {N}earest {N}eighbors {L}ibrary},
+  note   = {http://www.cs.sunysb.edu/~algorith/implement/ANN/implement.shtml}
+}
+
+@article{DBLP:journals/comgeo/ChenK13,
+  author    = {Chao Chen and
+               Michael Kerber},
+  title     = {An output-sensitive algorithm for persistent homology},
+  journal   = {Comput. Geom.},
+  volume    = {46},
   number    = {4},
-  year      = {2012},
-  pages     = {279-304},
-  ee        = {http://dx.doi.org/10.1142/S0218195912600060},
+  year      = {2013},
+  pages     = {435-447},
+  ee        = {http://dx.doi.org/10.1016/j.comgeo.2012.02.010},
   bibsource = {DBLP, http://dblp.uni-trier.de}
 }
 
-%------------------------------------------------------------------
-@article{rips2012,
-    hal_id = {hal-00785072},
-    url = {https://hal.archives-ouvertes.fr/hal-00785072},
-    title = {{Vietoris-Rips Complexes also Provide Topologically Correct Reconstructions of Sampled Shapes}},
-    author = {Attali, Dominique and Lieutier, Andr{\'e} and Salinas, David},
-    keywords = {Shape reconstruction \sep Rips complexes \sep clique complexes \sep \v Cech complexes ; homotopy equivalence ; collapses ; high dimensions},
-    language = {Anglais},
-    affiliation = {Grenoble Images Parole Signal Automatique - GIPSA-lab , Laboratoire Jean Kuntzmann - LJK},
-    pages = {448-465},
-    journal = {Computational Geometry},
-    volume = {46},
-    number = {4, special issue },
-    audience = {internationale },
-    doi = {10.1016/j.comgeo.2012.02.009 },
-    year = {2012},
-    pdf = {http://hal.archives-ouvertes.fr/hal-00785072/PDF/2012-cgta-Rips.pdf},
+@article{RS62,
+  author   = {J. B. Rosser and L. Schoenfeld},
+  title    = {Approximate Formulas for some Functions of Prime Numbers},
+  journal  = {ijm},
+  volume   = 6,
+  year     = 1962,
+  pages    = {64-94},
+  mrnumber = {25 \#1139}
 }
 
+@inproceedings{DBLP:conf/issac/StorjohannL96,
+  author    = {Arne Storjohann and
+               George Labahn},
+  title     = {Asymptotically Fast Computation of {H}ermite Normal Forms
+               of Integer Matrices},
+  booktitle = {ISSAC},
+  year      = {1996},
+  pages     = {259-266},
+  ee        = {http://doi.acm.org/10.1145/236869.237083},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}
 
-%------------------------------------------------------------------
+@article{DBLP:journals/siamcomp/HafnerM91,
+  author    = {James L. Hafner and
+               Kevin S. McCurley},
+  title     = {Asymptotically Fast Triangularization of Matrices Over Rings},
+  journal   = {SIAM J. Comput.},
+  volume    = {20},
+  number    = {6},
+  year      = {1991},
+  pages     = {1068-1083},
+  ee        = {http://dx.doi.org/10.1137/0220067},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}
+
+@book{DBLP:tibkat_237559129,
+  author = {Saunders Mac Lane},
+  title  = {Categories for the working mathematician},
+  year   = {1998},
+  ee     = {http://www.zentralblatt-math.org/zmath/en/search/?an}
+}
+
+@article{DBLP:journals/corr/abs-1205-3669,
+  author    = {Peter Bubenik and
+               Jonathan A. Scott},
+  title     = {Categorification of persistent homology},
+  journal   = {CoRR},
+  volume    = {abs/1205.3669},
+  year      = {2012},
+  ee        = {http://arxiv.org/abs/1205.3669},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}
+
+@incollection{Bauer:arXiv1303.0477,
+  year      = {2014},
+  isbn      = {978-3-319-04098-1},
+  booktitle = {Topological Methods in Data Analysis and Visualization III},
+  doi       = {10.1007/978-3-319-04099-8_7},
+  title     = {Clear and Compress: Computing Persistent Homology in Chunks},
+  url       = {http://dx.doi.org/10.1007/978-3-319-04099-8_7},
+  author    = {Bauer, Ulrich and Kerber, Michael and Reininghaus, Jan},
+  pages     = {103-117},
+  language  = {English}
+}
+
 @article{DBLP:journals/corr/abs-1210-1429,
   author    = {Pawel Dlotko and
                Hubert Wagner},
@@ -353,55 +913,279 @@ language={English},
   bibsource = {DBLP, http://dblp.uni-trier.de}
 }
 
-%------------------------------------------------------------------
-@article{tangentialcomplex2014,
-author="Boissonnat, Jean-Daniel and Ghosh, Arijit",
-title="Manifold Reconstruction Using Tangential Delaunay Complexes",
-journal="Discrete {\&} Computational Geometry",
-year="2014",
-volume="51",
-number="1",
-pages="221--267",
-abstract="We give a provably correct algorithm to reconstruct a k-dimensional smooth manifold embedded in d-dimensional Euclidean space. The input to our algorithm is a point sample coming from an unknown manifold. Our approach is based on two main ideas: the notion of tangential Delaunay complex defined in Boissonnat and Fl{\"o}totto (Comput. Aided Des. 36:161--174, 2004), Fl{\"o}totto (A coordinate system associated to a point cloud issued from a manifold: definition, properties and applications. Ph.D. thesis, 2003), Freedman (IEEE Trans. Pattern Anal. Mach. Intell. 24(10), 2002), and the technique of sliver removal by weighting the sample points (Cheng et al. in J. ACM 47:883--904, 2000). Differently from previous methods, we do not construct any subdivision of the d-dimensional ambient space. As a result, the running time of our algorithm depends only linearly on the extrinsic dimension d while it depends quadratically on the size of the input sample, and exponentially on the intrinsic dimension k. To the best of our knowledge, this is the first certified algorithm for manifold reconstruction whose complexity depends linearly on the ambient dimension. We also prove that for a dense enough sample the output of our algorithm is isotopic to the manifold and a close geometric approximation of the manifold.",
-issn="1432-0444",
-doi="10.1007/s00454-013-9557-2",
-url="http://dx.doi.org/10.1007/s00454-013-9557-2"
+@article{ghrist_coverage,
+  author  = {V. de Silva and R. Ghrist},
+  title   = {Coverage in sensor network via persistent homology},
+  journal = {Algebraic {\&} Geometric Topology},
+  volume  = {7},
+  year    = {2007},
+  pages   = {339-358}
 }
 
-%BOOKS
-%------------------------------------------------------------------
-@book{DBLP:tibkat_237559129,
-   author              = {Saunders Mac Lane},
-   title               = {Categories for the working mathematician},
-   year                = {1998},
-   ee                  = {http://www.zentralblatt-math.org/zmath/en/search/?an}
+@misc{dionysus_morozov,
+  author = {Dmitriy Morozov},
+  title  = {\textsc{Dionysus}},
+  note   = {http://www.mrzv.org/software/dionysus/}
 }
 
-
-@book{Hatcher-algebraictopology2001,
-    author = {Hatcher, Allen},
-    day = {03},
-    edition = {1},
-    howpublished = {Paperback},
-    isbn = {0521795400},
-    keywords = {topology},
-    month = dec,
-    posted-at = {2008-06-25 09:53:39},
-    priority = {2},
-    publisher = {Cambridge University Press},
-    title = {{Algebraic Topology}},
-    url = {http://www.math.cornell.edu/\~{}hatcher/AT/AT.pdf},
-    year = {2001}
-}
-@book{Munkres-elementsalgtop1984,
-  author    = {James R. Munkres},
-  title     = {Elements of algebraic topology},
-  publisher = {Addison-Wesley},
-  year      = {1984},
-  isbn      = {978-0-201-04586-4},
-  pages     = {I-IX, 1-454},
+@inproceedings{DBLP:conf/alenex/BauerKR14,
+  author    = {Ulrich Bauer and
+               Michael Kerber and
+               Jan Reininghaus},
+  title     = {Distributed Computation of Persistent Homology},
+  booktitle = {ALENEX},
+  year      = {2014},
+  pages     = {31-38},
+  ee        = {http://dx.doi.org/10.1137/1.9781611973198.4},
   bibsource = {DBLP, http://dblp.uni-trier.de}
 }
+
+@article{SMV211,
+  author  = {V. de Silva and
+             D. Morozov and
+             M. Vejdemo-Johansson},
+  title   = {Dualities in persistent (co)homology},
+  journal = {Inverse Problems},
+  volume  = {27},
+  year    = {2011},
+  pages   = {124003},
+  url     = {http://arxiv.org/abs/1107.5665}
+}  
+
+@inproceedings{edgecollapsesocg2020,
+  author    = {Jean-Daniel Boissonnat and Siddharth Pritam},
+  title     = {{Edge Collapse and Persistence of Flag Complexes}},
+  booktitle = {36th International Symposium on Computational Geometry (SoCG 2020)},
+  pages     = {19:1--19:15},
+  series    = {Leibniz International Proceedings in Informatics (LIPIcs)},
+  isbn      = {978-3-95977-143-6},
+  issn      = {1868-8969},
+  year      = {2020},
+  volume    = {164},
+  editor    = {Sergio Cabello and Danny Z. Chen},
+  publisher = {Schloss Dagstuhl--Leibniz-Zentrum f{\"u}r Informatik},
+  address   = {Dagstuhl, Germany},
+  url       = {https://drops.dagstuhl.de/opus/volltexte/2020/12177/},
+  urn       = {urn:nbn:de:0030-drops-121777},
+  doi       = {10.4230/LIPIcs.SoCG.2020.19},
+  annote    = {Keywords: Computational Topology, Topological Data Analysis, Edge Collapse, Simple Collapse, Persistent homology}
+}
+
+@inproceedings{DBLP:conf/soda/BentleyS97,
+  author    = {Jon Louis Bentley and
+               Robert Sedgewick},
+  title     = {Fast Algorithms for Sorting and Searching Strings},
+  booktitle = {SODA},
+  year      = {1997},
+  pages     = {360-369},
+  ee        = {http://doi.acm.org/10.1145/314161.314321},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}
+
+@article{DBLP:journals/siamcomp/Furer09,
+  author    = {Martin F{\"u}rer},
+  title     = {Faster Integer Multiplication},
+  journal   = {SIAM J. Comput.},
+  volume    = {39},
+  number    = {3},
+  year      = {2009},
+  pages     = {979-1005},
+  ee        = {http://dx.doi.org/10.1137/070711761},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}
+
+@inproceedings{deSilva:2013:GSP:2493132.2462402,
+  author    = {de Silva, Vin and Nanda, Vidit},
+  title     = {Geometry in the space of persistence modules},
+  booktitle = {Proceedings of the twenty-ninth annual symposium on Computational geometry},
+  series    = {SoCG '13},
+  year      = {2013},
+  isbn      = {978-1-4503-2031-3},
+  location  = {Rio de Janeiro, Brazil},
+  pages     = {397--404},
+  numpages  = {8},
+  url       = {http://doi.acm.org/10.1145/2462356.2462402},
+  doi       = {10.1145/2462356.2462402},
+  acmid     = {2462402},
+  publisher = {ACM},
+  address   = {New York, NY, USA},
+  keywords  = {discrete and computational geometry, embedding theorem, persistent homology}
+}
+
+@misc{gmplib_cite,
+  title = {GMP, The GNU Multiple Precision Arithmetic Library},
+  note  = {http://gmplib.org/}
+}
+
+@book{Cormen:2001:IA:580470,
+  author    = {Cormen, Thomas H. and Stein, Clifford and Rivest, Ronald L. and Leiserson, Charles E.},
+  title     = {Introduction to Algorithms},
+  year      = {2001},
+  isbn      = {0070131511},
+  edition   = {2nd},
+  publisher = {McGraw-Hill Higher Education}
+}
+
+@misc{jplex_cite,
+  author = {Sexton, Harlan and Johansson, Mikael Vejdemo},
+  title  = {\textsc{JPlex}},
+  year   = {2009},
+  note   = {http://comptop.stanford.edu/programs/jplex/}
+}
+
+@book{Gathen:2003:MCA:945759,
+  author    = {Gathen, Joachim Von Zur and Gerhard, Jurgen},
+  title     = {Modern Computer Algebra},
+  year      = {2003},
+  isbn      = {0521826462},
+  edition   = {2},
+  publisher = {Cambridge University Press},
+  address   = {New York, NY, USA}
+}
+
+@article{mischaikow_nanda_morse,
+  year      = {2013},
+  issn      = {0179-5376},
+  journal   = {Discrete {\&} Computational Geometry},
+  volume    = {50},
+  number    = {2},
+  doi       = {10.1007/s00454-013-9529-6},
+  title     = {Morse Theory for Filtrations and Efficient Computation of Persistent Homology},
+  url       = {http://dx.doi.org/10.1007/s00454-013-9529-6},
+  publisher = {Springer US},
+  keywords  = {Computational topology; Discrete Morse theory; Persistent homology},
+  author    = {Mischaikow, Konstantin and Nanda, Vidit},
+  pages     = {330-353},
+  language  = {English}
+}
+
+@inproceedings{DBLP:conf/issac/Storjohann96,
+  author    = {Arne Storjohann},
+  title     = {Near Optimal Algorithms for Computing Smith Normal Forms
+               of Integer Matrices},
+  booktitle = {ISSAC},
+  year      = {1996},
+  pages     = {267-274},
+  ee        = {http://doi.acm.org/10.1145/236869.237084},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}
+
+@inproceedings{sheehy20onehop,
+  title     = {One Hop Greedy Permutations},
+  author    = {Donald R. Sheehy},
+  booktitle = {Proceedings of the 32nd Canadian Conference on Computational Geometry},
+  pages     = {221--225},
+  year      = {2020},
+  url       = {https://par.nsf.gov/biblio/10211951}
+}
+
+@article{journals/moc/Moller08,
+  added-at  = {2011-04-10T00:00:00.000+0200},
+  author    = {M\"oller, Niels},
+  biburl    = {http://www.bibsonomy.org/bibtex/2a40c83ae0a723c978ff29ccaec7ff7ee/dblp},
+  ee        = {http://dx.doi.org/10.1090/S0025-5718-07-02017-0},
+  interhash = {d2f425fef08e9b3ea347b12cbcf9792f},
+  intrahash = {a40c83ae0a723c978ff29ccaec7ff7ee},
+  journal   = {Math. Comput.},
+  keywords  = {dblp},
+  number    = 261,
+  pages     = {589-607},
+  timestamp = {2011-04-10T00:00:00.000+0200},
+  title     = {On Sch\"onhage's algorithm and subquadratic integer gcd computation.},
+  url       = {http://dblp.uni-trier.de/db/journals/moc/moc77.html#Moller08},
+  volume    = 77,
+  year      = 2008
+}
+
+@article{Carlsson:2008:LBS:1325290.1325300,
+  author    = {Carlsson, Gunnar and Ishkhanov, Tigran and Silva, Vin and Zomorodian, Afra},
+  title     = {On the Local Behavior of Spaces of Natural Images},
+  journal   = {Int. J. Comput. Vision},
+  volume    = {76},
+  issue     = {1},
+  month     = {January},
+  year      = {2008},
+  issn      = {0920-5691},
+  pages     = {1--12},
+  numpages  = {12},
+  url       = {http://portal.acm.org/citation.cfm?id=1325290.1325300},
+  doi       = {10.1007/s11263-007-0056-x},
+  acmid     = {1325300},
+  publisher = {Kluwer Academic Publishers},
+  address   = {Hingham, MA, USA},
+  keywords  = {Filtration, Klein bottle, Manifold, Natural images, Persistent homology, Topology}
+}
+
+@article{Morozov05persistencealgorithm,
+  author  = {Dmitriy Morozov},
+  title   = {Persistence algorithm takes cubic time in worst case},
+  journal = {BioGeometry News, Dept. Comput. Sci., Duke Univ},
+  year    = {2005}
+}
+
+@inproceedings{Chen11persistenthomology,
+  author    = {Chao Chen and Michael Kerber},
+  title     = {Persistent homology computation with a twist},
+  booktitle = {Proceedings 27th European Workshop on Computational Geometry},
+  year      = {2011}
+}
+
+@misc{phat_lib,
+  author = {Bauer, Ulrich and Kerber, Michael and Reininghaus, Jan},
+  title  = {\textsc{Phat}},
+  note   = {https://code.google.com/p/phat/}
+}
+
+@article{quiverrepresentations_derksenweyman,
+  author  = {Harm Derksen and Jerzy Weyman},
+  title   = {Quiver Representations},
+  journal = {Notices of the AMS},
+  volume  = {52},
+  number  = {2},
+  year    = {2005},
+  pages   = {200-206}
+}
+
+@inproceedings{Rahimi07randomfeatures,
+  author    = {Ali Rahimi and Ben Recht},
+  title     = {Random features for large-scale kernel machines},
+  booktitle = {In Neural Information Processing Systems},
+  year      = {2007}
+}
+
+@article{DBLP:journals/dcg/Cohen-SteinerEH07,
+  author    = {David Cohen-Steiner and
+               Herbert Edelsbrunner and
+               John Harer},
+  title     = {Stability of Persistence Diagrams},
+  journal   = {Discrete {\&} Computational Geometry},
+  volume    = {37},
+  number    = {1},
+  year      = {2007},
+  pages     = {103-120},
+  ee        = {http://dx.doi.org/10.1007/s00454-006-1276-5},
+  bibsource = {DBLP, http://dblp.uni-trier.de}
+}
+
+@article{Fredman:1984:SST:828.1884,
+  author     = {Fredman, Michael L. and Koml\'{o}s, J\'{a}nos and Szemer{\'e}di, Endre},
+  title      = {Storing a Sparse Table with {O}(1) Worst Case Access Time},
+  journal    = {J. ACM},
+  issue_date = {July 1984},
+  volume     = {31},
+  number     = {3},
+  month      = jun,
+  year       = {1984},
+  issn       = {0004-5411},
+  pages      = {538--544},
+  numpages   = {7},
+  url        = {http://doi.acm.org/10.1145/828.1884},
+  doi        = {10.1145/828.1884},
+  acmid      = {1884},
+  publisher  = {ACM},
+  address    = {New York, NY, USA}
+}
+
 @book{DBLP:books/aw/Knuth81,
   author    = {Donald E. Knuth},
   title     = {The Art of Computer Programming, Volume II: Seminumerical
@@ -411,26 +1195,7 @@ url="http://dx.doi.org/10.1007/s00454-013-9557-2"
   isbn      = {0-201-03822-6},
   bibsource = {DBLP, http://dblp.uni-trier.de}
 }
-@book{DBLP:books/daglib/0025666,
-  author    = {Herbert Edelsbrunner and
-               John Harer},
-  title     = {Computational Topology - an Introduction},
-  publisher = {American Mathematical Society},
-  year      = {2010},
-  isbn      = {978-0-8218-4925-5},
-  pages     = {I-XII, 1-241},
-  ee        = {http://www.ams.org/bookstore-getitem/item=MBK-69},
-  bibsource = {DBLP, http://dblp.uni-trier.de}
-}
-@book{Gathen:2003:MCA:945759,
- author = {Gathen, Joachim Von Zur and Gerhard, Jurgen},
- title = {Modern Computer Algebra},
- year = {2003},
- isbn = {0521826462},
- edition = {2},
- publisher = {Cambridge University Press},
- address = {New York, NY, USA},
-}
+
 @book{DBLP:books/aw/AhoHU74,
   author    = {Alfred V. Aho and
                John E. Hopcroft and
@@ -441,205 +1206,26 @@ url="http://dx.doi.org/10.1007/s00454-013-9557-2"
   isbn      = {0-201-00029-6},
   bibsource = {DBLP, http://dblp.uni-trier.de}
 }
-%------------------------------------------------------------------
 
-
-
-%INPROCEEDINGS
-%------------------------------------------------------------------
-
-  crossref  = {DBLP:conf/esa/2013},
-
-proceedings{DBLP:conf/esa/2013,
-  editor    = {Hans L. Bodlaender and
-               Giuseppe F. Italiano},
-  title     = {Algorithms - ESA 2013 - 21st Annual European Symposium,
-               Sophia Antipolis, France, September 2-4, 2013. Proceedings},
-  booktitle = {ESA},
-  publisher = {Springer},
-  series    = {Lecture Notes in Computer Science},
-  volume    = {8125},
-  year      = {2013},
-  isbn      = {978-3-642-40449-8},
-  ee        = {http://dx.doi.org/10.1007/978-3-642-40450-4},
-  bibsource = {DBLP, http://dblp.uni-trier.de}
-}
-@inproceedings{DBLP:conf/issac/StorjohannL96,
-  author    = {Arne Storjohann and
-               George Labahn},
-  title     = {Asymptotically Fast Computation of {H}ermite Normal Forms
-               of Integer Matrices},
-  booktitle = {ISSAC},
-  year      = {1996},
-  pages     = {259-266},
-  ee        = {http://doi.acm.org/10.1145/236869.237083},
-  bibsource = {DBLP, http://dblp.uni-trier.de}
-}  crossref  = {DBLP:conf/issac/1996},
-@inproceedings{DBLP:conf/issac/Storjohann96,
-  author    = {Arne Storjohann},
-  title     = {Near Optimal Algorithms for Computing Smith Normal Forms
-               of Integer Matrices},
-  booktitle = {ISSAC},
-  year      = {1996},
-  pages     = {267-274},
-  ee        = {http://doi.acm.org/10.1145/236869.237084},
-
-  bibsource = {DBLP, http://dblp.uni-trier.de}
-}  crossref  = {DBLP:conf/issac/1996},
-proceedings{DBLP:conf/issac/1996,
-  editor    = {Erwin Engeler and
-               B. F. Caviness and
-               Yagati N. Lakshman},
-  title     = {Proceedings of the 1996 International Symposium on Symbolic
-               and Algebraic Computation, ISSAC '96, Zurich, Switzerland,
-               July 24-26, 1996},
-  booktitle = {ISSAC},
-  publisher = {ACM},
-  year      = {1996},
-  isbn      = {0-89791-796-0},
-  ee        = {http://dl.acm.org/citation.cfm?id=236869},
+@article{DBLP:journals/ijcv/LeePM03,
+  author    = {Ann B. Lee and
+               Kim Steenstrup Pedersen and
+               David Mumford},
+  title     = {The Nonlinear Statistics of High-Contrast Patches in Natural
+               Images},
+  journal   = {International Journal of Computer Vision},
+  volume    = {54},
+  number    = {1-3},
+  year      = {2003},
+  pages     = {83-103},
+  ee        = {http://dx.doi.org/10.1023/A:1023705401078},
   bibsource = {DBLP, http://dblp.uni-trier.de}
 }
 
-
-proceedings{DBLP:conf/issac/1996,
-  editor    = {Erwin Engeler and
-               B. F. Caviness and
-               Yagati N. Lakshman},
-  title     = {Proceedings of the 1996 International Symposium on Symbolic
-               and Algebraic Computation, ISSAC '96, Zurich, Switzerland,
-               July 24-26, 1996},
-  booktitle = {ISSAC},
-  publisher = {ACM},
-  year      = {1996},
-  isbn      = {0-89791-796-0},
-  ee        = {http://dl.acm.org/citation.cfm?id=236869},
-  bibsource = {DBLP, http://dblp.uni-trier.de}
-}
-
-
-@inproceedings{socg_blockers_2011,
- author = {Attali, Dominique and Lieutier, Andr{\'e} and Salinas, David},
- title = {Efficient data structure for representing and simplifying simplicial complexes in high dimensions},
- booktitle = {Proceedings of the 27th annual ACM symposium on Computational geometry},
- series = {SoCG '11},
- year = {2011},
- location = {Paris, France},
- pages = {501--509},
- numpages = {9},
- keywords = {clique complexes, data structure, edge contraction, flag complexes, high dimensions, homotopy equivalence, shape reconstruction, shape simplification, simplicial complexes, vietoris-rips complexes},
-}
-
-
-
-%------------------------------------------------------------------
-
-%MISC
-%------------------------------------------------------------------
-@article{DBLP:journals/corr/abs-1208-5018,
-  author    = {Tamal K. Dey and
-               Fengtao Fan and
-               Yusu Wang},
-  title     = {Computing Topological Persistence for Simplicial Maps},
-  journal   = {CoRR},
-  volume    = {abs/1208.5018},
-  year      = {2012},
-  ee        = {http://arxiv.org/abs/1208.5018},
-  bibsource = {DBLP, http://dblp.uni-trier.de}
-}
-@article{DBLP:journals/corr/abs-1107-5665,
-  author    = {Vin de Silva and
-               Dmitriy Morozov and
-               Mikael Vejdemo-Johansson},
-  title     = {Dualities in persistent (co)homology},
-  journal   = {CoRR},
-  volume    = {abs/1107.5665},
-  year      = {2011},
-  ee        = {http://arxiv.org/abs/1107.5665},
-  bibsource = {DBLP, http://dblp.uni-trier.de}
-}
-
-%------------------------------------------------------------------
-
-%LIBRARY
-
-%------------------------------------------------------------------
-@misc{gmplib_cite,
-title = "GMP, The GNU Multiple Precision Arithmetic Library",
-note = "http://gmplib.org/",
-}
-%------------------------------------------------------------------
-
-
-
-
-%TEMPORARY
-%------------------------------------------------------------------
-@misc{royer2019atol,
-    title={ATOL: Measure Vectorisation for Automatic Topologically-Oriented Learning},
-    author={Martin Royer and Frédéric Chazal and Clément Levrard and Yuichi Ike and Yuhei Umeda},
-    year={2019},
-    eprint={1909.13472},
-    archivePrefix={arXiv},
-    primaryClass={cs.CG}
-}
-
-@inproceedings{deSilva:2013:GSP:2493132.2462402,
- author = {de Silva, Vin and Nanda, Vidit},
- title = {Geometry in the space of persistence modules},
- booktitle = {Proceedings of the twenty-ninth annual symposium on Computational geometry},
- series = {SoCG '13},
- year = {2013},
- isbn = {978-1-4503-2031-3},
- location = {Rio de Janeiro, Brazil},
- pages = {397--404},
- numpages = {8},
- url = {http://doi.acm.org/10.1145/2462356.2462402},
- doi = {10.1145/2462356.2462402},
- acmid = {2462402},
- publisher = {ACM},
- address = {New York, NY, USA},
- keywords = {discrete and computational geometry, embedding theorem, persistent homology},
-}
-@article{Fredman:1984:SST:828.1884,
- author = {Fredman, Michael L. and Koml\'{o}s, J\'{a}nos and Szemer{\'e}di, Endre},
- title = {Storing a Sparse Table with {O}(1) Worst Case Access Time},
- journal = {J. ACM},
- issue_date = {July 1984},
- volume = {31},
- number = {3},
- month = jun,
- year = {1984},
- issn = {0004-5411},
- pages = {538--544},
- numpages = {7},
- url = {http://doi.acm.org/10.1145/828.1884},
- doi = {10.1145/828.1884},
- acmid = {1884},
- publisher = {ACM},
- address = {New York, NY, USA},
-}
-%------------------------------------------------------------------
-
-
-
-%%%%% TEMP
-article{journals/moc/Moller08,
-  added-at = {2011-04-10T00:00:00.000+0200},
-  author = {M\"oller, Niels},
-  biburl = {http://www.bibsonomy.org/bibtex/2a40c83ae0a723c978ff29ccaec7ff7ee/dblp},
-  ee = {http://dx.doi.org/10.1090/S0025-5718-07-02017-0},
-  interhash = {d2f425fef08e9b3ea347b12cbcf9792f},
-  intrahash = {a40c83ae0a723c978ff29ccaec7ff7ee},
-  journal = {Math. Comput.},
-  keywords = {dblp},
-  number = 261,
-  pages = {589-607},
-  timestamp = {2011-04-10T00:00:00.000+0200},
-  title = {On Sch\"onhage's algorithm and subquadratic integer gcd computation.},
-  url = {http://dblp.uni-trier.de/db/journals/moc/moc77.html#Moller08},
-  volume = 77,
-  year = 2008
+@misc{buddha_stanford_scan,
+  author = {},
+  title  = {The Stanford 3D Scanning Repository},
+  note   = {http://graphics.stanford.edu/data/3Dscanrep/}
 }
 
 @article{DBLP:journals/dcg/EdelsbrunnerLZ02,
@@ -656,222 +1242,66 @@ article{journals/moc/Moller08,
   bibsource = {DBLP, http://dblp.uni-trier.de}
 }
 
-
-
-
-inproceedings{DBLP:conf/esa/2012,
-  editor    = {Leah Epstein and
-               Paolo Ferragina},
-  title     = {Algorithms - ESA 2012 - 20th Annual European Symposium,
-               Ljubljana, Slovenia, September 10-12, 2012. Proceedings},
-  booktitle = {ESA},
-  publisher = {Springer},
-  series    = {Lecture Notes in Computer Science},
-  volume    = {7501},
-  year      = {2012},
-  isbn      = {978-3-642-33089-6},
-  ee        = {http://dx.doi.org/10.1007/978-3-642-33090-2},
-  bibsource = {DBLP, http://dblp.uni-trier.de}
+@article{martin2010top,
+  title    = {Topology of cyclo-octane energy landscape.},
+  author   = {Martin, S. and Thompson, A. and Coutsias, E.A. and Watson, J.},
+  journal  = {J Chem Phys},
+  volume   = {132},
+  number   = {23},
+  pages    = {234115},
+  year     = {2010},
+  abstract = {Understanding energy landscapes is a major challenge in chemistry and biology. Although a wide variety of methods have been invented and applied to this problem, very little is understood about the actual mathematical structures underlying such landscapes. Perhaps the most general assumption is the idea that energy landscapes are low-dimensional manifolds embedded in high-dimensional Euclidean space. While this is a very mild assumption, we have discovered an example of an energy landscape which is nonmanifold, demonstrating previously unknown mathematical complexity. The example occurs in the energy landscape of cyclo-octane, which was found to have the structure of a reducible algebraic variety, composed of the union of a sphere and a Klein bottle, intersecting in two rings.}
 }
 
-
-
-@article{SMV11,
-  author    = {V. de Silva and
-               D. Morozov and
-               M. Vejdemo-Johansson},
-  title     = {Persistent cohomology and circular coordinates},
-  journal   = {Discrete Comput. Geom.},
-  volume    = {45},
-  pages = {737-759},
-  year      = {2011},
-}
-@article{SMV211,
-  author    = {V. de Silva and
-               D. Morozov and
-               M. Vejdemo-Johansson},
-  title     = {Dualities in persistent (co)homology},
-  journal   = {Inverse Problems},
-  volume    = {27},
-  year      = {2011},
-  pages     = {124003},
-}
-
-
-
-
-
-inproceedings{DBLP:conf/soda/BentleyS97,
-  author    = {Jon Louis Bentley and
-               Robert Sedgewick},
-  title     = {Fast Algorithms for Sorting and Searching Strings},
-  booktitle = {SODA},
-  year      = {1997},
-  pages     = {360-369},
-  ee        = {http://doi.acm.org/10.1145/314161.314321},
-  bibsource = {DBLP, http://dblp.uni-trier.de}
-}
 @inproceedings{CO08,
   author    = {F. Chazal and S. Oudot},
   title     = {Towards persistence-based reconstruction in Euclidean spaces},
-  booktitle   = {Proc. 24th. Annu. Sympos. Comput. Geom.},
+  booktitle = {Proc. 24th. Annu. Sympos. Comput. Geom.},
   year      = {2008},
-  pages = {231-241}
-}
-inproceedings{DBLP:conf/soda/1997,
-  editor    = {Michael E. Saks},
-  title     = {Proceedings of the Eighth Annual ACM-SIAM Symposium on Discrete
-               Algorithms, 5-7 January 1997, New Orleans, Louisiana},
-  booktitle = {SODA},
-  publisher = {ACM/SIAM},
-  year      = {1997},
-  isbn      = {0-89871-390-0},
-  ee        = {http://dl.acm.org/citation.cfm?id=314161},
-  bibsource = {DBLP, http://dblp.uni-trier.de}
+  pages     = {231-241}
 }
 
+@article{rips2012,
+  hal_id      = {hal-00785072},
+  url         = {https://hal.archives-ouvertes.fr/hal-00785072},
+  title       = {{Vietoris-Rips Complexes also Provide Topologically Correct Reconstructions of Sampled Shapes}},
+  author      = {Attali, Dominique and Lieutier, Andr{\'e} and Salinas, David},
+  keywords    = {Shape reconstruction \sep Rips complexes \sep clique complexes \sep \v Cech complexes ; homotopy equivalence ; collapses ; high dimensions},
+  language    = {Anglais},
+  affiliation = {Grenoble Images Parole Signal Automatique - GIPSA-lab , Laboratoire Jean Kuntzmann - LJK},
+  pages       = {448-465},
+  journal     = {Computational Geometry},
+  volume      = {46},
+  number      = {4, special issue },
+  audience    = {internationale },
+  doi         = {10.1016/j.comgeo.2012.02.009 },
+  year        = {2012},
+  pdf         = {http://hal.archives-ouvertes.fr/hal-00785072/PDF/2012-cgta-Rips.pdf}
+}
 
-
-
-@inproceedings{attali-rips_approx,
-  author    = {Dominique Attali and
-               Andr{\'e} Lieutier and
-               David Salinas},
-  title     = {Vietoris-rips complexes also provide topologically correct
-               reconstructions of sampled shapes},
+@inproceedings{DBLP:conf/compgeom/Cohen-SteinerEM06,
+  author    = {David Cohen-Steiner and
+               Herbert Edelsbrunner and
+               Dmitriy Morozov},
+  title     = {Vines and vineyards by updating persistence in linear time},
   booktitle = {Symposium on Computational Geometry},
-  year      = {2011},
-  pages     = {491-500},
-  ee        = {http://doi.acm.org/10.1145/1998196.1998276},
+  year      = {2006},
+  pages     = {119-126},
+  ee        = {http://doi.acm.org/10.1145/1137856.1137877},
   bibsource = {DBLP, http://dblp.uni-trier.de}
 }
 
-
-
-
-
-
-@article{Carlsson:2008:LBS:1325290.1325300,
- author = {Carlsson, Gunnar and Ishkhanov, Tigran and Silva, Vin and Zomorodian, Afra},
- title = {On the Local Behavior of Spaces of Natural Images},
- journal = {Int. J. Comput. Vision},
- volume = {76},
- issue = {1},
- month = {January},
- year = {2008},
- issn = {0920-5691},
- pages = {1--12},
- numpages = {12},
- url = {http://portal.acm.org/citation.cfm?id=1325290.1325300},
- doi = {10.1007/s11263-007-0056-x},
- acmid = {1325300},
- publisher = {Kluwer Academic Publishers},
- address = {Hingham, MA, USA},
- keywords = {Filtration, Klein bottle, Manifold, Natural images, Persistent homology, Topology},
-}
-
-article{DBLP:journals/ijcv/LeePM03,
-  author    = {Ann B. Lee and
-               Kim Steenstrup Pedersen and
-               David Mumford},
-  title     = {The Nonlinear Statistics of High-Contrast Patches in Natural
-               Images},
-  journal   = {International Journal of Computer Vision},
-  volume    = {54},
-  number    = {1-3},
-  year      = {2003},
-  pages     = {83-103},
-  ee        = {http://dx.doi.org/10.1023/A:1023705401078},
-  bibsource = {DBLP, http://dblp.uni-trier.de}
-}
-
-
-@article{martin2010top,
-title={Topology of cyclo-octane energy landscape.},
-author={Martin, S. and Thompson, A. and Coutsias, E.A. and Watson, J.},
-journal={J Chem Phys},
-volume={132},
-number={23},
-pages={234115},
-year={2010},
-abstract={Understanding energy landscapes is a major challenge in chemistry and biology. Although a wide variety of methods have been invented and applied to this problem, very little is understood about the actual mathematical structures underlying such landscapes. Perhaps the most general assumption is the idea that energy landscapes are low-dimensional manifolds embedded in high-dimensional Euclidean space. While this is a very mild assumption, we have discovered an example of an energy landscape which is nonmanifold, demonstrating previously unknown mathematical complexity. The example occurs in the energy landscape of cyclo-octane, which was found to have the structure of a reducible algebraic variety, composed of the union of a sphere and a Klein bottle, intersecting in two rings.}
-}
-
-
-book{hatcher2002algebraic,
-  title={Algebraic Topology},
-  author={Hatcher, A.},
-  isbn={9780521795401},
-  lccn={00065166},
-  url={http://books.google.fr/books?id=BjKs86kosqgC},
-  year={2002},
-  publisher={Cambridge University Press}
-}
-
-
-
-@article{DBLP:journals/cagd/DelfinadoE95,
-  author    = {Cecil Jose A. Delfinado and
-               Herbert Edelsbrunner},
-  title     = {An incremental algorithm for {B}etti numbers of simplicial
-               complexes on the 3-sphere},
-  journal   = {Computer Aided Geometric Design},
-  volume    = {12},
-  number    = {7},
-  year      = {1995},
-  pages     = {771-784},
-  ee        = {http://dx.doi.org/10.1016/0167-8396(95)00016-Y},
-  bibsource = {DBLP, http://dblp.uni-trier.de}
-}
-
-
-@book{Cormen:2001:IA:580470,
- author = {Cormen, Thomas H. and Stein, Clifford and Rivest, Ronald L. and Leiserson, Charles E.},
- title = {Introduction to Algorithms},
- year = {2001},
- isbn = {0070131511},
- edition = {2nd},
- publisher = {McGraw-Hill Higher Education},
-}
-
-@article{DBLP:journals/focm/CarlssonS10,
+@inproceedings{DBLP:conf/compgeom/CarlssonSM09,
   author    = {Gunnar E. Carlsson and
-               Vin de Silva},
-  title     = {Zigzag Persistence},
-  journal   = {Foundations of Computational Mathematics},
-  volume    = {10},
-  number    = {4},
-  year      = {2010},
-  pages     = {367-405},
-  doi       = {10.1007/s10208-010-9066-0},
-  ee        = {http://dx.doi.org/10.1007/s10208-010-9066-0},
+               Vin de Silva and
+               Dmitriy Morozov},
+  title     = {Zigzag persistent homology and real-valued functions},
+  booktitle = {Symposium on Computational Geometry},
+  year      = {2009},
+  pages     = {247-256},
+  ee        = {http://doi.acm.org/10.1145/1542362.1542408},
   bibsource = {DBLP, http://dblp.uni-trier.de}
 }
-
-@article{ghrist_coverage,
-  author    = {V. de Silva and R. Ghrist},
-  title     = {Coverage in sensor network via persistent homology},
-  journal   = {Algebraic {\&} Geometric Topology},
-  volume    = {7},
-  year      = {2007},
-  pages     = {339-358},
-}
-@article{mischaikow_nanda_morse,
-year={2013},
-issn={0179-5376},
-journal={Discrete {\&} Computational Geometry},
-volume={50},
-number={2},
-doi={10.1007/s00454-013-9529-6},
-title={Morse Theory for Filtrations and Efficient Computation of Persistent Homology},
-url={http://dx.doi.org/10.1007/s00454-013-9529-6},
-publisher={Springer US},
-keywords={Computational topology; Discrete Morse theory; Persistent homology},
-author={Mischaikow, Konstantin and Nanda, Vidit},
-pages={330-353},
-language={English}
-}
-
 
 @inproceedings{DBLP:conf/compgeom/MilosavljevicMS11,
   author    = {Nikola Milosavljevic and
@@ -883,537 +1313,10 @@ language={English}
   ee        = {http://doi.acm.org/10.1145/1998196.1998229},
   bibsource = {DBLP, http://dblp.uni-trier.de}
 }
-proceedings{DBLP:conf/compgeom/2011,
-  editor    = {Ferran Hurtado and
-               Marc J. van Kreveld},
-  title     = {Proceedings of the 27th ACM Symposium on Computational Geometry,
-               Paris, France, June 13-15, 2011},
-  booktitle = {Symposium on Computational Geometry},
-  publisher = {ACM},
-  year      = {2011},
-  isbn      = {978-1-4503-0682-9},
-  bibsource = {DBLP, http://dblp.uni-trier.de}
-}
-
-@article{DBLP:journals/comgeo/ChenK13,
-  author    = {Chao Chen and
-               Michael Kerber},
-  title     = {An output-sensitive algorithm for persistent homology},
-  journal   = {Comput. Geom.},
-  volume    = {46},
-  number    = {4},
-  year      = {2013},
-  pages     = {435-447},
-  ee        = {http://dx.doi.org/10.1016/j.comgeo.2012.02.010},
-  bibsource = {DBLP, http://dblp.uni-trier.de}
-}
 
 
-@incollection{Bauer:arXiv1303.0477,
-year={2014},
-isbn={978-3-319-04098-1},
-booktitle={Topological Methods in Data Analysis and Visualization III},
-doi={10.1007/978-3-319-04099-8_7},
-title={Clear and Compress: Computing Persistent Homology in Chunks},
-url={http://dx.doi.org/10.1007/978-3-319-04099-8_7},
-author={Bauer, Ulrich and Kerber, Michael and Reininghaus, Jan},
-pages={103-117},
-language={English}
-}
-@inproceedings{DBLP:conf/alenex/BauerKR14,
-  author    = {Ulrich Bauer and
-               Michael Kerber and
-               Jan Reininghaus},
-  title     = {Distributed Computation of Persistent Homology},
-  booktitle = {ALENEX},
-  year      = {2014},
-  pages     = {31-38},
-  ee        = {http://dx.doi.org/10.1137/1.9781611973198.4},
-  bibsource = {DBLP, http://dblp.uni-trier.de}
-}
-@inproceedings{DBLP:conf/compgeom/DeyFW14,
-  author    = {Tamal K. Dey and
-               Fengtao Fan and
-               Yusu Wang},
-  title     = {Computing Topological Persistence for Simplicial Maps},
-  booktitle = {Symposium on Computational Geometry},
-  year      = {2014},
-  pages     = {345},
-  doi       = {10.1145/2582112.2582165},
-  ee        = {http://doi.acm.org/10.1145/2582112.2582165},
-  bibsource = {DBLP, http://dblp.uni-trier.de}
-}
-
-@INPROCEEDINGS{Chen11persistenthomology,
-    author = {Chao Chen and Michael Kerber},
-    title = {Persistent homology computation with a twist},
-    booktitle = {Proceedings 27th European Workshop on Computational Geometry},
-    year = {2011}
-}
 
 
-@ARTICLE{Morozov05persistencealgorithm,
-    author = {Dmitriy Morozov},
-    title = {Persistence algorithm takes cubic time in worst case},
-    journal = {BioGeometry News, Dept. Comput. Sci., Duke Univ},
-    year = {2005}
-}
-
-@article{DBLP:journals/corr/abs-1205-3669,
-  author    = {Peter Bubenik and
-               Jonathan A. Scott},
-  title     = {Categorification of persistent homology},
-  journal   = {CoRR},
-  volume    = {abs/1205.3669},
-  year      = {2012},
-  ee        = {http://arxiv.org/abs/1205.3669},
-  bibsource = {DBLP, http://dblp.uni-trier.de}
-}
-
-misc{buddha_stanford_scan,
- author = "",
-   title = "The Stanford 3D Scanning Repository",
-    note  = "http://graphics.stanford.edu/data/3Dscanrep/"
-}
-@misc{dionysus_morozov,
- author = "Dmitriy Morozov",
-   title = "\textsc{Dionysus}",
-    note  = "http://www.mrzv.org/software/dionysus/"
-}
-
-@misc{phat_lib,
-author={Bauer, Ulrich and Kerber, Michael and Reininghaus, Jan},
-   title = "\textsc{Phat}",
-    note  = "https://code.google.com/p/phat/"
-}
-
-misc{ann_mount,
-author = "David M. Mount
-and Sunil Arya",
-    title = "\textsc{ANN}, {A}pproximate {N}earest {N}eighbors {L}ibrary",
-    note  = "http://www.cs.sunysb.edu/~algorith/implement/ANN/implement.shtml"
-}
-
-misc{jplex_cite,
-  author    = "Sexton, Harlan and Johansson, Mikael Vejdemo",
-  title     = "\textsc{JPlex}",
-  year      = "2009",
-  note = "http://comptop.stanford.edu/programs/jplex/"
-}
-
-@book{kaczynski2004computational,
-  title={Computational Homology},
-  author={Kaczynski, T. and Mischaikow, K. and Mrozek, M.},
-  isbn={9780387408538},
-  lccn={03061109},
-  series={Applied Mathematical Sciences},
-  url={https://books.google.fr/books?id=AShKtpi3GecC},
-  year={2004},
-  publisher={Springer New York}
-}
-
-@inbook{peikert2012topological,
-year={2012},
-isbn={978-3-642-23174-2},
-booktitle={Topological Methods in Data Analysis and Visualization II},
-series={Mathematics and Visualization},
-editor={Peikert, Ronald and Hauser, Helwig and Carr, Hamish and Fuchs, Raphael},
-doi={10.1007/978-3-642-23175-9_7},
-title={Efficient Computation of Persistent Homology for Cubical Data},
-url={http://dx.doi.org/10.1007/978-3-642-23175-9_7},
-publisher={Springer Berlin Heidelberg},
-author={Wagner, Hubert and Chen, Chao and Vucini, Erald},
-pages={91-106},
-language={English}
-}
-
-@article{de2004topological,
-  title={Topological estimation using witness complexes},
-  author={De Silva, Vin and Carlsson, Gunnar},
-  journal={Proc. Sympos. Point-Based Graphics},
-  pages={157-166},
-  year={2004}
-}
-
-@ARTICLE{bubenik_landscapes_2015,
-    author = {P. Bubenik},
-    title = {Statistical topological data analysis using persistence landscapes.},
-    journal = {Journal of Machine Learning Research},
-    year = {2015}
-}
-
-@ARTICLE{bubenik_dlotko_landscapes_2016,
-    author = {P. Bubenik and P. Dlotko},
-    title = {A persistence landscapes toolbox for topological statistics.},
-    journal = {Journal of Symbolic Computation.},
-    year = {2016}
-}
-
-@ARTICLE{Fasy_Kim_Lecci_Maria_tda,
-    author = {B. Fasy and J. Kim and F. Lecci and C. Maria},
-    title = {Introduction to the R package TDA.},
-    journal = {arXiv:1411.1830.},
-    year = {2016}
-}
 
 
-@ARTICLE{Ferri_Frosini_comparision_sheme_1,
-    author = {P. Donatini and P. Frosini and A. Lovato},
-    title = {Size functions for signature recognition.},
-    journal = {Proceedings of SPIE, Vision Geometry VII, vol. 3454},
-    year = {1998}
-}
 
-
-@ARTICLE{Ferri_Frosini_comparision_sheme_2,
-    author = {M. Ferri and P. Frosini and A. Lovato and C. Zambelli},
-    title = {Point selection: A new comparison scheme for size functions (With an application to monogram recognition).},
-    journal = {Proceedings Third Asian Conference on Computer Vision, Lecture Notes in Computer Science 1351.},
-    year = {1998}
-}
-
-@ARTICLE{Persistence_Images_2017,
-    author = {H. Adams and S. Chepushtanova and T. Emerson and E. Hanson and M. Kirby and F. Motta and R. Neville and C. Peterson and P. Shipman and L. Ziegelmeier},
-    title = {Persistence Images: A Stable Vector Representation of Persistent Homology.},
-    journal = {Journal of Machine Learning Research},
-    year = {2017}
-}
-
-
-@ARTICLE{Kusano_Fukumizu_Hiraoka_PWGK,
-    author = {G. Kusano and K. Fukumizu and Y. Hiraoka},
-    title = {Persistence weighted Gaussian kernel for topological data analysis.},
-    journal = {ICML'16 Proceedings of the 33rd International Conference on International Conference on Machine Learning - Volume 48},
-    year = {2016}
-}
-
-@ARTICLE{Reininghaus_Huber_ALL_PSSK,
-    author = {J. Reininghaus and S. Huber and U. Bauer and R. Kwitt},
-    title = {A Stable Multi-Scale Kernel for Topological Machine Learning.},
-    journal = {Proc. 2015 IEEE Conf. Comp. Vision \& Pat. Rec. (CVPR '15)},
-    year = {2015}
-}
-
-@ARTICLE{Carriere_Oudot_Ovsjanikov_top_signatures_3d,
-    author = {M. Carri\`ere and S. Oudot and M. Ovsjanikov},
-    title = {Stable Topological Signatures for Points on 3D Shapes.},
-    journal = {Proc. Sympos. on Geometry Processing},
-    year = {2015}
-}
-
-@article{buchet16efficient,
-  title = {Efficient and Robust Persistent Homology for Measures},
-  author = {Micka\"{e}l Buchet and Fr\'{e}d\'{e}ric Chazal and Steve Y. Oudot and Donald Sheehy},
-  journal = {Computational Geometry: Theory and Applications},
-  volume = {58},
-  pages = {70--96},
-  doi = "10.1016/j.comgeo.2016.07.001",
-  year = {2016}
-}
-
-@inproceedings{cavanna15geometric,
-  author = {Nicholas J. Cavanna and Mahmoodreza Jahanseir and Donald R. Sheehy},
-  booktitle = {Proceedings of the Canadian Conference on Computational Geometry},
-  title = {A Geometric Perspective on Sparse Filtrations},
-  url = {https://arxiv.org/abs/1506.03797},
-  year = {2015}
-}
-
-@inproceedings{cavanna15visualizing,
-  author = {Nicholas J. Cavanna and Mahmoodreza Jahanseir and Donald R. Sheehy},
-  booktitle = {Proceedings of the 31st International Symposium on Computational Geometry},
-  title = {Visualizing Sparse Filtrations},
-  year = {2015},
-  doi = {10.4230/LIPIcs.SOCG.2015.23}
-}
-
-@article{sheehy13linear,
-  title = {Linear-Size Approximations to the {V}ietoris-{R}ips Filtration},
-  author = {Donald R. Sheehy},
-  journal = {Discrete \& Computational Geometry},
-  volume = {49},
-  number = {4},
-  pages = {778--796},
-  doi = "10.1007/s00454-013-9513-1",
-  year = {2013}
-}
-
-@InProceedings{boissonnat_et_al:LIPIcs:2015:5098,
-  author =	{Jean-Daniel Boissonnat and Karthik C. S. and S{\'e}bastien Tavenas},
-  title =	{{Building Efficient and Compact Data Structures for Simplicial Complexes}},
-  booktitle =	{31st International Symposium on Computational Geometry (SoCG 2015)},
-  pages =	{642--656},
-  series =	{Leibniz International Proceedings in Informatics (LIPIcs)},
-  ISBN =	{978-3-939897-83-5},
-  ISSN =	{1868-8969},
-  year =	{2015},
-  volume =	{34},
-  editor =	{Lars Arge and J{\'a}nos Pach},
-  publisher =	{Schloss Dagstuhl--Leibniz-Zentrum fuer Informatik},
-  address =	{Dagstuhl, Germany},
-  URL =		{https://drops.dagstuhl.de/opus/volltexte/2015/5098/},
-  URN =		{urn:nbn:de:0030-drops-50981},
-  doi =		{10.4230/LIPIcs.SOCG.2015.642},
-  annote =	{Keywords: Simplicial complex, Compact data structures, Automaton, NP-hard}
-}
-
-@article{DBLP:journals/corr/BoissonnatS16,
-  author    = {Jean{-}Daniel Boissonnat and
-               {Karthik {C. S.}}},
-  title     = {An Efficient Representation for Filtrations of Simplicial Complexes},
-  journal   = {CoRR},
-  volume    = {abs/1607.08449},
-  year      = {2016},
-  url       = {https://arxiv.org/abs/1607.08449},
-  archivePrefix = {arXiv},
-  eprint    = {1607.08449},
-  timestamp = {Mon, 13 Aug 2018 16:46:26 +0200},
-  biburl    = {https://dblp.org/rec/bib/journals/corr/BoissonnatS16},
-  bibsource = {dblp computer science bibliography, https://dblp.org}
-}
-
-@article{Kerber:2017:GHC:3047249.3064175,
- author = {Kerber, Michael and Morozov, Dmitriy and Nigmetov, Arnur},
- title = {Geometry Helps to Compare Persistence Diagrams},
- journal = {J. Exp. Algorithmics},
- issue_date = {2017},
- volume = {22},
- month = sep,
- year = {2017},
- issn = {1084-6654},
- pages = {1.4:1--1.4:20},
- articleno = {1.4},
- numpages = {20},
- url = {http://doi.acm.org/10.1145/3064175},
- doi = {10.1145/3064175},
- acmid = {3064175},
- publisher = {ACM},
- address = {New York, NY, USA},
- keywords = {Assignment problems, bipartite matching, k-d tree, persistent homology},
-}
-@InProceedings{pmlr-v70-carriere17a,
-  title = 	 {Sliced {W}asserstein Kernel for Persistence Diagrams},
-  author = 	 {Mathieu Carri{\`e}re and Marco Cuturi and Steve Oudot},
-  booktitle = 	 {Proceedings of the 34th International Conference on Machine Learning},
-  pages = 	 {664--673},
-  year = 	 {2017},
-  editor = 	 {Doina Precup and Yee Whye Teh},
-  volume = 	 {70},
-  series = 	 {Proceedings of Machine Learning Research},
-  address = 	 {International Convention Centre, Sydney, Australia},
-  month = 	 {06--11 Aug},
-  publisher = 	 {PMLR},
-}
-
-@INPROCEEDINGS{Rahimi07randomfeatures,
-    author = {Ali Rahimi and Ben Recht},
-    title = {Random features for large-scale kernel machines},
-    booktitle = {In Neural Information Processing Systems},
-    year = {2007}
-}
-@inproceedings{10.5555/3327546.3327645,
-author = {Lacombe, Th\'{e}o and Cuturi, Marco and Oudot, Steve},
-title = {Large Scale Computation of Means and Clusters for Persistence Diagrams Using Optimal Transport},
-year = {2018},
-publisher = {Curran Associates Inc.},
-address = {Red Hook, NY, USA},
-booktitle = {Proceedings of the 32nd International Conference on Neural Information Processing Systems},
-pages = {9792–9802},
-numpages = {11},
-location = {Montr\'{e}al, Canada},
-series = {NIPS’18}
-}
-@article{tomato,
-author = {Chazal, Fr\'{e}d\'{e}ric and Guibas, Leonidas J. and Oudot, Steve Y. and Skraba, Primoz},
-title = {Persistence-Based Clustering in Riemannian Manifolds},
-year = {2013},
-issue_date = {November 2013},
-publisher = {Association for Computing Machinery},
-address = {New York, NY, USA},
-volume = {60},
-number = {6},
-issn = {0004-5411},
-url = {https://doi.org/10.1145/2535927},
-doi = {10.1145/2535927},
-journal = {J. ACM},
-month = nov,
-articleno = {Article 41},
-numpages = {38},
-keywords = {mode seeking, Unsupervised learning, computational topology, clustering, Morse theory, topological persistence}
-}
-@Article{dtm,
-author={Chazal, Fr{\'e}d{\'e}ric
-and Cohen-Steiner, David
-and M{\'e}rigot, Quentin},
-title={Geometric Inference for Probability Measures},
-journal={Foundations of Computational Mathematics},
-year={2011},
-volume={11},
-number={6},
-pages={733-751},
-abstract={Data often comes in the form of a point cloud sampled from an unknown compact subset of Euclidean space. The general goal of geometric inference is then to recover geometric and topological features (e.g., Betti numbers, normals) of this subset from the approximating point cloud data. It appears that the study of distance functions allows one to address many of these questions successfully. However, one of the main limitations of this framework is that it does not cope well with outliers or with background noise. In this paper, we show how to extend the framework of distance functions to overcome this problem. Replacing compact subsets by measures, we introduce a notion of distance function to a probability distribution in Rd. These functions share many properties with classical distance functions, which make them suitable for inference purposes. In particular, by considering appropriate level sets of these distance functions, we show that it is possible to reconstruct offsets of sampled shapes with topological guarantees even in the presence of outliers. Moreover, in settings where empirical measures are considered, these functions can be easily evaluated, making them of particular practical interest.},
-issn={1615-3383},
-doi={10.1007/s10208-011-9098-0},
-url={https://doi.org/10.1007/s10208-011-9098-0}
-}
-@article{dtmdensity,
-author = "Biau, Gérard and Chazal, Frédéric and Cohen-Steiner, David and Devroye, Luc and Rodríguez, Carlos",
-doi = "10.1214/11-EJS606",
-fjournal = "Electronic Journal of Statistics",
-journal = "Electron. J. Statist.",
-pages = "204--237",
-publisher = "The Institute of Mathematical Statistics and the Bernoulli Society",
-title = "A weighted k-nearest neighbor density estimate for geometric inference",
-url = "https://doi.org/10.1214/11-EJS606",
-volume = "5",
-year = "2011"
-}
-@article{turner2014frechet,
-  title={Fr{\'e}chet means for distributions of persistence diagrams},
-  author={Turner, Katharine and Mileyko, Yuriy and Mukherjee, Sayan and Harer, John},
-  journal={Discrete \& Computational Geometry},
-  doi={10.1007/s00454-014-9604-7},
-  volume={52},
-  number={1},
-  pages={44--70},
-  year={2014},
-  publisher={Springer}
-}
-
-@inproceedings{dtmfiltrationsconf,
-  author    = {Hirokazu Anai and
-               Fr{\'{e}}d{\'{e}}ric Chazal and
-               Marc Glisse and
-               Yuichi Ike and
-               Hiroya Inakoshi and
-               Rapha{\"{e}}l Tinarrage and
-               Yuhei Umeda},
-  editor    = {Gill Barequet and
-               Yusu Wang},
-  title     = {DTM-Based Filtrations},
-  booktitle = {35th International Symposium on Computational Geometry, SoCG 2019,
-               June 18-21, 2019, Portland, Oregon, {USA}},
-  series    = {LIPIcs},
-  volume    = {129},
-  pages     = {58:1--58:15},
-  publisher = {Schloss Dagstuhl - Leibniz-Zentrum f{\"{u}}r Informatik},
-  year      = {2019},
-  url       = {https://doi.org/10.4230/LIPIcs.SoCG.2019.58},
-  doi       = {10.4230/LIPIcs.SoCG.2019.58},
-  timestamp = {Tue, 11 Feb 2020 15:52:14 +0100},
-  biburl    = {https://dblp.org/rec/conf/compgeom/AnaiCGIITU19.bib},
-  bibsource = {dblp computer science bibliography, https://dblp.org}
-}
-
-@InProceedings{dtmfiltrations,
-author="Anai, Hirokazu
-and Chazal, Fr{\'e}d{\'e}ric
-and Glisse, Marc
-and Ike, Yuichi
-and Inakoshi, Hiroya
-and Tinarrage, Rapha{\"e}l
-and Umeda, Yuhei",
-editor="Baas, Nils A.
-and Carlsson, Gunnar E.
-and Quick, Gereon
-and Szymik, Markus
-and Thaule, Marius",
-title="DTM-Based Filtrations",
-booktitle="Topological Data Analysis",
-year="2020",
-publisher="Springer International Publishing",
-address="Cham",
-pages="33--66",
-isbn="978-3-030-43408-3",
-doi="10.1007/978-3-030-43408-3_2",
-}
-
-@InProceedings{edgecollapsesocg2020,
-  author =	{Jean-Daniel Boissonnat and Siddharth Pritam},
-  title =	{{Edge Collapse and Persistence of Flag Complexes}},
-  booktitle =	{36th International Symposium on Computational Geometry (SoCG 2020)},
-  pages =	{19:1--19:15},
-  series =	{Leibniz International Proceedings in Informatics (LIPIcs)},
-  ISBN =	{978-3-95977-143-6},
-  ISSN =	{1868-8969},
-  year =	{2020},
-  volume =	{164},
-  editor =	{Sergio Cabello and Danny Z. Chen},
-  publisher =	{Schloss Dagstuhl--Leibniz-Zentrum f{\"u}r Informatik},
-  address =	{Dagstuhl, Germany},
-  URL =		{https://drops.dagstuhl.de/opus/volltexte/2020/12177/},
-  URN =		{urn:nbn:de:0030-drops-121777},
-  doi =		{10.4230/LIPIcs.SoCG.2020.19},
-  annote =	{Keywords: Computational Topology, Topological Data Analysis, Edge Collapse, Simple Collapse, Persistent homology}
-}
-
-@misc{edgecollapsearxiv,
-  author = {Marc Glisse and Siddharth Pritam},
-  title = {{Swap, Shift and Trim to Edge Collapse a Filtration}},
-  url = {https://arxiv.org/abs/2203.07022},
-}
-
-@phdthesis{KachanovichThesis,
-  TITLE = {{Meshing submanifolds using Coxeter triangulations}},
-  AUTHOR = {Kachanovich, Siargey},
-  URL = {https://hal.inria.fr/tel-02419148},
-  NUMBER = {2019AZUR4072},
-  SCHOOL = {{COMUE Universit{\'e} C{\^o}te d'Azur (2015 - 2019)}},
-  YEAR = {2019},
-  MONTH = Oct,
-  KEYWORDS = {Mesh generation ; Coxeter triangulations ; Simplex quality ; Triangulations of the Euclidean space ; Freudenthal-Kuhn triangulations ; G{\'e}n{\'e}ration de maillages ; Triangulations de Coxeter ; Qualit{\'e} des simplexes ; Triangulations de l'espace euclidien ; Triangulations de Freudenthal-Kuhn},
-  TYPE = {Theses},
-  PDF = {https://hal.inria.fr/tel-02419148v2/file/2019AZUR4072.pdf},
-  HAL_ID = {tel-02419148},
-  HAL_VERSION = {v2},
-}
-
-@inproceedings{sheehy20onehop,
-  title = {One Hop Greedy Permutations},
-  author = {Donald R. Sheehy},
-  booktitle = {Proceedings of the 32nd Canadian Conference on Computational Geometry},
-  pages = {221--225},
-  year = {2020},
-  url = {https://par.nsf.gov/biblio/10211951}
-}
-
-@misc{arxivpers1d,
-  doi = {10.48550/ARXIV.2301.04745},
-  url = {https://arxiv.org/abs/2301.04745},
-  author = {Glisse, Marc},
-  keywords = {Computational Geometry (cs.CG), Algebraic Topology (math.AT), FOS: Computer and information sciences, FOS: Computer and information sciences, FOS: Mathematics, FOS: Mathematics},
-  title = {Fast persistent homology computation for functions on $\mathbb{R}$},
-  publisher = {arXiv},
-  year = {2023},
-  copyright = {arXiv.org perpetual, non-exclusive license}
-}
-
-@misc{icml2014,
-  doi = {10.48550/ARXIV.1406.1901},
-  url = {https://arxiv.org/abs/1406.1901},
-  author = {Chazal, Frédéric and Fasy, Brittany Terese and Lecci, Fabrizio and Michel, Bertrand and Rinaldo, Alessandro and Wasserman, Larry},
-  keywords = {Algebraic Topology (math.AT), Computational Geometry (cs.CG), Applications (stat.AP), FOS: Mathematics, FOS: Mathematics, FOS: Computer and information sciences, FOS: Computer and information sciences},
-  title = {Subsampling Methods for Persistent Homology},
-  publisher = {arXiv},
-  year = {2014},
-  copyright = {arXiv.org perpetual, non-exclusive license}
-}
-
-@InProceedings{chubet_et_al:LIPIcs.SoCG.2023.64,
-  author =	{Chubet, Oliver A. and Macnichol, Paul and Parikh, Parth and Sheehy, Donald R. and Sheth, Siddharth S.},
-  title =	{{Greedy Permutations and Finite Voronoi Diagrams}},
-  booktitle =	{39th International Symposium on Computational Geometry (SoCG 2023)},
-  pages =	{64:1--64:5},
-  series =	{Leibniz International Proceedings in Informatics (LIPIcs)},
-  ISBN =	{978-3-95977-273-0},
-  ISSN =	{1868-8969},
-  year =	{2023},
-  volume =	{258},
-  editor =	{Chambers, Erin W. and Gudmundsson, Joachim},
-  publisher =	{Schloss Dagstuhl -- Leibniz-Zentrum f{\"u}r Informatik},
-  address =	{Dagstuhl, Germany},
-  URL =		{https://drops.dagstuhl.de/opus/volltexte/2023/17914},
-  URN =		{urn:nbn:de:0030-drops-179146},
-  doi =		{10.4230/LIPIcs.SoCG.2023.64},
-  annote =	{Keywords: greedy permutation, Voronoi diagrams}
-}

--- a/biblio/bibliography.bib
+++ b/biblio/bibliography.bib
@@ -316,7 +316,7 @@
 % G
 %-----------------------------
 
-@article{dtm,
+@article{dtmgeoinference2011,
   author   = {Chazal, Fr{\'e}d{\'e}ric
               and Cohen-Steiner, David
               and M{\'e}rigot, Quentin},
@@ -503,7 +503,7 @@
 % P
 %-----------------------------
 
-@article{tomato,
+@article{tomato2013,
   author     = {Chazal, Fr\'{e}d\'{e}ric and Guibas, Leonidas J. and Oudot, Steve Y. and Skraba, Primoz},
   title      = {Persistence-Based Clustering in Riemannian Manifolds},
   year       = {2013},

--- a/src/python/doc/clustering.rst
+++ b/src/python/doc/clustering.rst
@@ -6,7 +6,7 @@
 Clustering manual
 =================
 
-We provide an implementation of ToMATo :cite:`tomato`, a persistence-based clustering algorithm. In short, this algorithm uses a density estimator and a neighborhood graph, starts with a mode-seeking phase (naive hill-climbing) to build initial clusters, and finishes by merging clusters based on their prominence.
+We provide an implementation of ToMATo :cite:`tomato2013`, a persistence-based clustering algorithm. In short, this algorithm uses a density estimator and a neighborhood graph, starts with a mode-seeking phase (naive hill-climbing) to build initial clusters, and finishes by merging clusters based on their prominence.
 
 The merging phase depends on a parameter, which is the minimum prominence a cluster needs to avoid getting merged into another, bigger cluster. This parameter determines the number of clusters, and for convenience we allow you to choose instead the number of clusters. Decreasing the prominence threshold defines a hierarchy of clusters: if 2 points are in separate clusters when we have k clusters, they are still in different clusters for k+1 clusters.
 

--- a/src/python/gudhi/point_cloud/dtm.py
+++ b/src/python/gudhi/point_cloud/dtm.py
@@ -17,7 +17,8 @@ __license__ = "MIT"
 
 class DistanceToMeasure:
     """
-    Class to compute the distance to the empirical measure defined by a point set, as introduced in :cite:`dtm`.
+    Class to compute the distance to the empirical measure defined by a point set, 
+    as introduced in :cite:`dtmgeoinference2011`.
     """
 
     def __init__(self, k, q=2, **kwargs):


### PR DESCRIPTION
Clean up of the bibliography.bib file:
 - re-alignement of the citations
 - alphabetical sort by titles + all unused citations at the end of the file (also by alphabetical order)
 - removal of doubles
 - removal of unnecessary/incomplete citations when they were not used
 - addition of an url for used citations when there was none (except for one I couldn't find)

I thought also about homogenizing the authors names and titles, but I don't know if it is worth it when future citations will probably do whatever they want again...