### PR TITLE
Implementing sklearn set_output API for BaseEstimator s

### DIFF
--- a/src/python/gudhi/sklearn/rips_persistence.py
+++ b/src/python/gudhi/sklearn/rips_persistence.py
@@ -131,3 +131,7 @@ class RipsPersistence(BaseEstimator, TransformerMixin):
         if unwrap:
             res = [d[0] for d in res]
         return res
+
+    def get_feature_names_out(self):
+        """Provide column names for implementing sklearn's set_output API."""
+        return [f"H{i}" for i in self.dim_list_]

--- a/src/python/test/test_sklearn_rips_persistence.py
+++ b/src/python/test/test_sklearn_rips_persistence.py
@@ -13,11 +13,12 @@ from gudhi.sklearn.rips_persistence import RipsPersistence
 import random
 import pytest
 
+
 def test_rips_persistence_of_points_on_a_circle():
     # Let's test with 5 point clouds
     NB_PC = 5
-    point_clouds = [points.sphere(n_samples = random.randint(100,150), ambient_dim = 2) for _ in range(NB_PC)]
-    
+    point_clouds = [points.sphere(n_samples=random.randint(100, 150), ambient_dim=2) for _ in range(NB_PC)]
+
     rips = RipsPersistence(homology_dimensions=[0, 1], n_jobs=-2)
     diags = rips.fit_transform(point_clouds)
     # list of one array as an input means list of one array as an output
@@ -30,22 +31,25 @@ def test_rips_persistence_of_points_on_a_circle():
         # H1
         assert len(diags[idx][1]) == 1
 
+
 def test_h1_only_rips_persistence_of_points_on_a_circle():
     rips = RipsPersistence(homology_dimensions=1, n_jobs=-2)
-    diags = rips.fit_transform([points.sphere(n_samples = 150, ambient_dim = 2)])[0]
+    diags = rips.fit_transform([points.sphere(n_samples=150, ambient_dim=2)])[0]
     assert len(diags) == 1
     assert 0. < diags[0][0] < 0.6
     assert 1. < diags[0][1] < 2.
 
+
 def test_invalid_input_type():
     rips = RipsPersistence(homology_dimensions=0, input_type='whatsoever')
     with pytest.raises(ValueError):
-        rips.fit_transform([points.sphere(n_samples = 10, ambient_dim = 2)])
+        rips.fit_transform([points.sphere(n_samples=10, ambient_dim=2)])
+
 
 def test_distance_matrix_rips_persistence_of_points_on_a_circle():
     try:
         from scipy.spatial.distance import cdist
-        pts = points.sphere(n_samples = 150, ambient_dim = 2)
+        pts = points.sphere(n_samples=150, ambient_dim=2)
         distance_matrix = cdist(pts, pts)
         rips = RipsPersistence(homology_dimensions=1, input_type='lower distance matrix')
         diags = rips.fit_transform([distance_matrix])[0]
@@ -54,3 +58,15 @@ def test_distance_matrix_rips_persistence_of_points_on_a_circle():
         assert 1. < diags[0][1] < 2.
     except ValueError:
         pass
+
+
+def test_set_output():
+    NB_PC = 5
+    point_clouds = [points.sphere(n_samples=random.randint(100, 150), ambient_dim=2) for _ in range(NB_PC)]
+
+    rips = RipsPersistence(homology_dimensions=[0, 2], n_jobs=-2)
+    diags_pandas = rips.set_output(transform="pandas").fit_transform(point_clouds)
+    assert 'H0' == diags_pandas.columns[0]
+    assert 'H2' == diags_pandas.columns[1]
+    assert len(diags_pandas.index) == NB_PC
+

--- a/src/python/test/test_sklearn_rips_persistence.py
+++ b/src/python/test/test_sklearn_rips_persistence.py
@@ -61,12 +61,15 @@ def test_distance_matrix_rips_persistence_of_points_on_a_circle():
 
 
 def test_set_output():
-    NB_PC = 5
-    point_clouds = [points.sphere(n_samples=random.randint(100, 150), ambient_dim=2) for _ in range(NB_PC)]
+    try:
+        import pandas
+        NB_PC = 5
+        point_clouds = [points.sphere(n_samples=random.randint(100, 150), ambient_dim=2) for _ in range(NB_PC)]
 
-    rips = RipsPersistence(homology_dimensions=[0, 2], n_jobs=-2)
-    diags_pandas = rips.set_output(transform="pandas").fit_transform(point_clouds)
-    assert 'H0' == diags_pandas.columns[0]
-    assert 'H2' == diags_pandas.columns[1]
-    assert len(diags_pandas.index) == NB_PC
-
+        rips = RipsPersistence(homology_dimensions=[0, 2], n_jobs=-2)
+        diags_pandas = rips.set_output(transform="pandas").fit_transform(point_clouds)
+        assert 'H0' == diags_pandas.columns[0]
+        assert 'H2' == diags_pandas.columns[1]
+        assert len(diags_pandas.index) == NB_PC
+    except ImportError:
+        print("Missing pandas, skipping set_output test")


### PR DESCRIPTION
Simple example showing how to implement scikit-learn's set_output API and an example test.

This outputs diagrams nicely:
```                                        
>>> RipsPersistence(homology_dimensions=[0, 2], n_jobs=-2).set_output(transform="pandas").fit_transform(point_clouds)
                                       H0  H2
0  [[0.0, 10.456032537513941], [0.0, inf]]  []
1  [[0.0, 12.925628779692705], [0.0, inf]]  []
2  [[0.0, 11.126843373147965], [0.0, inf]]  []
3  [[0.0, 12.647790894762348], [0.0, inf]]  []
4  [[0.0, 11.340625000427952], [0.0, inf]]  []
```


Let me add that although this PR is very simple, I am a bit sore that it took so long for me to write for the following reasons:
- I am on windows (granted this is on me)
- the test_sklearn_rips_persistence.py generates points using gudhi.datasets.generators.points
- this gudhi.datasets.generators.points imports from gudhi.datasets.generators._points.cc which if I understood correctly requires CGAL in the gudhi computation step
- CGAL is currently quite hard to install on some windows : for some reason if installed with `conda install cgal-cpp`, conda will not also install GMP (conda claims specs are incompatible) so gudhi will not be happy on compilation because it cannot find GMP, if installed through `vcpkg` the install will be stuck on ` Building x64-windows-dbg` (see https://github.com/microsoft/vcpkg/issues/31181 for detailed symptoms resembling mine), and installing GMP any other way seems nearly impossible on windows.
- but all this turned to be actually unnecessary, as the only reason for gudhi.datasets.generators.points to import the _points.cc is to ... generate points on a sphere or a torus, which I reckon can easily be done in python too!

So we could probably get rid of this dependency if I understood that correctly...