### PR TITLE
Update 'uses:' actions versions

### DIFF
--- a/.github/workflows/pip-build-linux.yml
+++ b/.github/workflows/pip-build-linux.yml
@@ -31,7 +31,8 @@ jobs:
           $PYTHON38/bin/python -m pytest -v src/python/test/test_cubical_complex.py
           $PYTHON38/bin/python -m pytest -v src/python/test/test_rips_complex.py
       - name: Upload linux python wheel
-        uses: actions/upload-artifact@v4
+        # Should use actions/upload-artifact@v4, but requires node20, not available for quay.io/pypa/manylinux2014_x86_64
+        uses: actions/upload-artifact@v3
         with:
           name: linux python wheel
           path: build_38/src/python/wheelhouse/*.whl

--- a/.github/workflows/pip-build-linux.yml
+++ b/.github/workflows/pip-build-linux.yml
@@ -9,7 +9,7 @@ jobs:
     # cf. https://github.com/GUDHI/gudhi-deploy/blob/main/Dockerfile_for_pip
     container: gudhi/pip_for_gudhi:2023.12.01
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true
       - name: Build wheel for Python 3.8
@@ -30,7 +30,7 @@ jobs:
           $PYTHON38/bin/python -m pytest -v src/python/test/test_cubical_complex.py
           $PYTHON38/bin/python -m pytest -v src/python/test/test_rips_complex.py
       - name: Upload linux python wheel
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: linux python wheel
           path: build_38/src/python/wheelhouse/*.whl

--- a/.github/workflows/pip-build-linux.yml
+++ b/.github/workflows/pip-build-linux.yml
@@ -9,7 +9,8 @@ jobs:
     # cf. https://github.com/GUDHI/gudhi-deploy/blob/main/Dockerfile_for_pip
     container: gudhi/pip_for_gudhi:2023.12.01
     steps:
-      - uses: actions/checkout@v4
+      # Should use actions/checkout@v4, but requires node20, not available for quay.io/pypa/manylinux2014_x86_64
+      - uses: actions/checkout@v3
         with:
           submodules: true
       - name: Build wheel for Python 3.8

--- a/.github/workflows/pip-build-osx.yml
+++ b/.github/workflows/pip-build-osx.yml
@@ -21,10 +21,10 @@ jobs:
             numpy-version: '1.21.4'
     name: Build wheels for Python ${{ matrix.python-version }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           architecture: x64
@@ -60,7 +60,7 @@ jobs:
           python -m pytest -v src/python/test/test_cubical_complex.py
           python -m pytest -v src/python/test/test_rips_complex.py
       - name: Upload OSx python wheel
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: osx python wheel
           path: build/src/python/dist/*.whl

--- a/.github/workflows/pip-build-windows.yml
+++ b/.github/workflows/pip-build-windows.yml
@@ -14,10 +14,10 @@ jobs:
             numpy-version: '1.21.4'
     name: Build wheels for Python ${{ matrix.python-version }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           architecture: x64
@@ -53,7 +53,7 @@ jobs:
           python -m pytest -v ".\src\python\test\test_cubical_complex.py"
           python -m pytest -v ".\src\python\test\test_rips_complex.py"
       - name: Upload Windows python wheel
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: windows python wheel
           path: build/src/python/dist/*.whl

--- a/.github/workflows/pip-packaging-linux.yml
+++ b/.github/workflows/pip-packaging-linux.yml
@@ -11,7 +11,8 @@ jobs:
     # cf. https://github.com/GUDHI/gudhi-deploy/blob/main/Dockerfile_for_pip
     container: gudhi/pip_for_gudhi:2023.12.01
     steps:
-      - uses: actions/checkout@v4
+      # Should use actions/checkout@v4, but requires node20, not available for quay.io/pypa/manylinux2014_x86_64
+      - uses: actions/checkout@v3
         with:
           submodules: true
       - name: Build wheel for Python 3.8

--- a/.github/workflows/pip-packaging-linux.yml
+++ b/.github/workflows/pip-packaging-linux.yml
@@ -11,7 +11,7 @@ jobs:
     # cf. https://github.com/GUDHI/gudhi-deploy/blob/main/Dockerfile_for_pip
     container: gudhi/pip_for_gudhi:2023.12.01
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true
       - name: Build wheel for Python 3.8

--- a/.github/workflows/pip-packaging-osx.yml
+++ b/.github/workflows/pip-packaging-osx.yml
@@ -33,10 +33,10 @@ jobs:
             numpy-version: '1.26.0'
     name: Build wheels for Python ${{ matrix.python-version }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           architecture: x64

--- a/.github/workflows/pip-packaging-windows.yml
+++ b/.github/workflows/pip-packaging-windows.yml
@@ -26,10 +26,10 @@ jobs:
             numpy-version: '1.26.0'
     name: Build wheels for Python ${{ matrix.python-version }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           architecture: x64


### PR DESCRIPTION
Fix warnings in github actions logs:
* uses: actions/checkout@v3 -> v4
* uses: actions/upload-artifact@v3 -> v4
* uses: actions/setup-python@v4 -> v5

Except for linux, where actions/checkout@v4 and actions/upload-artifact@v4 require node20, which is not available for quay.io/pypa/manylinux2014_x86_64