### PR TITLE
Tweak default parameters of KMeans in Atol

### DIFF
--- a/src/python/gudhi/representations/vector_methods.py
+++ b/src/python/gudhi/representations/vector_methods.py
@@ -737,7 +737,7 @@ class Atol(BaseEstimator, TransformerMixin):
     # Note the example above must be up to date with the one in tests called test_atol_doc
     def __init__(
             self,
-            quantiser=KMeans(n_clusters=2, random_state=202312, n_init=10),
+            quantiser=KMeans(n_clusters=2, n_init="auto"),
             weighting_method="cloud",
             contrast="gaussian"
     ):
@@ -747,9 +747,8 @@ class Atol(BaseEstimator, TransformerMixin):
         Parameters:
             quantiser (Object): Object with `fit` (sklearn API consistent) and `cluster_centers` and `n_clusters`
                 attributes, e.g. `sklearn.cluster.KMeans`. It will be fitted when the Atol object function `fit` is
-                called (default: `sklearn.cluster.KMeans` with 2 clusters because there are very few points, a fixed
-                `random_state` to be deterministic and `n_init=10` because it was KMeans default value for sklearn <
-                1.4.0)
+                called. Users are encouraged to provide their own quantiser, and in particular increase the number
+                of clusters.
             weighting_method (string): constant generic function for weighting the measure points
                 choose from {"cloud", "iidproba"}
                 (default: constant function, i.e. the measure is seen as a point cloud by default).


### PR DESCRIPTION
Refer to https://github.com/GUDHI/gudhi-devel/pull/1056#discussion_r1636010293

Sphinx is nice enough to show only `KMeans(n_clusters=2)`, i.e. it hides `n_init="auto"`, probably because it is the default. I don't know how good that is in general, but here where we only specify `n_init` to avoid warnings with old versions of scikit-learn, that's very cool.

@martinroyer, @VincentRouvreau, no objection?