### PR TITLE
[Persistence_matrix] move bar type outside

### DIFF
--- a/src/Persistence_matrix/include/gudhi/Persistence_matrix/base_pairing.h
+++ b/src/Persistence_matrix/include/gudhi/Persistence_matrix/base_pairing.h
@@ -152,7 +152,7 @@ inline void Base_pairing<Master_matrix>::_reduce()
       auto& curr = _matrix()->get_column(i);
       if (curr.is_empty()) {
         if (pivotsToColumn.find(i) == pivotsToColumn.end()) {
-          barcode_.emplace_back(dim, i, -1);
+          barcode_.emplace_back(i, -1, dim);
         }
       } else {
         id_index pivot = curr.get_pivot();
@@ -175,10 +175,10 @@ inline void Base_pairing<Master_matrix>::_reduce()
         if (pivot != static_cast<id_index>(-1)) {
           pivotsToColumn.emplace(pivot, i);
           _matrix()->get_column(pivot).clear();
-          barcode_.emplace_back(dim - 1, pivot, i);
+          barcode_.emplace_back(pivot, i, dim - 1);
         } else {
           curr.clear();
-          barcode_.emplace_back(dim, i, -1);
+          barcode_.emplace_back(i, -1, dim);
         }
       }
     }

--- a/src/Persistence_matrix/include/gudhi/Persistence_matrix/chain_matrix.h
+++ b/src/Persistence_matrix/include/gudhi/Persistence_matrix/chain_matrix.h
@@ -1260,7 +1260,7 @@ template <class Master_matrix>
 inline void Chain_matrix<Master_matrix>::_add_bar(dimension_type dim) 
 {
   if constexpr (Master_matrix::Option_list::has_column_pairings) {
-    _barcode().emplace_back(dim, _nextPosition(), -1);
+    _barcode().emplace_back(_nextPosition(), -1, dim);
     if constexpr (Master_matrix::Option_list::has_removable_columns) {
       _indexToBar().try_emplace(_nextPosition(), --_barcode().end());
     } else {

--- a/src/Persistence_matrix/include/gudhi/Persistence_matrix/ru_matrix.h
+++ b/src/Persistence_matrix/include/gudhi/Persistence_matrix/ru_matrix.h
@@ -897,7 +897,7 @@ template <class Master_matrix>
 inline void RU_matrix<Master_matrix>::_add_bar(dimension_type dim, pos_index birth) 
 {
   if constexpr (Master_matrix::Option_list::has_column_pairings) {
-    _barcode().emplace_back(dim, birth, -1);
+    _barcode().emplace_back(birth, -1, dim);
     if constexpr (Master_matrix::hasFixedBarcode || !Master_matrix::Option_list::has_removable_columns) {
       _indexToBar().push_back(_barcode().size() - 1);
     } else {

--- a/src/Persistence_matrix/include/gudhi/matrix.h
+++ b/src/Persistence_matrix/include/gudhi/matrix.h
@@ -27,6 +27,7 @@
 #include <gudhi/Debug_utils.h>
 
 #include <gudhi/persistence_matrix_options.h>
+#include <gudhi/persistence_interval.h>
 
 #include <gudhi/Fields/Z2_field_operators.h>
 
@@ -161,27 +162,11 @@ class Matrix {
    */
   using element_type = typename Field_operators::element_type;
   using characteristic_type = typename Field_operators::characteristic_type;
-
-  // TODO: move outside? unify with other bar types in Gudhi?
+  
   /**
    * @brief Type for a bar in the computed barcode. Stores the birth, death and dimension of the bar.
    */
-  struct Bar {
-    Bar() : dim(-1), birth(-1), death(-1) {}
-
-    Bar(dimension_type dim, pos_index birth, pos_index death) : dim(dim), birth(birth), death(death) {}
-
-    dimension_type dim; /**< Dimension of the bar.*/
-    pos_index birth;    /**< Birth index in the current filtration. */
-    pos_index death;    /**< Death index in the current filtration. */
-
-    inline friend std::ostream &operator<<(std::ostream &stream, const Bar& bar) {
-      stream << "[" << bar.dim << "] ";
-      stream << bar.birth << ", " << bar.death;
-      stream << "\n";
-      return stream;
-    }
-  };
+  using Bar = Persistence_interval<dimension_type, pos_index>;
 
   //tags for boost to associate a row and a column to a same cell
   struct matrix_row_tag;

--- a/src/Persistence_matrix/include/gudhi/persistence_interval.h
+++ b/src/Persistence_matrix/include/gudhi/persistence_interval.h
@@ -60,8 +60,8 @@ struct Persistence_interval {
 
 namespace std {
 
-template<>
-struct tuple_size<Gudhi::persistence_matrix::Persistence_interval<int, double> >
+template<typename dimension_type, typename event_value_type>
+struct tuple_size<Gudhi::persistence_matrix::Persistence_interval<dimension_type, event_value_type> >
     : std::integral_constant<std::size_t, 3> {};
 
 template <size_t I, typename dimension_type, typename event_value_type>

--- a/src/Persistence_matrix/include/gudhi/persistence_interval.h
+++ b/src/Persistence_matrix/include/gudhi/persistence_interval.h
@@ -26,6 +26,7 @@ namespace Gudhi {
 namespace persistence_matrix {
 
 /**
+ * @class Persistence_interval persistence_interval.h gudhi/persistence_interval.h
  * @ingroup persistence_matrix
  *
  * @brief Type for an interval in a persistent diagram or barcode.
@@ -37,7 +38,11 @@ namespace persistence_matrix {
 template <typename dimension_type, typename event_value_type>
 struct Persistence_interval {
   /**
-   * @brief Stores the infinity value for birth and death events.
+   * @brief Stores the infinity value for birth and death events. Its value depends on the template parameter
+   * `event_value_type`:
+   * - if `event_value_type` has a native infinity value, it takes this value,
+   * - otherwise, if `event_value_type` is a signed type, it takes value -1,
+   * - otherwise, if `event_value_type` is a unsigned type, it takes the maximal possible value.
    *
    * Is also used as default value for birth and death attributes when not initialized.
    */
@@ -47,13 +52,13 @@ struct Persistence_interval {
 
   /**
    * @brief Default constructor. Initializes the stored dimension to -1 and the stored birth and death values
-   * to @ref Persistence_interval::inf.
+   * to @ref inf.
    */
   Persistence_interval() : dim(-1), birth(inf), death(inf) {}
 
   /**
    * @brief Constructor. Initializes the stored dimension and the stored birth to the given values and the stored
-   * death value to @ref Persistence_interval::inf.
+   * death value to @ref inf.
    * 
    * @param dim Dimension of the cycle.
    * @param birth Birth value of the cycle.

--- a/src/Persistence_matrix/include/gudhi/persistence_interval.h
+++ b/src/Persistence_matrix/include/gudhi/persistence_interval.h
@@ -67,7 +67,15 @@ struct Persistence_interval {
 
   inline friend std::ostream &operator<<(std::ostream &stream, const Persistence_interval &interval) {
     stream << "[" << interval.dim << "] ";
-    stream << interval.birth << ", " << interval.death;
+    if constexpr (std::numeric_limits<event_value_type>::has_infinity) {
+      stream << interval.birth << " - " << interval.death;
+    } else {
+      if (interval.birth == inf) stream << "inf";
+      else stream << interval.birth;
+      stream << " - ";
+      if (interval.death == inf) stream << "inf";
+      else stream << interval.death;
+    }
     return stream;
   }
 };

--- a/src/Persistence_matrix/include/gudhi/persistence_interval.h
+++ b/src/Persistence_matrix/include/gudhi/persistence_interval.h
@@ -29,8 +29,9 @@ namespace persistence_matrix {
  * @class Persistence_interval persistence_interval.h gudhi/persistence_interval.h
  * @ingroup persistence_matrix
  *
- * @brief Type for an interval in a persistent diagram or barcode.
- * Stores the birth, death and dimension of the interval.
+ * @brief Type for an interval in a persistent diagram or barcode. Stores the birth, death and dimension of the
+ * interval. It can be used as a tuple with `get`/`std::get` (birth, death and dimension in this order),
+ * `std::tuple_element` and `std::tuple_size`, as well as structured binding.
  * 
  * @tparam dimension_type Type of the dimension value.
  * @tparam event_value_type Type of the birth and death value.
@@ -51,29 +52,13 @@ struct Persistence_interval {
                                               : static_cast<event_value_type>(-1);
 
   /**
-   * @brief Default constructor. Initializes the stored dimension to -1 and the stored birth and death values
-   * to @ref inf.
-   */
-  Persistence_interval() : dim(-1), birth(inf), death(inf) {}
-
-  /**
-   * @brief Constructor. Initializes the stored dimension and the stored birth to the given values and the stored
-   * death value to @ref inf.
+   * @brief Constructor.
    * 
-   * @param dim Dimension of the cycle.
-   * @param birth Birth value of the cycle.
+   * @param dim Dimension of the cycle. Default value: -1.
+   * @param birth Birth value of the cycle. Default value: @ref inf.
+   * @param death Death value of the cycle. Default value: @ref inf.
    */
-  Persistence_interval(dimension_type dim, event_value_type birth) : dim(dim), birth(birth), death(inf) {}
-
-  /**
-   * @brief Constructor. Initializes the stored dimension, the stored birth value and the stored
-   * death value to the given values.
-   * 
-   * @param dim Dimension of the cycle.
-   * @param birth Birth value of the cycle.
-   * @param death Death value of the cycle.
-   */
-  Persistence_interval(dimension_type dim, event_value_type birth, event_value_type death)
+  Persistence_interval(dimension_type dim = -1, event_value_type birth = inf, event_value_type death = inf)
       : dim(dim), birth(birth), death(death) {}
 
   dimension_type dim;     /**< Dimension of the cycle.*/
@@ -85,40 +70,6 @@ struct Persistence_interval {
     stream << interval.birth << ", " << interval.death;
     return stream;
   }
-};
-
-}  // namespace persistence_matrix
-}  // namespace Gudhi
-
-namespace std {
-
-/**
- * @ingroup persistence_matrix
- *
- * @brief Overload of `std::tuple_size` for @ref Gudhi::persistence_matrix::Persistence_interval.
- * 
- * @tparam dimension_type First template parameter of @ref Gudhi::persistence_matrix::Persistence_interval.
- * @tparam event_value_type Second template parameter of @ref Gudhi::persistence_matrix::Persistence_interval.
- */
-template <typename dimension_type, typename event_value_type>
-struct tuple_size<Gudhi::persistence_matrix::Persistence_interval<dimension_type, event_value_type> >
-    : std::integral_constant<std::size_t, 3> {};
-
-/**
- * @ingroup persistence_matrix
- *
- * @brief Overload of `std::tuple_element` for @ref Gudhi::persistence_matrix::Persistence_interval.
- * 
- * @tparam I Index of the type to store: 0 for the birth value type, 1 for the death value type and 2 for the
- * dimension value type.
- * @tparam dimension_type First template parameter of @ref Gudhi::persistence_matrix::Persistence_interval.
- * @tparam event_value_type Second template parameter of @ref Gudhi::persistence_matrix::Persistence_interval.
- */
-template <std::size_t I, typename dimension_type, typename event_value_type>
-struct tuple_element<I, Gudhi::persistence_matrix::Persistence_interval<dimension_type, event_value_type> > {
-  static_assert(I < 3, "Value mismatch at argument 1 in template parameter list. Maximal possible value is 2.");
-
-  using type = typename std::conditional<I < 2, event_value_type, dimension_type>::type;
 };
 
 /**
@@ -201,6 +152,62 @@ constexpr const auto&& get(
   if constexpr (I == 0) return std::move(i.birth);
   if constexpr (I == 1) return std::move(i.death);
   if constexpr (I == 2) return std::move(i.dim);
+}
+
+}  // namespace persistence_matrix
+}  // namespace Gudhi
+
+namespace std {
+
+/**
+ * @ingroup persistence_matrix
+ *
+ * @brief Overload of `std::tuple_size` for @ref Gudhi::persistence_matrix::Persistence_interval.
+ * 
+ * @tparam dimension_type First template parameter of @ref Gudhi::persistence_matrix::Persistence_interval.
+ * @tparam event_value_type Second template parameter of @ref Gudhi::persistence_matrix::Persistence_interval.
+ */
+template <typename dimension_type, typename event_value_type>
+struct tuple_size<Gudhi::persistence_matrix::Persistence_interval<dimension_type, event_value_type> >
+    : std::integral_constant<std::size_t, 3> {};
+
+/**
+ * @ingroup persistence_matrix
+ *
+ * @brief Overload of `std::tuple_element` for @ref Gudhi::persistence_matrix::Persistence_interval.
+ * 
+ * @tparam I Index of the type to store: 0 for the birth value type, 1 for the death value type and 2 for the
+ * dimension value type.
+ * @tparam dimension_type First template parameter of @ref Gudhi::persistence_matrix::Persistence_interval.
+ * @tparam event_value_type Second template parameter of @ref Gudhi::persistence_matrix::Persistence_interval.
+ */
+template <std::size_t I, typename dimension_type, typename event_value_type>
+struct tuple_element<I, Gudhi::persistence_matrix::Persistence_interval<dimension_type, event_value_type> > {
+  static_assert(I < 3, "Value mismatch at argument 1 in template parameter list. Maximal possible value is 2.");
+
+  using type = typename std::conditional<I < 2, event_value_type, dimension_type>::type;
+};
+
+template <size_t I, typename dimension_type, typename event_value_type>
+constexpr auto& get(Gudhi::persistence_matrix::Persistence_interval<dimension_type, event_value_type>& i) noexcept {
+  return Gudhi::persistence_matrix::get<I>(i);
+}
+
+template <size_t I, typename dimension_type, typename event_value_type>
+constexpr const auto& get(
+    const Gudhi::persistence_matrix::Persistence_interval<dimension_type, event_value_type>& i) noexcept {
+  return Gudhi::persistence_matrix::get<I>(i);
+}
+
+template <size_t I, typename dimension_type, typename event_value_type>
+constexpr auto&& get(Gudhi::persistence_matrix::Persistence_interval<dimension_type, event_value_type>&& i) noexcept {
+  return Gudhi::persistence_matrix::get<I>(i);
+}
+
+template <size_t I, typename dimension_type, typename event_value_type>
+constexpr const auto&& get(
+    const Gudhi::persistence_matrix::Persistence_interval<dimension_type, event_value_type>&& i) noexcept {
+  return Gudhi::persistence_matrix::get<I>(i);
 }
 
 }  // namespace std

--- a/src/Persistence_matrix/include/gudhi/persistence_interval.h
+++ b/src/Persistence_matrix/include/gudhi/persistence_interval.h
@@ -75,7 +75,7 @@ struct Persistence_interval {
 /**
  * @ingroup persistence_matrix
  *
- * @brief Overload of `std::get` for @ref Gudhi::persistence_matrix::Persistence_interval.
+ * @brief Partial specialization of `get` for @ref Gudhi::persistence_matrix::Persistence_interval.
  * 
  * @tparam I Index of the value to return: 0 for the birth value, 1 for the death value and 2 for the dimension.
  * @tparam dimension_type First template parameter of @ref Gudhi::persistence_matrix::Persistence_interval.
@@ -95,7 +95,7 @@ constexpr auto& get(Gudhi::persistence_matrix::Persistence_interval<dimension_ty
 /**
  * @ingroup persistence_matrix
  *
- * @brief Overload of `std::get` for @ref Gudhi::persistence_matrix::Persistence_interval.
+ * @brief Partial specialization of `get` for @ref Gudhi::persistence_matrix::Persistence_interval.
  * 
  * @tparam I Index of the value to return: 0 for the birth value, 1 for the death value and 2 for the dimension.
  * @tparam dimension_type First template parameter of @ref Gudhi::persistence_matrix::Persistence_interval.
@@ -116,7 +116,7 @@ constexpr const auto& get(
 /**
  * @ingroup persistence_matrix
  *
- * @brief Overload of `std::get` for @ref Gudhi::persistence_matrix::Persistence_interval.
+ * @brief Partial specialization of `get` for @ref Gudhi::persistence_matrix::Persistence_interval.
  * 
  * @tparam I Index of the value to return: 0 for the birth value, 1 for the death value and 2 for the dimension.
  * @tparam dimension_type First template parameter of @ref Gudhi::persistence_matrix::Persistence_interval.
@@ -136,7 +136,7 @@ constexpr auto&& get(Gudhi::persistence_matrix::Persistence_interval<dimension_t
 /**
  * @ingroup persistence_matrix
  *
- * @brief Overload of `std::get` for @ref Gudhi::persistence_matrix::Persistence_interval.
+ * @brief Partial specialization of `get` for @ref Gudhi::persistence_matrix::Persistence_interval.
  * 
  * @tparam I Index of the value to return: 0 for the birth value, 1 for the death value and 2 for the dimension.
  * @tparam dimension_type First template parameter of @ref Gudhi::persistence_matrix::Persistence_interval.
@@ -162,7 +162,7 @@ namespace std {
 /**
  * @ingroup persistence_matrix
  *
- * @brief Overload of `std::tuple_size` for @ref Gudhi::persistence_matrix::Persistence_interval.
+ * @brief Partial specialization of `std::tuple_size` for @ref Gudhi::persistence_matrix::Persistence_interval.
  * 
  * @tparam dimension_type First template parameter of @ref Gudhi::persistence_matrix::Persistence_interval.
  * @tparam event_value_type Second template parameter of @ref Gudhi::persistence_matrix::Persistence_interval.
@@ -174,7 +174,7 @@ struct tuple_size<Gudhi::persistence_matrix::Persistence_interval<dimension_type
 /**
  * @ingroup persistence_matrix
  *
- * @brief Overload of `std::tuple_element` for @ref Gudhi::persistence_matrix::Persistence_interval.
+ * @brief Partial specialization of `std::tuple_element` for @ref Gudhi::persistence_matrix::Persistence_interval.
  * 
  * @tparam I Index of the type to store: 0 for the birth value type, 1 for the death value type and 2 for the
  * dimension value type.
@@ -201,13 +201,13 @@ constexpr const auto& get(
 
 template <size_t I, typename dimension_type, typename event_value_type>
 constexpr auto&& get(Gudhi::persistence_matrix::Persistence_interval<dimension_type, event_value_type>&& i) noexcept {
-  return Gudhi::persistence_matrix::get<I>(i);
+  return Gudhi::persistence_matrix::get<I>(std::move(i));
 }
 
 template <size_t I, typename dimension_type, typename event_value_type>
 constexpr const auto&& get(
     const Gudhi::persistence_matrix::Persistence_interval<dimension_type, event_value_type>&& i) noexcept {
-  return Gudhi::persistence_matrix::get<I>(i);
+  return Gudhi::persistence_matrix::get<I>(std::move(i));
 }
 
 }  // namespace std

--- a/src/Persistence_matrix/include/gudhi/persistence_interval.h
+++ b/src/Persistence_matrix/include/gudhi/persistence_interval.h
@@ -1,0 +1,129 @@
+/*    This file is part of the Gudhi Library - https://gudhi.inria.fr/ - which is released under MIT.
+ *    See file LICENSE or go to https://gudhi.inria.fr/licensing/ for full license details.
+ *    Author(s):       Hannah Schreiber
+ *
+ *    Copyright (C) 2024 Inria
+ *
+ *    Modification(s):
+ *      - YYYY/MM Author: Description of the modification
+ */
+
+/**
+ * @file persistence_interval.h
+ * @author Hannah Schreiber
+ * @brief Contains @ref Gudhi::persistence_matrix::Persistence_interval class.
+ */
+
+#ifndef PM_INTERVAL_INCLUDED
+#define PM_INTERVAL_INCLUDED
+
+#include <iostream>
+#include <limits>
+#include <tuple>
+
+namespace Gudhi {
+namespace persistence_matrix {
+
+/**
+ * @ingroup persistence_matrix
+ *
+ * @brief Type for an interval in a persistent diagram or barcode.
+ * Stores the birth, death and dimension of the interval.
+ */
+template <typename dimension_type, typename event_value_type>
+struct Persistence_interval {
+  static constexpr event_value_type inf = std::numeric_limits<event_value_type>::has_infinity
+                                              ? std::numeric_limits<event_value_type>::infinity()
+                                              : static_cast<event_value_type>(-1);
+
+  Persistence_interval() : dim(-1), birth(inf), death(inf) {}
+
+  Persistence_interval(dimension_type dim, event_value_type birth) : dim(dim), birth(birth), death(inf) {}
+
+  Persistence_interval(dimension_type dim, event_value_type birth, event_value_type death)
+      : dim(dim), birth(birth), death(death) {}
+
+  dimension_type dim;     /**< Dimension of the bar.*/
+  event_value_type birth; /**< Birth index in the current filtration. */
+  event_value_type death; /**< Death index in the current filtration. */
+
+  inline friend std::ostream &operator<<(std::ostream &stream, const Persistence_interval &interval) {
+    stream << "[" << interval.dim << "] ";
+    stream << interval.birth << ", " << interval.death;
+    stream << "\n";
+    return stream;
+  }
+};
+
+}  // namespace persistence_matrix
+}  // namespace Gudhi
+
+namespace std {
+
+template<>
+struct tuple_size<Gudhi::persistence_matrix::Persistence_interval<int, double> >
+    : std::integral_constant<std::size_t, 3> {};
+
+template <size_t I, typename dimension_type, typename event_value_type>
+constexpr typename tuple_element<I, tuple<event_value_type, event_value_type, dimension_type> >::type& get(
+    Gudhi::persistence_matrix::Persistence_interval<dimension_type, event_value_type>& i) noexcept {
+  if constexpr (I == 0) return i.birth;
+  if constexpr (I == 1) return i.death;
+  if constexpr (I == 2) return i.dim;
+  // does not compile if I > 2, because of tuple_element
+}
+
+template <size_t I, typename dimension_type, typename event_value_type>
+constexpr const typename tuple_element<I, tuple<event_value_type, event_value_type, dimension_type> >::type& get(
+    const Gudhi::persistence_matrix::Persistence_interval<dimension_type, event_value_type>& i) noexcept {
+  if constexpr (I == 0) return i.birth;
+  if constexpr (I == 1) return i.death;
+  if constexpr (I == 2) return i.dim;
+  // does not compile if I > 2, because of tuple_element
+}
+
+template <size_t I, typename dimension_type, typename event_value_type>
+constexpr typename tuple_element<I, tuple<event_value_type, event_value_type, dimension_type> >::type&& get(
+    Gudhi::persistence_matrix::Persistence_interval<dimension_type, event_value_type>&& i) noexcept {
+  if constexpr (I == 0) return i.birth;
+  if constexpr (I == 1) return i.death;
+  if constexpr (I == 2) return i.dim;
+  // does not compile if I > 2, because of tuple_element
+}
+
+template <size_t I, typename dimension_type, typename event_value_type>
+constexpr const typename tuple_element<I, tuple<event_value_type, event_value_type, dimension_type> >::type&& get(
+    const Gudhi::persistence_matrix::Persistence_interval<dimension_type, event_value_type>&& i) noexcept {
+  if constexpr (I == 0) return i.birth;
+  if constexpr (I == 1) return i.death;
+  if constexpr (I == 2) return i.dim;
+  // does not compile if I > 2, because of tuple_element
+}
+
+template <typename dimension_type, typename event_value_type>
+constexpr dimension_type& get(
+    Gudhi::persistence_matrix::Persistence_interval<dimension_type, event_value_type>& t) noexcept {
+  return t.dim;
+}
+
+template <typename dimension_type, typename event_value_type>
+constexpr dimension_type&& get(
+    Gudhi::persistence_matrix::Persistence_interval<dimension_type, event_value_type>&& t) noexcept {
+  return t.dim;
+}
+
+template <typename dimension_type, typename event_value_type>
+constexpr const dimension_type& get(
+    const Gudhi::persistence_matrix::Persistence_interval<dimension_type, event_value_type>& t) noexcept {
+  return t.dim;
+}
+
+template <typename dimension_type, typename event_value_type>
+constexpr const dimension_type&& get(
+    const Gudhi::persistence_matrix::Persistence_interval<dimension_type, event_value_type>&& t) noexcept {
+  return t.dim;
+}
+
+}  // namespace std
+
+#endif  // PM_INTERVAL_INCLUDED

--- a/src/Persistence_matrix/include/gudhi/persistence_interval.h
+++ b/src/Persistence_matrix/include/gudhi/persistence_interval.h
@@ -17,7 +17,7 @@
 #ifndef PM_INTERVAL_INCLUDED
 #define PM_INTERVAL_INCLUDED
 
-#include <iostream>
+#include <ostream>
 #include <limits>
 #include <tuple>
 
@@ -32,25 +32,48 @@ namespace persistence_matrix {
  */
 template <typename dimension_type, typename event_value_type>
 struct Persistence_interval {
+  /**
+   * @brief Stores the infinity value for birth and death events.
+   *
+   * Is also used as default value for birth and death attributes when not initialized.
+   */
   static constexpr event_value_type inf = std::numeric_limits<event_value_type>::has_infinity
                                               ? std::numeric_limits<event_value_type>::infinity()
                                               : static_cast<event_value_type>(-1);
 
+  /**
+   * @brief Default constructor. Initializes the stored dimension to -1 and the stored birth and death values
+   * to @ref Persistence_interval::inf.
+   */
   Persistence_interval() : dim(-1), birth(inf), death(inf) {}
 
+  /**
+   * @brief Constructor. Initializes the stored dimension and the stored birth to the given values and the stored
+   * death value to @ref Persistence_interval::inf.
+   * 
+   * @param dim Dimension of the cycle.
+   * @param birth Birth value of the cycle.
+   */
   Persistence_interval(dimension_type dim, event_value_type birth) : dim(dim), birth(birth), death(inf) {}
 
+  /**
+   * @brief Constructor. Initializes the stored dimension, the stored birth value and the stored
+   * death value to the given values.
+   * 
+   * @param dim Dimension of the cycle.
+   * @param birth Birth value of the cycle.
+   * @param death Death value of the cycle.
+   */
   Persistence_interval(dimension_type dim, event_value_type birth, event_value_type death)
       : dim(dim), birth(birth), death(death) {}
 
-  dimension_type dim;     /**< Dimension of the bar.*/
-  event_value_type birth; /**< Birth index in the current filtration. */
-  event_value_type death; /**< Death index in the current filtration. */
+  dimension_type dim;     /**< Dimension of the cycle.*/
+  event_value_type birth; /**< Birth value of the cycle. */
+  event_value_type death; /**< Death value of the cycle. */
 
   inline friend std::ostream &operator<<(std::ostream &stream, const Persistence_interval &interval) {
     stream << "[" << interval.dim << "] ";
     stream << interval.birth << ", " << interval.death;
-    stream << "\n";
     return stream;
   }
 };
@@ -60,9 +83,16 @@ struct Persistence_interval {
 
 namespace std {
 
-template<typename dimension_type, typename event_value_type>
+template <typename dimension_type, typename event_value_type>
 struct tuple_size<Gudhi::persistence_matrix::Persistence_interval<dimension_type, event_value_type> >
     : std::integral_constant<std::size_t, 3> {};
+
+template <std::size_t I, typename dimension_type, typename event_value_type>
+struct tuple_element<I, Gudhi::persistence_matrix::Persistence_interval<dimension_type, event_value_type> > {
+  static_assert(I < 3, "Value mismatch at argument 1 in template parameter list. Maximal possible value is 2.");
+
+  using type = typename std::conditional<I < 2, event_value_type, dimension_type>::type;
+};
 
 template <size_t I, typename dimension_type, typename event_value_type>
 constexpr typename tuple_element<I, tuple<event_value_type, event_value_type, dimension_type> >::type& get(

--- a/src/Persistence_matrix/include/gudhi/persistence_interval.h
+++ b/src/Persistence_matrix/include/gudhi/persistence_interval.h
@@ -54,17 +54,23 @@ struct Persistence_interval {
   /**
    * @brief Constructor.
    * 
-   * @param dim Dimension of the cycle. Default value: -1.
    * @param birth Birth value of the cycle. Default value: @ref inf.
    * @param death Death value of the cycle. Default value: @ref inf.
+   * @param dim Dimension of the cycle. Default value: -1.
    */
-  Persistence_interval(dimension_type dim = -1, event_value_type birth = inf, event_value_type death = inf)
+  Persistence_interval(event_value_type birth = inf, event_value_type death = inf, dimension_type dim = -1)
       : dim(dim), birth(birth), death(death) {}
 
   dimension_type dim;     /**< Dimension of the cycle.*/
   event_value_type birth; /**< Birth value of the cycle. */
   event_value_type death; /**< Death value of the cycle. */
 
+  /**
+   * @brief operator<<
+   * 
+   * @param stream outstream
+   * @param interval interval to stream
+   */
   inline friend std::ostream &operator<<(std::ostream &stream, const Persistence_interval &interval) {
     stream << "[" << interval.dim << "] ";
     if constexpr (std::numeric_limits<event_value_type>::has_infinity) {

--- a/src/Persistence_matrix/include/gudhi/persistence_interval.h
+++ b/src/Persistence_matrix/include/gudhi/persistence_interval.h
@@ -17,9 +17,10 @@
 #ifndef PM_INTERVAL_INCLUDED
 #define PM_INTERVAL_INCLUDED
 
-#include <ostream>
-#include <limits>
+#include <ostream>  //std::ostream
+#include <limits>   //std::numeric_limits
 #include <tuple>
+#include <utility>  //std::move
 
 namespace Gudhi {
 namespace persistence_matrix {
@@ -29,6 +30,9 @@ namespace persistence_matrix {
  *
  * @brief Type for an interval in a persistent diagram or barcode.
  * Stores the birth, death and dimension of the interval.
+ * 
+ * @tparam dimension_type Type of the dimension value.
+ * @tparam event_value_type Type of the birth and death value.
  */
 template <typename dimension_type, typename event_value_type>
 struct Persistence_interval {
@@ -83,10 +87,28 @@ struct Persistence_interval {
 
 namespace std {
 
+/**
+ * @ingroup persistence_matrix
+ *
+ * @brief Overload of `std::tuple_size` for @ref Gudhi::persistence_matrix::Persistence_interval.
+ * 
+ * @tparam dimension_type First template parameter of @ref Gudhi::persistence_matrix::Persistence_interval.
+ * @tparam event_value_type Second template parameter of @ref Gudhi::persistence_matrix::Persistence_interval.
+ */
 template <typename dimension_type, typename event_value_type>
 struct tuple_size<Gudhi::persistence_matrix::Persistence_interval<dimension_type, event_value_type> >
     : std::integral_constant<std::size_t, 3> {};
 
+/**
+ * @ingroup persistence_matrix
+ *
+ * @brief Overload of `std::tuple_element` for @ref Gudhi::persistence_matrix::Persistence_interval.
+ * 
+ * @tparam I Index of the type to store: 0 for the birth value type, 1 for the death value type and 2 for the
+ * dimension value type.
+ * @tparam dimension_type First template parameter of @ref Gudhi::persistence_matrix::Persistence_interval.
+ * @tparam event_value_type Second template parameter of @ref Gudhi::persistence_matrix::Persistence_interval.
+ */
 template <std::size_t I, typename dimension_type, typename event_value_type>
 struct tuple_element<I, Gudhi::persistence_matrix::Persistence_interval<dimension_type, event_value_type> > {
   static_assert(I < 3, "Value mismatch at argument 1 in template parameter list. Maximal possible value is 2.");
@@ -94,64 +116,86 @@ struct tuple_element<I, Gudhi::persistence_matrix::Persistence_interval<dimensio
   using type = typename std::conditional<I < 2, event_value_type, dimension_type>::type;
 };
 
+/**
+ * @ingroup persistence_matrix
+ *
+ * @brief Overload of `std::get` for @ref Gudhi::persistence_matrix::Persistence_interval.
+ * 
+ * @tparam I Index of the value to return: 0 for the birth value, 1 for the death value and 2 for the dimension.
+ * @tparam dimension_type First template parameter of @ref Gudhi::persistence_matrix::Persistence_interval.
+ * @tparam event_value_type Second template parameter of @ref Gudhi::persistence_matrix::Persistence_interval.
+ * @param i Interval from which the value should be returned.
+ * @return Either the birth value if @p I == 0, the death value if @p I == 1 or the dimension if @p I == 2.
+ */
 template <size_t I, typename dimension_type, typename event_value_type>
-constexpr typename tuple_element<I, tuple<event_value_type, event_value_type, dimension_type> >::type& get(
-    Gudhi::persistence_matrix::Persistence_interval<dimension_type, event_value_type>& i) noexcept {
+constexpr auto& get(Gudhi::persistence_matrix::Persistence_interval<dimension_type, event_value_type>& i) noexcept {
+  static_assert(I < 3, "Value mismatch at argument 1 in template parameter list. Maximal possible value is 2.");
+
   if constexpr (I == 0) return i.birth;
   if constexpr (I == 1) return i.death;
   if constexpr (I == 2) return i.dim;
-  // does not compile if I > 2, because of tuple_element
 }
 
+/**
+ * @ingroup persistence_matrix
+ *
+ * @brief Overload of `std::get` for @ref Gudhi::persistence_matrix::Persistence_interval.
+ * 
+ * @tparam I Index of the value to return: 0 for the birth value, 1 for the death value and 2 for the dimension.
+ * @tparam dimension_type First template parameter of @ref Gudhi::persistence_matrix::Persistence_interval.
+ * @tparam event_value_type Second template parameter of @ref Gudhi::persistence_matrix::Persistence_interval.
+ * @param i Interval from which the value should be returned.
+ * @return Either the birth value if @p I == 0, the death value if @p I == 1 or the dimension if @p I == 2.
+ */
 template <size_t I, typename dimension_type, typename event_value_type>
-constexpr const typename tuple_element<I, tuple<event_value_type, event_value_type, dimension_type> >::type& get(
+constexpr const auto& get(
     const Gudhi::persistence_matrix::Persistence_interval<dimension_type, event_value_type>& i) noexcept {
+  static_assert(I < 3, "Value mismatch at argument 1 in template parameter list. Maximal possible value is 2.");
+
   if constexpr (I == 0) return i.birth;
   if constexpr (I == 1) return i.death;
   if constexpr (I == 2) return i.dim;
-  // does not compile if I > 2, because of tuple_element
 }
 
+/**
+ * @ingroup persistence_matrix
+ *
+ * @brief Overload of `std::get` for @ref Gudhi::persistence_matrix::Persistence_interval.
+ * 
+ * @tparam I Index of the value to return: 0 for the birth value, 1 for the death value and 2 for the dimension.
+ * @tparam dimension_type First template parameter of @ref Gudhi::persistence_matrix::Persistence_interval.
+ * @tparam event_value_type Second template parameter of @ref Gudhi::persistence_matrix::Persistence_interval.
+ * @param i Interval from which the value should be returned.
+ * @return Either the birth value if @p I == 0, the death value if @p I == 1 or the dimension if @p I == 2.
+ */
 template <size_t I, typename dimension_type, typename event_value_type>
-constexpr typename tuple_element<I, tuple<event_value_type, event_value_type, dimension_type> >::type&& get(
-    Gudhi::persistence_matrix::Persistence_interval<dimension_type, event_value_type>&& i) noexcept {
-  if constexpr (I == 0) return i.birth;
-  if constexpr (I == 1) return i.death;
-  if constexpr (I == 2) return i.dim;
-  // does not compile if I > 2, because of tuple_element
+constexpr auto&& get(Gudhi::persistence_matrix::Persistence_interval<dimension_type, event_value_type>&& i) noexcept {
+  static_assert(I < 3, "Value mismatch at argument 1 in template parameter list. Maximal possible value is 2.");
+
+  if constexpr (I == 0) return std::move(i.birth);
+  if constexpr (I == 1) return std::move(i.death);
+  if constexpr (I == 2) return std::move(i.dim);
 }
 
+/**
+ * @ingroup persistence_matrix
+ *
+ * @brief Overload of `std::get` for @ref Gudhi::persistence_matrix::Persistence_interval.
+ * 
+ * @tparam I Index of the value to return: 0 for the birth value, 1 for the death value and 2 for the dimension.
+ * @tparam dimension_type First template parameter of @ref Gudhi::persistence_matrix::Persistence_interval.
+ * @tparam event_value_type Second template parameter of @ref Gudhi::persistence_matrix::Persistence_interval.
+ * @param i Interval from which the value should be returned.
+ * @return Either the birth value if @p I == 0, the death value if @p I == 1 or the dimension if @p I == 2.
+ */
 template <size_t I, typename dimension_type, typename event_value_type>
-constexpr const typename tuple_element<I, tuple<event_value_type, event_value_type, dimension_type> >::type&& get(
+constexpr const auto&& get(
     const Gudhi::persistence_matrix::Persistence_interval<dimension_type, event_value_type>&& i) noexcept {
-  if constexpr (I == 0) return i.birth;
-  if constexpr (I == 1) return i.death;
-  if constexpr (I == 2) return i.dim;
-  // does not compile if I > 2, because of tuple_element
-}
+  static_assert(I < 3, "Value mismatch at argument 1 in template parameter list. Maximal possible value is 2.");
 
-template <typename dimension_type, typename event_value_type>
-constexpr dimension_type& get(
-    Gudhi::persistence_matrix::Persistence_interval<dimension_type, event_value_type>& t) noexcept {
-  return t.dim;
-}
-
-template <typename dimension_type, typename event_value_type>
-constexpr dimension_type&& get(
-    Gudhi::persistence_matrix::Persistence_interval<dimension_type, event_value_type>&& t) noexcept {
-  return t.dim;
-}
-
-template <typename dimension_type, typename event_value_type>
-constexpr const dimension_type& get(
-    const Gudhi::persistence_matrix::Persistence_interval<dimension_type, event_value_type>& t) noexcept {
-  return t.dim;
-}
-
-template <typename dimension_type, typename event_value_type>
-constexpr const dimension_type&& get(
-    const Gudhi::persistence_matrix::Persistence_interval<dimension_type, event_value_type>&& t) noexcept {
-  return t.dim;
+  if constexpr (I == 0) return std::move(i.birth);
+  if constexpr (I == 1) return std::move(i.death);
+  if constexpr (I == 2) return std::move(i.dim);
 }
 
 }  // namespace std

--- a/src/Persistence_matrix/test/pm_matrix_tests.h
+++ b/src/Persistence_matrix/test/pm_matrix_tests.h
@@ -15,6 +15,7 @@
 #include <utility>  //std::swap, std::move & std::exchange
 #include <vector>
 #include <set>
+#include <tuple>
 
 #include <boost/test/unit_test.hpp>
 #include "pm_test_utilities.h"
@@ -1415,12 +1416,18 @@ void test_barcode() {
     }
   }
 
-  std::set<std::tuple<int, int, int>, BarComp> bars;
+  std::set<std::tuple<int, int, int>, BarComp> bars1;
+  std::set<std::tuple<int, int, int>, BarComp> bars2;
+  std::set<std::tuple<int, int, int>, BarComp> bars3;
   // bars are not ordered the same for all matrices
   for (auto it = barcode.begin(); it != barcode.end(); ++it) {
-    bars.emplace(it->dim, it->birth, it->death);
+    //three access possibilities
+    bars1.emplace(it->dim, it->birth, it->death);
+    bars2.emplace(std::get<2>(*it), std::get<0>(*it), std::get<1>(*it));
+    auto [ x, y, z ] = *it;
+    bars3.emplace(z, x, y);
   }
-  auto it = bars.begin();
+  auto it = bars1.begin();
   BOOST_CHECK_EQUAL(std::get<0>(*it), 0);
   BOOST_CHECK_EQUAL(std::get<1>(*it), 0);
   // TODO: verify why this -1 works...: it->death should be unsigned int, so double conversion
@@ -1442,35 +1449,10 @@ void test_barcode() {
   BOOST_CHECK_EQUAL(std::get<1>(*it), 5);
   BOOST_CHECK_EQUAL(std::get<2>(*it), 6);
   ++it;
-  BOOST_CHECK(it == bars.end());
+  BOOST_CHECK(it == bars1.end());
 
-  //same test but with std::get
-  bars.clear();
-  for (auto it = barcode.begin(); it != barcode.end(); ++it) {
-    bars.emplace(std::get<2>(*it), std::get<0>(*it), std::get<1>(*it));
-  }
-  it = bars.begin();
-  BOOST_CHECK_EQUAL(std::get<0>(*it), 0);
-  BOOST_CHECK_EQUAL(std::get<1>(*it), 0);
-  BOOST_CHECK_EQUAL(std::get<2>(*it), -1);
-  ++it;
-  BOOST_CHECK_EQUAL(std::get<0>(*it), 0);
-  BOOST_CHECK_EQUAL(std::get<1>(*it), 1);
-  BOOST_CHECK_EQUAL(std::get<2>(*it), 3);
-  ++it;
-  BOOST_CHECK_EQUAL(std::get<0>(*it), 0);
-  BOOST_CHECK_EQUAL(std::get<1>(*it), 2);
-  BOOST_CHECK_EQUAL(std::get<2>(*it), 4);
-  ++it;
-  BOOST_CHECK_EQUAL(std::get<0>(*it), 0);
-  BOOST_CHECK_EQUAL(std::get<1>(*it), 7);
-  BOOST_CHECK_EQUAL(std::get<2>(*it), 8);
-  ++it;
-  BOOST_CHECK_EQUAL(std::get<0>(*it), 1);
-  BOOST_CHECK_EQUAL(std::get<1>(*it), 5);
-  BOOST_CHECK_EQUAL(std::get<2>(*it), 6);
-  ++it;
-  BOOST_CHECK(it == bars.end());
+  BOOST_CHECK(bars1 == bars2);
+  BOOST_CHECK(bars1 == bars3);
 }
 
 template <class Matrix>

--- a/src/Persistence_matrix/test/pm_matrix_tests.h
+++ b/src/Persistence_matrix/test/pm_matrix_tests.h
@@ -1443,6 +1443,34 @@ void test_barcode() {
   BOOST_CHECK_EQUAL(std::get<2>(*it), 6);
   ++it;
   BOOST_CHECK(it == bars.end());
+
+  //same test but with std::get
+  bars.clear();
+  for (auto it = barcode.begin(); it != barcode.end(); ++it) {
+    bars.emplace(std::get<2>(*it), std::get<0>(*it), std::get<1>(*it));
+  }
+  it = bars.begin();
+  BOOST_CHECK_EQUAL(std::get<0>(*it), 0);
+  BOOST_CHECK_EQUAL(std::get<1>(*it), 0);
+  BOOST_CHECK_EQUAL(std::get<2>(*it), -1);
+  ++it;
+  BOOST_CHECK_EQUAL(std::get<0>(*it), 0);
+  BOOST_CHECK_EQUAL(std::get<1>(*it), 1);
+  BOOST_CHECK_EQUAL(std::get<2>(*it), 3);
+  ++it;
+  BOOST_CHECK_EQUAL(std::get<0>(*it), 0);
+  BOOST_CHECK_EQUAL(std::get<1>(*it), 2);
+  BOOST_CHECK_EQUAL(std::get<2>(*it), 4);
+  ++it;
+  BOOST_CHECK_EQUAL(std::get<0>(*it), 0);
+  BOOST_CHECK_EQUAL(std::get<1>(*it), 7);
+  BOOST_CHECK_EQUAL(std::get<2>(*it), 8);
+  ++it;
+  BOOST_CHECK_EQUAL(std::get<0>(*it), 1);
+  BOOST_CHECK_EQUAL(std::get<1>(*it), 5);
+  BOOST_CHECK_EQUAL(std::get<2>(*it), 6);
+  ++it;
+  BOOST_CHECK(it == bars.end());
 }
 
 template <class Matrix>


### PR DESCRIPTION
To be able to use it also for Zigzag persistence (PR #917) more easily.

I also added the possibility to use `std::get` and `std::tuple_size` for the bars for the compatibility with other modules. `std::tuple_size` just doesn't work for structure inheriting from a `Persistence_interval`.