### PR TITLE
Python 3.8 is not available on macos-14 (latest), but ok on macos-13

### DIFF
--- a/.github/workflows/pip-build-osx.yml
+++ b/.github/workflows/pip-build-osx.yml
@@ -9,6 +9,7 @@ env:
 
 jobs:
   build:
+    # Should use macos-latest, but python 3.8 is no more available from macos-14
     runs-on: macos-13
     strategy:
       max-parallel: 4

--- a/.github/workflows/pip-build-osx.yml
+++ b/.github/workflows/pip-build-osx.yml
@@ -9,7 +9,7 @@ env:
 
 jobs:
   build:
-    runs-on: macos-latest
+    runs-on: macos-13
     strategy:
       max-parallel: 4
       matrix:

--- a/.github/workflows/pip-packaging-osx.yml
+++ b/.github/workflows/pip-packaging-osx.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   build:
-    runs-on: macos-latest
+    runs-on: macos-13
     strategy:
       max-parallel: 4
       matrix:

--- a/.github/workflows/pip-packaging-osx.yml
+++ b/.github/workflows/pip-packaging-osx.yml
@@ -11,6 +11,7 @@ env:
 
 jobs:
   build:
+    # Should use macos-latest, but python 3.8 is no more available from macos-14
     runs-on: macos-13
     strategy:
       max-parallel: 4


### PR DESCRIPTION
cf. https://github.com/actions/setup-python/issues/825