### PR TITLE
Fix CI for numpy 2.X support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
   examples:
     docker:
       # cf. https://github.com/GUDHI/gudhi-deploy/blob/main/Dockerfile_for_circleci_image
-      - image: gudhi/ci_for_gudhi:2024.06.01
+      - image: gudhi/ci_for_gudhi:2024.06.02
     steps:
       - checkout
       - run:
@@ -25,7 +25,7 @@ jobs:
 
   tests:
     docker:
-      - image: gudhi/ci_for_gudhi:2024.06.01
+      - image: gudhi/ci_for_gudhi:2024.06.02
     steps:
       - checkout
       - run:
@@ -44,7 +44,7 @@ jobs:
 
   debug_tests:
     docker:
-      - image: gudhi/ci_for_gudhi:2024.06.01
+      - image: gudhi/ci_for_gudhi:2024.06.02
     steps:
       - checkout
       - run:
@@ -63,7 +63,7 @@ jobs:
 
   utils:
     docker:
-      - image: gudhi/ci_for_gudhi:2024.06.01
+      - image: gudhi/ci_for_gudhi:2024.06.02
     steps:
       - checkout
       - run:
@@ -82,7 +82,7 @@ jobs:
 
   python:
     docker:
-      - image: gudhi/ci_for_gudhi:2024.06.01
+      - image: gudhi/ci_for_gudhi:2024.06.02
     steps:
       - checkout
       - run:

--- a/.github/workflows/pip-build-linux.yml
+++ b/.github/workflows/pip-build-linux.yml
@@ -7,32 +7,33 @@ jobs:
     name: build pip wheel
     runs-on: ubuntu-latest
     # cf. https://github.com/GUDHI/gudhi-deploy/blob/main/Dockerfile_for_pip
-    container: gudhi/pip_for_gudhi:2024.06.01
+    container: gudhi/pip_for_gudhi:2024.06.02
     steps:
       # Should use actions/checkout@v4, but requires node20, not available for quay.io/pypa/manylinux2014_x86_64
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - name: Build wheel for Python 3.8
+      - name: Build wheel for Python 3.9
         run: |
-          mkdir build_38
-          cd build_38
-          cmake -DCMAKE_BUILD_TYPE=Release -DPYTHON_EXECUTABLE=$PYTHON38/bin/python ..
+          mkdir build_39
+          cd build_39
+          cmake -DCMAKE_BUILD_TYPE=Release -DPYTHON_EXECUTABLE=$PYTHON39/bin/python ..
           cd src/python
-          $PYTHON38/bin/python -m build -n -w
+          $PYTHON39/bin/python -m build -n -w
           auditwheel repair dist/*.whl
-      - name: Install and test wheel for Python 3.8
+      # NumPy 2.X is installed and guarantees ABI compatibility, test it with the minimal numpy version for python version
+      - name: Install and test wheel for Python 3.9
         run: |
-          $PYTHON38/bin/python -m pip install --user pytest build_38/src/python/dist/*.whl
-          $PYTHON38/bin/python -m pip install numpy --upgrade
-          $PYTHON38/bin/python -c "import gudhi; print(gudhi.__version__)"
-          $PYTHON38/bin/python -m pytest -v src/python/test/test_alpha_complex.py
-          $PYTHON38/bin/python -m pytest -v src/python/test/test_bottleneck_distance.py
-          $PYTHON38/bin/python -m pytest -v src/python/test/test_cubical_complex.py
-          $PYTHON38/bin/python -m pytest -v src/python/test/test_rips_complex.py
+          $PYTHON39/bin/python -m pip install --user pytest build_39/src/python/dist/*.whl
+          $PYTHON39/bin/python -m pip install numpy~=1.19.3
+          $PYTHON39/bin/python -c "import gudhi; print(gudhi.__version__)"
+          $PYTHON39/bin/python -m pytest -v src/python/test/test_alpha_complex.py
+          $PYTHON39/bin/python -m pytest -v src/python/test/test_bottleneck_distance.py
+          $PYTHON39/bin/python -m pytest -v src/python/test/test_cubical_complex.py
+          $PYTHON39/bin/python -m pytest -v src/python/test/test_rips_complex.py
       - name: Upload linux python wheel
         # Should use actions/upload-artifact@v4, but requires node20, not available for quay.io/pypa/manylinux2014_x86_64
         uses: actions/upload-artifact@v3
         with:
           name: linux python wheel
-          path: build_38/src/python/wheelhouse/*.whl
+          path: build_39/src/python/wheelhouse/*.whl

--- a/.github/workflows/pip-build-osx.yml
+++ b/.github/workflows/pip-build-osx.yml
@@ -9,16 +9,13 @@ env:
 
 jobs:
   build:
-    # Should use macos-latest, but python 3.8 is no more available from macos-14
-    runs-on: macos-13
+    runs-on: macos-latest
     strategy:
       max-parallel: 4
       matrix:
-        # numpy packages for osx x86 and arm are only available from 1.21.2, but stable for both versions from 1.21.4
-        # and python 3.8+
-        python-version: ['3.8']
+        python-version: ['3.9']
         include:
-          - python-version: '3.8'
+          - python-version: '3.9'
             numpy-version: '1.21.4'
     name: Build wheels for Python ${{ matrix.python-version }}
     steps:
@@ -29,11 +26,13 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           architecture: x64
+      # For python >=3.9, numpy >= 2.0 for package build and ABI compatibility with numpy 1.X and 2.X
+      # cf. https://numpy.org/doc/stable/dev/depending_on_numpy.html#numpy-2-0-specific-advice
       - name: Install dependencies
         run: |
           brew update || true
           brew install boost eigen gmp mpfr cgal || true
-          python -m pip install --user numpy~=${{ matrix.numpy-version }}
+          python -m pip install --user numpy>=2.0
           python -m pip install --user -r ext/gudhi-deploy/build-requirements.txt
           python -m pip install --user delocate
           ./scripts/build_osx_universal_gmpfr.sh
@@ -51,9 +50,10 @@ jobs:
           python -m build -n -w
           export PATH="$PATH:`python -m site --user-base`/bin"
           delocate-wheel --require-archs universal2 -v dist/*.whl
+      # Test ABI compatibility with numpy 1.X
       - name: Install and test python wheel
         run: |
-          python -m pip install --user  numpy --upgrade
+          python -m pip install --user numpy~=${{ matrix.numpy-version }}
           python -m pip install --user pytest build/src/python/dist/*.whl
           python -c "import gudhi; print(gudhi.__version__)"
           python -m pytest -v src/python/test/test_alpha_complex.py

--- a/.github/workflows/pip-build-osx.yml
+++ b/.github/workflows/pip-build-osx.yml
@@ -9,7 +9,8 @@ env:
 
 jobs:
   build:
-    runs-on: macos-latest
+    # Should use macos-latest, but python 3.8 and 3.9 is no more available from macos-14
+    runs-on: macos-13
     strategy:
       max-parallel: 4
       matrix:

--- a/.github/workflows/pip-build-windows.yml
+++ b/.github/workflows/pip-build-windows.yml
@@ -23,50 +23,38 @@ jobs:
           architecture: x64
       - name: Install dependencies
         run: |
+          $ErrorActionPreference = 'Stop'
           set VCPKG_BUILD_TYPE=release
           vcpkg install eigen3 cgal --triplet x64-windows
-          IF %errorlevel% NEQ 0 exit /b %errorlevel%
           vcpkg version
           ls "C:\vcpkg\installed\x64-windows\bin\"
           python -m pip install --user numpy~=${{ matrix.numpy-version }}
-          IF %errorlevel% NEQ 0 exit /b %errorlevel%
           python -m pip install --user -r .\ext\gudhi-deploy\build-requirements.txt
-          IF %errorlevel% NEQ 0 exit /b %errorlevel%
       - name: Build python wheel and install it
         run: |
+          $ErrorActionPreference = 'Stop'
           mkdir build
           cd ".\build\"
           cmake -DCMAKE_BUILD_TYPE=Release -DFORCE_EIGEN_DEFAULT_DENSE_INDEX_TYPE_TO_INT=ON -DCMAKE_TOOLCHAIN_FILE=c:\vcpkg\scripts\buildsystems\vcpkg.cmake -DVCPKG_TARGET_TRIPLET=x64-windows ..
-          IF %errorlevel% NEQ 0 exit /b %errorlevel%
           cd ".\src\python\"
           cp "C:\vcpkg\installed\x64-windows\bin\mpfr*.dll" ".\gudhi\"
-          IF %errorlevel% NEQ 0 exit /b %errorlevel%
           cp "C:\vcpkg\installed\x64-windows\bin\gmp*.dll" ".\gudhi\"
-          IF %errorlevel% NEQ 0 exit /b %errorlevel%
           python -m build -n -w
-          IF %errorlevel% NEQ 0 exit /b %errorlevel%
           ls ".\dist\"
           cd ".\dist\"
           Get-ChildItem *.whl | ForEach-Object{python -m pip install --user $_.Name}
-          IF %errorlevel% NEQ 0 exit /b %errorlevel%
       - name: Test python wheel
         run: |
+          $ErrorActionPreference = 'Stop'
           Get-Location
           dir
           python -m pip install --user  numpy --upgrade
-          IF %errorlevel% NEQ 0 exit /b %errorlevel%
           python -m pip install --user pytest
-          IF %errorlevel% NEQ 0 exit /b %errorlevel%
           python -c "import gudhi; print(gudhi.__version__)"
-          IF %errorlevel% NEQ 0 exit /b %errorlevel%
           python -m pytest -v ".\src\python\test\test_alpha_complex.py"
-          IF %errorlevel% NEQ 0 exit /b %errorlevel%
           python -m pytest -v ".\src\python\test\test_bottleneck_distance.py"
-          IF %errorlevel% NEQ 0 exit /b %errorlevel%
           python -m pytest -v ".\src\python\test\test_cubical_complex.py"
-          IF %errorlevel% NEQ 0 exit /b %errorlevel%
           python -m pytest -v ".\src\python\test\test_rips_complex.py"
-          IF %errorlevel% NEQ 0 exit /b %errorlevel%
       - name: Upload Windows python wheel
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/pip-build-windows.yml
+++ b/.github/workflows/pip-build-windows.yml
@@ -8,10 +8,10 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ['3.8']
+        python-version: ['3.9']
         include:
           - python-version: '3.8'
-            numpy-version: '1.21.4'
+            numpy-version: '1.19.3'
     name: Build wheels for Python ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@v4
@@ -21,6 +21,8 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           architecture: x64
+      # For python >=3.9, numpy >= 2.0 for package build and ABI compatibility with numpy 1.X and 2.X
+      # cf. https://numpy.org/doc/stable/dev/depending_on_numpy.html#numpy-2-0-specific-advice
       - name: Install dependencies
         run: |
           $ErrorActionPreference = 'Stop'
@@ -28,7 +30,7 @@ jobs:
           vcpkg install eigen3 cgal --triplet x64-windows
           vcpkg version
           ls "C:\vcpkg\installed\x64-windows\bin\"
-          python -m pip install --user numpy~=${{ matrix.numpy-version }}
+          python -m pip install --user numpy>=2.0
           python -m pip install --user -r .\ext\gudhi-deploy\build-requirements.txt
       - name: Build python wheel and install it
         run: |
@@ -43,12 +45,13 @@ jobs:
           ls ".\dist\"
           cd ".\dist\"
           Get-ChildItem *.whl | ForEach-Object{python -m pip install --user $_.Name}
+      # Test ABI compatibility with numpy 1.X
       - name: Test python wheel
         run: |
           $ErrorActionPreference = 'Stop'
           Get-Location
           dir
-          python -m pip install --user  numpy --upgrade
+          python -m pip install --user numpy~=${{ matrix.numpy-version }}
           python -m pip install --user pytest
           python -c "import gudhi; print(gudhi.__version__)"
           python -m pytest -v ".\src\python\test\test_alpha_complex.py"

--- a/.github/workflows/pip-build-windows.yml
+++ b/.github/workflows/pip-build-windows.yml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         python-version: ['3.9']
         include:
-          - python-version: '3.8'
+          - python-version: '3.9'
             numpy-version: '1.19.3'
     name: Build wheels for Python ${{ matrix.python-version }}
     steps:

--- a/.github/workflows/pip-build-windows.yml
+++ b/.github/workflows/pip-build-windows.yml
@@ -25,33 +25,48 @@ jobs:
         run: |
           set VCPKG_BUILD_TYPE=release
           vcpkg install eigen3 cgal --triplet x64-windows
+          IF %errorlevel% NEQ 0 exit /b %errorlevel%
           vcpkg version
           ls "C:\vcpkg\installed\x64-windows\bin\"
           python -m pip install --user numpy~=${{ matrix.numpy-version }}
+          IF %errorlevel% NEQ 0 exit /b %errorlevel%
           python -m pip install --user -r .\ext\gudhi-deploy\build-requirements.txt
+          IF %errorlevel% NEQ 0 exit /b %errorlevel%
       - name: Build python wheel and install it
         run: |
           mkdir build
           cd ".\build\"
           cmake -DCMAKE_BUILD_TYPE=Release -DFORCE_EIGEN_DEFAULT_DENSE_INDEX_TYPE_TO_INT=ON -DCMAKE_TOOLCHAIN_FILE=c:\vcpkg\scripts\buildsystems\vcpkg.cmake -DVCPKG_TARGET_TRIPLET=x64-windows ..
+          IF %errorlevel% NEQ 0 exit /b %errorlevel%
           cd ".\src\python\"
           cp "C:\vcpkg\installed\x64-windows\bin\mpfr*.dll" ".\gudhi\"
+          IF %errorlevel% NEQ 0 exit /b %errorlevel%
           cp "C:\vcpkg\installed\x64-windows\bin\gmp*.dll" ".\gudhi\"
+          IF %errorlevel% NEQ 0 exit /b %errorlevel%
           python -m build -n -w
+          IF %errorlevel% NEQ 0 exit /b %errorlevel%
           ls ".\dist\"
           cd ".\dist\"
           Get-ChildItem *.whl | ForEach-Object{python -m pip install --user $_.Name}
+          IF %errorlevel% NEQ 0 exit /b %errorlevel%
       - name: Test python wheel
         run: |
           Get-Location
           dir
           python -m pip install --user  numpy --upgrade
+          IF %errorlevel% NEQ 0 exit /b %errorlevel%
           python -m pip install --user pytest
+          IF %errorlevel% NEQ 0 exit /b %errorlevel%
           python -c "import gudhi; print(gudhi.__version__)"
+          IF %errorlevel% NEQ 0 exit /b %errorlevel%
           python -m pytest -v ".\src\python\test\test_alpha_complex.py"
+          IF %errorlevel% NEQ 0 exit /b %errorlevel%
           python -m pytest -v ".\src\python\test\test_bottleneck_distance.py"
+          IF %errorlevel% NEQ 0 exit /b %errorlevel%
           python -m pytest -v ".\src\python\test\test_cubical_complex.py"
+          IF %errorlevel% NEQ 0 exit /b %errorlevel%
           python -m pytest -v ".\src\python\test\test_rips_complex.py"
+          IF %errorlevel% NEQ 0 exit /b %errorlevel%
       - name: Upload Windows python wheel
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/pip-packaging-linux.yml
+++ b/.github/workflows/pip-packaging-linux.yml
@@ -9,12 +9,14 @@ jobs:
     name: build pip wheel
     runs-on: ubuntu-latest
     # cf. https://github.com/GUDHI/gudhi-deploy/blob/main/Dockerfile_for_pip
-    container: gudhi/pip_for_gudhi:2024.06.01
+    container: gudhi/pip_for_gudhi:2024.06.02
     steps:
       # Should use actions/checkout@v4, but requires node20, not available for quay.io/pypa/manylinux2014_x86_64
       - uses: actions/checkout@v3
         with:
           submodules: true
+      # Python 3.8 specific case where NumPy 2.x will not be supported
+      # numpy~=1.21.4 means any numpy=1.21.*, but also numpy>=1.21.4 (numpy~=1.21 do not work as it means any numpy==1.*)
       - name: Build wheel for Python 3.8
         run: |
           mkdir build_38
@@ -40,10 +42,14 @@ jobs:
           cd src/python
           $PYTHON39/bin/python -m build -n -w
           auditwheel repair dist/*.whl
+      # For python >=3.9, numpy >= 2.0 is used to package and test ABI compatibility with numpy 1.X
+      # cf. https://numpy.org/doc/stable/dev/depending_on_numpy.html#numpy-2-0-specific-advice
+      # gudhi requires numpy >= 1.15.0, but minimal numpy version for python 3.9 is 1.19.3 for instance
+      # numpy~=1.19.3 means any numpy=1.19.*, but also numpy>=1.19.3 (numpy~=1.19 do not work as it means any numpy==1.*)
       - name: Install and test wheel for Python 3.9
         run: |
           $PYTHON39/bin/python -m pip install --user pytest build_39/src/python/dist/*.whl
-          $PYTHON39/bin/python -m pip install numpy --upgrade
+          $PYTHON39/bin/python -m pip install numpy~=1.19.3
           $PYTHON39/bin/python -c "import gudhi; print(gudhi.__version__)"
           $PYTHON39/bin/python -m pytest -v src/python/test/test_alpha_complex.py
           $PYTHON39/bin/python -m pytest -v src/python/test/test_bottleneck_distance.py
@@ -60,7 +66,7 @@ jobs:
       - name: Install and test wheel for Python 3.10
         run: |
           $PYTHON310/bin/python -m pip install --user pytest build_310/src/python/dist/*.whl
-          $PYTHON310/bin/python -m pip install numpy --upgrade
+          $PYTHON310/bin/python -m pip install numpy~=1.21.6
           $PYTHON310/bin/python -c "import gudhi; print(gudhi.__version__)"
           $PYTHON310/bin/python -m pytest -v src/python/test/test_alpha_complex.py
           $PYTHON310/bin/python -m pytest -v src/python/test/test_bottleneck_distance.py
@@ -77,7 +83,7 @@ jobs:
       - name: Install and test wheel for Python 3.11
         run: |
           $PYTHON311/bin/python -m pip install --user pytest build_311/src/python/dist/*.whl
-          $PYTHON311/bin/python -m pip install numpy --upgrade
+          $PYTHON311/bin/python -m pip install numpy~=1.23.2
           $PYTHON311/bin/python -c "import gudhi; print(gudhi.__version__)"
           $PYTHON311/bin/python -m pytest -v src/python/test/test_alpha_complex.py
           $PYTHON311/bin/python -m pytest -v src/python/test/test_bottleneck_distance.py
@@ -94,7 +100,7 @@ jobs:
       - name: Install and test wheel for Python 3.12
         run: |
           $PYTHON312/bin/python -m pip install --user pytest build_312/src/python/dist/*.whl
-          $PYTHON312/bin/python -m pip install numpy --upgrade
+          $PYTHON312/bin/python -m pip install numpy~=1.26.0
           $PYTHON312/bin/python -c "import gudhi; print(gudhi.__version__)"
           $PYTHON312/bin/python -m pytest -v src/python/test/test_alpha_complex.py
           $PYTHON312/bin/python -m pytest -v src/python/test/test_bottleneck_distance.py

--- a/.github/workflows/pip-packaging-osx.yml
+++ b/.github/workflows/pip-packaging-osx.yml
@@ -9,21 +9,72 @@ env:
   _PYTHON_HOST_PLATFORM: macosx-12.0-universal2
   ARCHFLAGS: "-arch arm64 -arch x86_64"
 
+# Python 3.8 specific case where NumPy 2.x will not be supported
+# NumPy packages for osx x86 and arm are only available from 1.21.2, but stable for both versions from 1.21.4 and python 3.8+
+# numpy~=1.21.4 means any numpy=1.21.*, but also numpy>=1.21.4 (numpy~=1.21 do not work as it means any numpy==1.*)
 jobs:
   build:
     # Should use macos-latest, but python 3.8 is no more available from macos-14
     runs-on: macos-13
+    name: Build wheels for Python 3.8
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.8
+          architecture: x64
+      - name: Install dependencies
+        run: |
+          brew update || true
+          brew install boost eigen gmp mpfr cgal || true
+          python -m pip install --user numpy~=1.21.4
+          python -m pip install --user -r ext/gudhi-deploy/build-requirements.txt
+          python -m pip install --user twine delocate
+          ./scripts/build_osx_universal_gmpfr.sh
+          # Now the universal libs are in $PWD/deps-uni/lib
+      - name: Build python wheel
+        run: |
+          export   GMP_LIB_DIR=$PWD/deps-uni/lib
+          export GMPXX_LIB_DIR=$PWD/deps-uni/lib
+          export  MPFR_LIB_DIR=$PWD/deps-uni/lib
+          python --version
+          mkdir build
+          cd build
+          cmake -DCMAKE_BUILD_TYPE=Release -DPython_ADDITIONAL_VERSIONS=3 ..
+          cd src/python
+          python -m build -n -w
+      - name: Install and test python wheel
+        run: |
+          python -m pip install --user  numpy --upgrade
+          python -m pip install --user pytest build/src/python/dist/*.whl
+          python -c "import gudhi; print(gudhi.__version__)"
+          python -m pytest -v src/python/test/test_alpha_complex.py
+          python -m pytest -v src/python/test/test_bottleneck_distance.py
+          python -m pytest -v src/python/test/test_cubical_complex.py
+          python -m pytest -v src/python/test/test_rips_complex.py
+      - name: Publish on PyPi
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        run: |
+          mkdir wheelhouse
+          export PATH="$PATH:`python -m site --user-base`/bin"
+          delocate-listdeps build/src/python/dist/*.whl
+          delocate-wheel --require-archs universal2 -w wheelhouse build/src/python/dist/*.whl
+          python -m twine upload wheelhouse/*.whl
+
+# Python 3.9+ specific case where NumPy 2.x will be supported
+# NumPy packages for osx x86 and arm are only available from 1.21.2, but stable for both versions from 1.21.4 and python 3.8+
+jobs:
+  build:
+    runs-on: macos-latest
     strategy:
       max-parallel: 4
       matrix:
-        # numpy packages for osx x86 and arm are only available from 1.21.2, but stable for both versions from 1.21.4
-        # and python 3.8+
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
         include:
-        # numpy >= 1.21.4 fort osx x86 and arm, but minimal numpy version for python 3.10 is 1.21.6 for instance
-        # numpy~=1.21.6 means any numpy=1.21.*, but also numpy>=1.21.6 (numpy~=1.21 do not work as it means any numpy==1.*)
-          - python-version: '3.8'
-            numpy-version: '1.21.4'
           - python-version: '3.9'
             numpy-version: '1.21.4'
           - python-version: '3.10'
@@ -45,7 +96,7 @@ jobs:
         run: |
           brew update || true
           brew install boost eigen gmp mpfr cgal || true
-          python -m pip install --user numpy~=${{ matrix.numpy-version }}
+          python -m pip install --user numpy>=2.0
           python -m pip install --user -r ext/gudhi-deploy/build-requirements.txt
           python -m pip install --user twine delocate
           ./scripts/build_osx_universal_gmpfr.sh
@@ -63,7 +114,7 @@ jobs:
           python -m build -n -w
       - name: Install and test python wheel
         run: |
-          python -m pip install --user  numpy --upgrade
+          python -m pip install --user numpy~=${{ matrix.numpy-version }}
           python -m pip install --user pytest build/src/python/dist/*.whl
           python -c "import gudhi; print(gudhi.__version__)"
           python -m pytest -v src/python/test/test_alpha_complex.py

--- a/.github/workflows/pip-packaging-osx.yml
+++ b/.github/workflows/pip-packaging-osx.yml
@@ -14,7 +14,7 @@ env:
 # numpy~=1.21.4 means any numpy=1.21.*, but also numpy>=1.21.4 (numpy~=1.21 do not work as it means any numpy==1.*)
 jobs:
   build:
-    # Should use macos-latest, but python 3.8 is no more available from macos-14
+    # Should use macos-latest, but python 3.8 and 3.9 is no more available from macos-14
     runs-on: macos-13
     name: Build wheels for Python 3.8
     steps:
@@ -69,7 +69,8 @@ jobs:
 # NumPy packages for osx x86 and arm are only available from 1.21.2, but stable for both versions from 1.21.4 and python 3.8+
 jobs:
   build:
-    runs-on: macos-latest
+    # Should use macos-latest, but python 3.8 and 3.9 is no more available from macos-14
+    runs-on: macos-13
     strategy:
       max-parallel: 4
       matrix:

--- a/.github/workflows/pip-packaging-windows.yml
+++ b/.github/workflows/pip-packaging-windows.yml
@@ -5,7 +5,6 @@ on:
     types: [published]
 
 # Python 3.8 specific case where NumPy 2.x will not be supported
-# NumPy packages for osx x86 and arm are only available from 1.21.2, but stable for both versions from 1.21.4 and python 3.8+
 # numpy~=1.21.4 means any numpy=1.21.*, but also numpy>=1.21.4 (numpy~=1.21 do not work as it means any numpy==1.*)
 jobs:
   build:

--- a/.github/workflows/pip-packaging-windows.yml
+++ b/.github/workflows/pip-packaging-windows.yml
@@ -4,34 +4,20 @@ on:
   release:
     types: [published]
 
+# Python 3.8 specific case where NumPy 2.x will not be supported
+# NumPy packages for osx x86 and arm are only available from 1.21.2, but stable for both versions from 1.21.4 and python 3.8+
+# numpy~=1.21.4 means any numpy=1.21.*, but also numpy>=1.21.4 (numpy~=1.21 do not work as it means any numpy==1.*)
 jobs:
   build:
     runs-on: windows-latest
-    strategy:
-      max-parallel: 4
-      matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
-        # gudhi requires numpy >= 1.15.0, but minimal numpy version for python 3.8 is 1.17.3 for instance
-        # numpy~=1.17.3 means any numpy=1.17.*, but also numpy>=1.17.3 (numpy~=1.17 do not work as it means any numpy==1.*)
-        include:
-          - python-version: '3.8'
-            numpy-version: '1.17.3'
-          - python-version: '3.9'
-            numpy-version: '1.19.3'
-          - python-version: '3.10'
-            numpy-version: '1.21.6'
-          - python-version: '3.11'
-            numpy-version: '1.23.2'
-          - python-version: '3.12'
-            numpy-version: '1.26.0'
-    name: Build wheels for Python ${{ matrix.python-version }}
+    name: Build wheels for Python 3.8
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: true
       - uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: 3.8
           architecture: x64
       - name: Install dependencies
         run: |
@@ -40,7 +26,7 @@ jobs:
           vcpkg install eigen3 cgal --triplet x64-windows
           vcpkg version
           ls "C:\vcpkg\installed\x64-windows\bin\"
-          python -m pip install --user numpy~=${{ matrix.numpy-version }}
+          python -m pip install --user numpy~=1.17.3
           python -m pip install --user -r .\ext\gudhi-deploy\build-requirements.txt
           python -m pip install --user twine
           python -m pip list
@@ -61,6 +47,75 @@ jobs:
         run: |
           $ErrorActionPreference = 'Stop'
           python -m pip install --user  numpy --upgrade
+          python -m pip install --user pytest
+          python -c "import gudhi; print(gudhi.__version__)"
+          python -m pytest -v ".\src\python\test\test_alpha_complex.py"
+          python -m pytest -v ".\src\python\test\test_bottleneck_distance.py"
+          python -m pytest -v ".\src\python\test\test_cubical_complex.py"
+          python -m pytest -v ".\src\python\test\test_rips_complex.py"
+      - name: Publish on PyPi
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        run: python -m twine upload build/src/python/dist/*.whl
+
+# Python 3.9+ specific case where NumPy 2.x will be supported
+jobs:
+  build:
+    runs-on: windows-latest
+    strategy:
+      max-parallel: 4
+      matrix:
+        python-version: ['3.9', '3.10', '3.11', '3.12']
+        include:
+          - python-version: '3.9'
+            numpy-version: '1.19.3'
+          - python-version: '3.10'
+            numpy-version: '1.21.6'
+          - python-version: '3.11'
+            numpy-version: '1.23.2'
+          - python-version: '3.12'
+            numpy-version: '1.26.0'
+    name: Build wheels for Python ${{ matrix.python-version }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          architecture: x64
+      # For python >=3.9, numpy >= 2.0 for package build and ABI compatibility with numpy 1.X and 2.X
+      # cf. https://numpy.org/doc/stable/dev/depending_on_numpy.html#numpy-2-0-specific-advice
+      - name: Install dependencies
+        run: |
+          $ErrorActionPreference = 'Stop'
+          set VCPKG_BUILD_TYPE=release
+          vcpkg install eigen3 cgal --triplet x64-windows
+          vcpkg version
+          ls "C:\vcpkg\installed\x64-windows\bin\"
+          python -m pip install --user numpy>=2.0
+          python -m pip install --user -r .\ext\gudhi-deploy\build-requirements.txt
+          python -m pip install --user twine
+          python -m pip list
+      - name: Build python wheel and install it
+        run: |
+          $ErrorActionPreference = 'Stop'
+          mkdir build
+          cd ".\build\"
+          cmake -DCMAKE_BUILD_TYPE=Release -DFORCE_EIGEN_DEFAULT_DENSE_INDEX_TYPE_TO_INT=ON -DCMAKE_TOOLCHAIN_FILE=c:\vcpkg\scripts\buildsystems\vcpkg.cmake -DVCPKG_TARGET_TRIPLET=x64-windows ..
+          cd ".\src\python\"
+          cp "C:\vcpkg\installed\x64-windows\bin\mpfr*.dll" ".\gudhi\"
+          cp "C:\vcpkg\installed\x64-windows\bin\gmp*.dll" ".\gudhi\"
+          python -m build -n -w
+          ls ".\dist\"
+          cd ".\dist\"
+          Get-ChildItem *.whl | ForEach-Object{python -m pip install --user $_.Name}
+      # Test ABI compatibility with numpy 1.X
+      - name: Test python wheel
+        run: |
+          $ErrorActionPreference = 'Stop'
+          python -m pip install --user numpy~=${{ matrix.numpy-version }}
           python -m pip install --user pytest
           python -c "import gudhi; print(gudhi.__version__)"
           python -m pytest -v ".\src\python\test\test_alpha_complex.py"

--- a/.github/workflows/pip-packaging-windows.yml
+++ b/.github/workflows/pip-packaging-windows.yml
@@ -35,51 +35,38 @@ jobs:
           architecture: x64
       - name: Install dependencies
         run: |
+          $ErrorActionPreference = 'Stop'
           set VCPKG_BUILD_TYPE=release
           vcpkg install eigen3 cgal --triplet x64-windows
-          IF %errorlevel% NEQ 0 exit /b %errorlevel%
           vcpkg version
           ls "C:\vcpkg\installed\x64-windows\bin\"
           python -m pip install --user numpy~=${{ matrix.numpy-version }}
-          IF %errorlevel% NEQ 0 exit /b %errorlevel%
           python -m pip install --user -r .\ext\gudhi-deploy\build-requirements.txt
-          IF %errorlevel% NEQ 0 exit /b %errorlevel%
           python -m pip install --user twine
-          IF %errorlevel% NEQ 0 exit /b %errorlevel%
           python -m pip list
       - name: Build python wheel and install it
         run: |
+          $ErrorActionPreference = 'Stop'
           mkdir build
           cd ".\build\"
           cmake -DCMAKE_BUILD_TYPE=Release -DFORCE_EIGEN_DEFAULT_DENSE_INDEX_TYPE_TO_INT=ON -DCMAKE_TOOLCHAIN_FILE=c:\vcpkg\scripts\buildsystems\vcpkg.cmake -DVCPKG_TARGET_TRIPLET=x64-windows ..
-          IF %errorlevel% NEQ 0 exit /b %errorlevel%
           cd ".\src\python\"
           cp "C:\vcpkg\installed\x64-windows\bin\mpfr*.dll" ".\gudhi\"
-          IF %errorlevel% NEQ 0 exit /b %errorlevel%
           cp "C:\vcpkg\installed\x64-windows\bin\gmp*.dll" ".\gudhi\"
-          IF %errorlevel% NEQ 0 exit /b %errorlevel%
           python -m build -n -w
-          IF %errorlevel% NEQ 0 exit /b %errorlevel%
           ls ".\dist\"
           cd ".\dist\"
           Get-ChildItem *.whl | ForEach-Object{python -m pip install --user $_.Name}
-          IF %errorlevel% NEQ 0 exit /b %errorlevel%
       - name: Test python wheel
         run: |
+          $ErrorActionPreference = 'Stop'
           python -m pip install --user  numpy --upgrade
-          IF %errorlevel% NEQ 0 exit /b %errorlevel%
           python -m pip install --user pytest
-          IF %errorlevel% NEQ 0 exit /b %errorlevel%
           python -c "import gudhi; print(gudhi.__version__)"
-          IF %errorlevel% NEQ 0 exit /b %errorlevel%
           python -m pytest -v ".\src\python\test\test_alpha_complex.py"
-          IF %errorlevel% NEQ 0 exit /b %errorlevel%
           python -m pytest -v ".\src\python\test\test_bottleneck_distance.py"
-          IF %errorlevel% NEQ 0 exit /b %errorlevel%
           python -m pytest -v ".\src\python\test\test_cubical_complex.py"
-          IF %errorlevel% NEQ 0 exit /b %errorlevel%
           python -m pytest -v ".\src\python\test\test_rips_complex.py"
-          IF %errorlevel% NEQ 0 exit /b %errorlevel%
       - name: Publish on PyPi
         env:
           TWINE_USERNAME: __token__

--- a/.github/workflows/pip-packaging-windows.yml
+++ b/.github/workflows/pip-packaging-windows.yml
@@ -37,33 +37,49 @@ jobs:
         run: |
           set VCPKG_BUILD_TYPE=release
           vcpkg install eigen3 cgal --triplet x64-windows
+          IF %errorlevel% NEQ 0 exit /b %errorlevel%
           vcpkg version
           ls "C:\vcpkg\installed\x64-windows\bin\"
           python -m pip install --user numpy~=${{ matrix.numpy-version }}
+          IF %errorlevel% NEQ 0 exit /b %errorlevel%
           python -m pip install --user -r .\ext\gudhi-deploy\build-requirements.txt
+          IF %errorlevel% NEQ 0 exit /b %errorlevel%
           python -m pip install --user twine
+          IF %errorlevel% NEQ 0 exit /b %errorlevel%
           python -m pip list
       - name: Build python wheel and install it
         run: |
           mkdir build
           cd ".\build\"
           cmake -DCMAKE_BUILD_TYPE=Release -DFORCE_EIGEN_DEFAULT_DENSE_INDEX_TYPE_TO_INT=ON -DCMAKE_TOOLCHAIN_FILE=c:\vcpkg\scripts\buildsystems\vcpkg.cmake -DVCPKG_TARGET_TRIPLET=x64-windows ..
+          IF %errorlevel% NEQ 0 exit /b %errorlevel%
           cd ".\src\python\"
           cp "C:\vcpkg\installed\x64-windows\bin\mpfr*.dll" ".\gudhi\"
+          IF %errorlevel% NEQ 0 exit /b %errorlevel%
           cp "C:\vcpkg\installed\x64-windows\bin\gmp*.dll" ".\gudhi\"
+          IF %errorlevel% NEQ 0 exit /b %errorlevel%
           python -m build -n -w
+          IF %errorlevel% NEQ 0 exit /b %errorlevel%
           ls ".\dist\"
           cd ".\dist\"
           Get-ChildItem *.whl | ForEach-Object{python -m pip install --user $_.Name}
+          IF %errorlevel% NEQ 0 exit /b %errorlevel%
       - name: Test python wheel
         run: |
           python -m pip install --user  numpy --upgrade
+          IF %errorlevel% NEQ 0 exit /b %errorlevel%
           python -m pip install --user pytest
+          IF %errorlevel% NEQ 0 exit /b %errorlevel%
           python -c "import gudhi; print(gudhi.__version__)"
+          IF %errorlevel% NEQ 0 exit /b %errorlevel%
           python -m pytest -v ".\src\python\test\test_alpha_complex.py"
+          IF %errorlevel% NEQ 0 exit /b %errorlevel%
           python -m pytest -v ".\src\python\test\test_bottleneck_distance.py"
+          IF %errorlevel% NEQ 0 exit /b %errorlevel%
           python -m pytest -v ".\src\python\test\test_cubical_complex.py"
+          IF %errorlevel% NEQ 0 exit /b %errorlevel%
           python -m pytest -v ".\src\python\test\test_rips_complex.py"
+          IF %errorlevel% NEQ 0 exit /b %errorlevel%
       - name: Publish on PyPi
         env:
           TWINE_USERNAME: __token__

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -59,8 +59,7 @@ jobs:
     - script: |
         git submodule update --init
         python -m pip install --user -r ext/gudhi-deploy/build-requirements.txt
-        # No PyKeOps on windows, let's workaround this one.
-        for /F "tokens=*" %%A in (ext\gudhi-deploy\test-requirements.txt) do python -m pip install  %%A
+        python -m pip install --user -r ext/gudhi-deploy/test-requirements.txt
         # Only vcpkg release libs for CI
         echo.set(VCPKG_BUILD_TYPE release)>> C:\vcpkg\triplets\x64-windows.cmake
         vcpkg install boost-filesystem:x64-windows boost-test:x64-windows boost-program-options:x64-windows tbb:x64-windows eigen3:x64-windows cgal:x64-windows

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,7 +7,7 @@ jobs:
     pool:
       vmImage: macOS-latest
     variables:
-      pythonVersion: '3.7'
+      pythonVersion: '3.9'
       cmakeBuildType: Release
 
     steps:
@@ -43,7 +43,7 @@ jobs:
     pool:
       vmImage: windows-latest
     variables:
-      pythonVersion: '3.7'
+      pythonVersion: '3.9'
       cmakeVcpkgFlags: -DVCPKG_TARGET_TRIPLET=x64-windows -DCMAKE_TOOLCHAIN_FILE=c:\vcpkg\scripts\buildsystems\vcpkg.cmake
       cmakeFlags: -DWITH_GUDHI_EXAMPLE=ON -DWITH_GUDHI_TEST=ON -DWITH_GUDHI_UTILITIES=ON -DWITH_GUDHI_PYTHON=OFF
 
@@ -67,26 +67,20 @@ jobs:
         choco install -y ninja --force --force-dependencies
       displayName: 'Install build dependencies'
     - script: |
+        $ErrorActionPreference = 'Stop'
         call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" amd64
-        IF %errorlevel% NEQ 0 exit /b %errorlevel%
         mkdir build
         cd build
         cmake -DCMAKE_BUILD_TYPE=Release -G "Ninja" -DFORCE_EIGEN_DEFAULT_DENSE_INDEX_TYPE_TO_INT=ON $(cmakeVcpkgFlags) $(cmakeFlags) ..
-        IF %errorlevel% NEQ 0 exit /b %errorlevel%
         ninja
-        IF %errorlevel% NEQ 0 exit /b %errorlevel%
         ctest --output-on-failure -C Release -E diff_files
-        IF %errorlevel% NEQ 0 exit /b %errorlevel%
         cmake  -DWITH_GUDHI_PYTHON=ON -DWITH_GUDHI_REMOTE_TEST=ON .
-        IF %errorlevel% NEQ 0 exit /b %errorlevel%
         cd src\python
         copy "C:\vcpkg\installed\x64-windows\bin\mpfr*.dll" ".\gudhi\"
         copy "C:\vcpkg\installed\x64-windows\bin\gmp*.dll" ".\gudhi\"
         copy "C:\vcpkg\installed\x64-windows\bin\tbb*.dll" ".\gudhi\"
         python setup.py build_ext --inplace
-        IF %errorlevel% NEQ 0 exit /b %errorlevel%
         SET PYTHONPATH=%CD%;%PYTHONPATH%
         echo %PYTHONPATH%
         ctest --output-on-failure -C Release
-        IF %errorlevel% NEQ 0 exit /b %errorlevel%
       displayName: 'Build and test'


### PR DESCRIPTION
* Fix Pypi wheel build for gudhi 3.10.0rc1 (hopefully)
* new docker images from gudhi-deploy 2024.06.02
* python from 3.7 to 3.9 for Azure (OSx and Windows)
* PyKeops is now available on windows