### PR TITLE
Use TDS_full_cell_mirror_storage_policy for static dimension as benchmark shows with CGAL 6.0

### DIFF
--- a/src/Alpha_complex/include/gudhi/Alpha_complex.h
+++ b/src/Alpha_complex/include/gudhi/Alpha_complex.h
@@ -113,7 +113,7 @@ class Alpha_complex {
   /** \brief Geometric traits class that provides the geometric types and predicates needed by the triangulations.*/
   using Geom_traits = std::conditional_t<Weighted, CGAL::Regular_triangulation_traits_adapter<Kernel>, Kernel>;
 
-  // CGAL::Triangulation_ds_full_cell<void, CGAL::TDS_full_cell_mirror_storage_policy> has been enhanced for CGAL > 6.0
+  // CGAL::Triangulation_ds_full_cell<void, CGAL::TDS_full_cell_mirror_storage_policy> has been enhanced for CGAL >= 6.0
   // But faster only with static dimensions
   using Triangulation_full_cell = std::conditional_t<Is_Dynamic_dimension_tag<Kernel>::value,
                                                      CGAL::Triangulation_full_cell<Geom_traits>,

--- a/src/Alpha_complex/include/gudhi/Alpha_complex.h
+++ b/src/Alpha_complex/include/gudhi/Alpha_complex.h
@@ -45,6 +45,7 @@
 #include <stdexcept>
 #include <numeric>  // for std::iota
 #include <algorithm>  // for std::sort
+#include <type_traits>  // for std::is_same_v
 
 // Make compilation fail - required for external projects - https://github.com/GUDHI/gudhi-devel/issues/10
 #if CGAL_VERSION_NR < 1041101000
@@ -61,10 +62,6 @@ namespace alpha_complex {
 
 template<typename D> struct Is_Epeck_D { static const bool value = false; };
 template<typename D> struct Is_Epeck_D<CGAL::Epeck_d<D>> { static const bool value = true; };
-
-template<typename D> struct Is_Dynamic_dimension_tag { static const bool value = false; };
-template<> struct Is_Dynamic_dimension_tag<CGAL::Epeck_d<CGAL::Dynamic_dimension_tag>> { static const bool value = true; };
-template<> struct Is_Dynamic_dimension_tag<CGAL::Epick_d<CGAL::Dynamic_dimension_tag>> { static const bool value = true; };
 
 /**
  * \class Alpha_complex Alpha_complex.h gudhi/Alpha_complex.h
@@ -115,7 +112,7 @@ class Alpha_complex {
 
   // CGAL::Triangulation_ds_full_cell<void, CGAL::TDS_full_cell_mirror_storage_policy> has been enhanced for CGAL >= 6.0
   // But faster only with static dimensions
-  using Triangulation_full_cell = std::conditional_t<Is_Dynamic_dimension_tag<Kernel>::value,
+  using Triangulation_full_cell = std::conditional_t<std::is_same_v<typename Kernel::Dimension, CGAL::Dynamic_dimension_tag>,
                                                      CGAL::Triangulation_full_cell<Geom_traits>,
                                                      CGAL::Triangulation_ds_full_cell<void, CGAL::TDS_full_cell_mirror_storage_policy>>;
   // Add an int in TDS to save point index in the structure

--- a/src/Alpha_complex/include/gudhi/Alpha_complex.h
+++ b/src/Alpha_complex/include/gudhi/Alpha_complex.h
@@ -113,7 +113,7 @@ class Alpha_complex {
   // CGAL::Triangulation_ds_full_cell<void, CGAL::TDS_full_cell_mirror_storage_policy> has been enhanced for CGAL >= 6.0
   // But faster only with static dimensions
   using Triangulation_full_cell = std::conditional_t<std::is_same_v<typename Kernel::Dimension, CGAL::Dynamic_dimension_tag>,
-                                                     CGAL::Triangulation_full_cell<Geom_traits>,
+                                                     CGAL::Triangulation_ds_full_cell<>,
                                                      CGAL::Triangulation_ds_full_cell<void, CGAL::TDS_full_cell_mirror_storage_policy>>;
   // Add an int in TDS to save point index in the structure
   using TDS = CGAL::Triangulation_data_structure<typename Geom_traits::Dimension,

--- a/src/Alpha_complex/include/gudhi/Alpha_complex.h
+++ b/src/Alpha_complex/include/gudhi/Alpha_complex.h
@@ -62,6 +62,10 @@ namespace alpha_complex {
 template<typename D> struct Is_Epeck_D { static const bool value = false; };
 template<typename D> struct Is_Epeck_D<CGAL::Epeck_d<D>> { static const bool value = true; };
 
+template<typename D> struct Is_Dynamic_dimension_tag { static const bool value = false; };
+template<> struct Is_Dynamic_dimension_tag<CGAL::Epeck_d<CGAL::Dynamic_dimension_tag>> { static const bool value = true; };
+template<> struct Is_Dynamic_dimension_tag<CGAL::Epick_d<CGAL::Dynamic_dimension_tag>> { static const bool value = true; };
+
 /**
  * \class Alpha_complex Alpha_complex.h gudhi/Alpha_complex.h
  * \brief Alpha complex data structure.
@@ -109,10 +113,15 @@ class Alpha_complex {
   /** \brief Geometric traits class that provides the geometric types and predicates needed by the triangulations.*/
   using Geom_traits = std::conditional_t<Weighted, CGAL::Regular_triangulation_traits_adapter<Kernel>, Kernel>;
 
+  // CGAL::Triangulation_ds_full_cell<void, CGAL::TDS_full_cell_mirror_storage_policy> has been enhanced for CGAL > 6.0
+  // But faster only with static dimensions
+  using Triangulation_full_cell = std::conditional_t<Is_Dynamic_dimension_tag<Kernel>::value,
+                                                     CGAL::Triangulation_full_cell<Geom_traits>,
+                                                     CGAL::Triangulation_ds_full_cell<void, CGAL::TDS_full_cell_mirror_storage_policy>>;
   // Add an int in TDS to save point index in the structure
   using TDS = CGAL::Triangulation_data_structure<typename Geom_traits::Dimension,
                                                  CGAL::Triangulation_vertex<Geom_traits, Internal_vertex_handle>,
-                                                 CGAL::Triangulation_full_cell<Geom_traits> >;
+                                                 Triangulation_full_cell >;
 
   /** \brief A (Weighted or not) Delaunay triangulation of a set of points in \f$ \mathbb{R}^D\f$.*/
   using Triangulation = std::conditional_t<Weighted, CGAL::Regular_triangulation<Kernel, TDS>,


### PR DESCRIPTION
Tested with #1049 on a temporary branch.

The benchmark (the one that is already in Alpha_complex and using `benchmark_points_on_torus_dD`) results:

```txt
// CGAL master - 6.0                                                  // CGAL master - 6.0 + CGAL::TDS_full_cell_mirror_storage_policy
+ Epick_d static dimension version                                    + Epick_d static dimension version
  Alpha complex dD on torus with 25000 points.                          Alpha complex dD on torus with 25000 points.
    benchmark_points_on_torus_dD - Alpha complex 3d creation: 0.343s      benchmark_points_on_torus_dD - Alpha complex 3d creation: 0.306s
    benchmark_points_on_torus_dD - complex creation: 0.291s               benchmark_points_on_torus_dD - complex creation: 0.299s
    benchmark_points_on_torus_dD - nb simplices = 1546293                 benchmark_points_on_torus_dD - nb simplices = 1551895
  Alpha complex dD on torus with 125000 points.                         Alpha complex dD on torus with 125000 points.
    benchmark_points_on_torus_dD - Alpha complex 3d creation: 2.207s      benchmark_points_on_torus_dD - Alpha complex 3d creation: 1.96s
    benchmark_points_on_torus_dD - complex creation: 2.393s               benchmark_points_on_torus_dD - complex creation: 2.47s
    benchmark_points_on_torus_dD - nb simplices = 9049571                 benchmark_points_on_torus_dD - nb simplices = 9041611
+ Epick_d dynamic dimension version                                   + Epick_d dynamic dimension version
  Alpha complex dD on torus with 25000 points.                          Alpha complex dD on torus with 25000 points.
    benchmark_points_on_torus_dD - Alpha complex 3d creation: 0.836s      benchmark_points_on_torus_dD - Alpha complex 3d creation: 0.822s
    benchmark_points_on_torus_dD - complex creation: 0.303s               benchmark_points_on_torus_dD - complex creation: 0.296s
    benchmark_points_on_torus_dD - nb simplices = 1550711                 benchmark_points_on_torus_dD - nb simplices = 1549971
  Alpha complex dD on torus with 125000 points.                         Alpha complex dD on torus with 125000 points.
    benchmark_points_on_torus_dD - Alpha complex 3d creation: 6.092s      benchmark_points_on_torus_dD - Alpha complex 3d creation: 6.091s
    benchmark_points_on_torus_dD - complex creation: 2.551s               benchmark_points_on_torus_dD - complex creation: 2.597s
    benchmark_points_on_torus_dD - nb simplices = 9057759                 benchmark_points_on_torus_dD - nb simplices = 9062213
+ Epeck_d static dimension version                                    + Epeck_d static dimension version
  Alpha complex dD on torus with 25000 points.                          Alpha complex dD on torus with 25000 points.
    benchmark_points_on_torus_dD - Alpha complex 3d creation: 0.451s      benchmark_points_on_torus_dD - Alpha complex 3d creation: 0.411s
    benchmark_points_on_torus_dD - complex creation: 0.275s               benchmark_points_on_torus_dD - complex creation: 0.28s
    benchmark_points_on_torus_dD - nb simplices = 1544141                 benchmark_points_on_torus_dD - nb simplices = 1555751
  Alpha complex dD on torus with 125000 points.                         Alpha complex dD on torus with 125000 points.
    benchmark_points_on_torus_dD - Alpha complex 3d creation: 2.996s      benchmark_points_on_torus_dD - Alpha complex 3d creation: 2.997s
    benchmark_points_on_torus_dD - complex creation: 2.252s               benchmark_points_on_torus_dD - complex creation: 2.274s
    benchmark_points_on_torus_dD - nb simplices = 9056937                 benchmark_points_on_torus_dD - nb simplices = 9050971
+ Epeck_d dynamic dimension version                                   + Epeck_d dynamic dimension version
  Alpha complex dD on torus with 25000 points.                          Alpha complex dD on torus with 25000 points.
    benchmark_points_on_torus_dD - Alpha complex 3d creation: 0.644s      benchmark_points_on_torus_dD - Alpha complex 3d creation: 0.672s
    benchmark_points_on_torus_dD - complex creation: 0.286s               benchmark_points_on_torus_dD - complex creation: 0.298s
    benchmark_points_on_torus_dD - nb simplices = 1549789                 benchmark_points_on_torus_dD - nb simplices = 1551985
  Alpha complex dD on torus with 125000 points.                         Alpha complex dD on torus with 125000 points.
    benchmark_points_on_torus_dD - Alpha complex 3d creation: 4.872s      benchmark_points_on_torus_dD - Alpha complex 3d creation: 5.153s
    benchmark_points_on_torus_dD - complex creation: 2.359s               benchmark_points_on_torus_dD - complex creation: 2.417s
    benchmark_points_on_torus_dD - nb simplices = 9038101                 benchmark_points_on_torus_dD - nb simplices = 9046073
```

As we can see, `CGAL::TDS_full_cell_mirror_storage_policy` enhances only the static versions of alpha.
