### PR TITLE
Workaround boost::optional that became std::optional on CGAL 6.X

### DIFF
--- a/src/Contraction/include/gudhi/Skeleton_blocker_contractor.h
+++ b/src/Contraction/include/gudhi/Skeleton_blocker_contractor.h
@@ -263,9 +263,12 @@ typename GeometricSimplifiableComplex::Vertex_handle> {
   }
 
   boost::optional<Edge_handle> pop_from_PQ() {
-    boost::optional<Edge_handle> edge = heap_PQ_->extract_top();
-    if (edge)
+    boost::optional<Edge_handle> edge;
+    if (!heap_PQ_->empty()) {
+      edge = heap_PQ_->top();
+      heap_PQ_->pop();
       get_data(*edge).reset_PQ_handle();
+    }
     return edge;
   }
 


### PR DESCRIPTION
Fix #1092 

Tested with CGAL 5.1, 5.1.5, 5.6.1 and 6.0-I-254.
