### PR TITLE
Some robustifying fixes on Atol fit and tests for vectorizers

### DIFF
--- a/src/python/gudhi/representations/vector_methods.py
+++ b/src/python/gudhi/representations/vector_methods.py
@@ -818,6 +818,13 @@ class Atol(BaseEstimator, TransformerMixin):
         filtered_measures_concat = measures_concat[~np.isinf(measures_concat).any(axis=1), :] if len(measures_concat) else measures_concat
         filtered_weights_concat = weights_concat[~np.isinf(measures_concat).any(axis=1)] if len(measures_concat) else weights_concat
 
+        n_clusters = self.quantiser.n_clusters
+        n_points = len(filtered_measures_concat)
+        if n_points < n_clusters:
+            # If not enough points to fit (including 0), let's arbitrarily put centers in [0, 1)^2
+            print(f"[Atol] had {n_points} points to fit {n_clusters} clusters, adding random points in [0, 1)^2.")
+            filtered_weights_concat = np.concatenate((filtered_weights_concat, np.ones(shape=(n_clusters - n_points))))
+            filtered_measures_concat = np.concatenate((filtered_measures_concat, np.random.random((n_clusters - n_points, 2))))
 
         self.quantiser.fit(X=filtered_measures_concat, sample_weight=filtered_weights_concat)
         self.centers = self.quantiser.cluster_centers_

--- a/src/python/gudhi/representations/vector_methods.py
+++ b/src/python/gudhi/representations/vector_methods.py
@@ -9,8 +9,6 @@
 #   - 2020/12 Gard: A more flexible Betti curve class capable of computing exact curves.
 #   - 2021/11 Vincent Rouvreau: factorize _automatic_sample_range
 
-import warnings
-
 import numpy as np
 from scipy.spatial.distance import cdist
 from sklearn.base          import BaseEstimator, TransformerMixin

--- a/src/python/gudhi/representations/vector_methods.py
+++ b/src/python/gudhi/representations/vector_methods.py
@@ -821,7 +821,7 @@ class Atol(BaseEstimator, TransformerMixin):
         filtered_weights_concat = weights_concat[~np.isinf(measures_concat).any(axis=1)] if len(measures_concat) else weights_concat
         n_points = len(filtered_measures_concat)
         if not n_points:
-            raise Exception("Cannot fit Atol on empty target.")
+            raise Exception("Cannot fit Atol on measure with infinite components only.")
 
         if n_points < n_clusters:
             # If not enough points to fit (including 0), we will arbitrarily put centers as [-np.inf]^measure_dim at the end.

--- a/src/python/gudhi/representations/vector_methods.py
+++ b/src/python/gudhi/representations/vector_methods.py
@@ -834,7 +834,7 @@ class Atol(BaseEstimator, TransformerMixin):
         # Hack, but some people are unhappy if the order depends on the version of sklearn
         self.centers = self.centers[np.lexsort(self.centers.T)]
         if self.quantiser.n_clusters == 1:
-            dist_centers = pairwise.pairwise_distances(measures_concat)
+            dist_centers = pairwise.pairwise_distances(filtered_measures_concat)
             np.fill_diagonal(dist_centers, 0)
             best_inertia = np.max(dist_centers)/2 if np.max(dist_centers)/2 > 0 else 1
             self.inertias = np.array([best_inertia])

--- a/src/python/gudhi/representations/vector_methods.py
+++ b/src/python/gudhi/representations/vector_methods.py
@@ -810,7 +810,7 @@ class Atol(BaseEstimator, TransformerMixin):
         n_clusters = self.quantiser.n_clusters
 
         if not len(X):
-            raise Exception("Cannot fit Atol on empty target.")
+            raise ValueError("Cannot fit Atol on empty target.")
         measures_concat = np.concatenate(X)
         if sample_weight is None:
             sample_weight = [self.get_weighting_method()(measure) for measure in X]
@@ -821,7 +821,7 @@ class Atol(BaseEstimator, TransformerMixin):
         filtered_weights_concat = weights_concat[~np.isinf(measures_concat).any(axis=1)] if len(measures_concat) else weights_concat
         n_points = len(filtered_measures_concat)
         if not n_points:
-            raise Exception("Cannot fit Atol on measure with infinite components only.")
+            raise ValueError("Cannot fit Atol on measure with infinite components only.")
 
         if n_points < n_clusters:
             # If not enough points to fit (including 0), we will arbitrarily put centers as [-np.inf]^measure_dim at the end.

--- a/src/python/gudhi/representations/vector_methods.py
+++ b/src/python/gudhi/representations/vector_methods.py
@@ -845,8 +845,7 @@ class Atol(BaseEstimator, TransformerMixin):
 
         if n_points < n_clusters:
             # There weren't enough points to fit n_clusters, so we arbitrarily put centers as [-np.inf]^measure_dim.
-            warnings.warn(f"[Atol] after flitering had only {n_points} points to fit {n_clusters} clusters,"
-                          f"adding meaningless cluster centers.", RuntimeWarning)
+            print(f"[Atol] after filtering had only {n_points=} to fit {n_clusters=}, adding meaningless centers.")
             fill_center = np.repeat(np.inf, repeats=X[0].shape[1])
             fill_inertia = 0
             self.centers = np.concatenate([self.centers, np.repeat([fill_center], repeats=n_clusters-n_points, axis=0)])

--- a/src/python/gudhi/representations/vector_methods.py
+++ b/src/python/gudhi/representations/vector_methods.py
@@ -807,7 +807,7 @@ class Atol(BaseEstimator, TransformerMixin):
             self
         """
         if not hasattr(self.quantiser, 'fit'):
-            raise TypeError("quantiser %s has no `fit` attribute." % (self.quantiser))
+            raise TypeError(f"quantiser {self.quantiser} has no `fit` attribute.")
 
         if sample_weight is None:
             sample_weight = [self.get_weighting_method()(measure) for measure in X]

--- a/src/python/test/test_representations_interface.py
+++ b/src/python/test/test_representations_interface.py
@@ -46,13 +46,6 @@ def test_fit():
         clone(vectorizer).fit(X=[diag1[0], diag2[0]])
 
 
-def test_fit_empty():
-    print(f" > Testing `fit_empty`.")
-    for name, vectorizer in vectorizers.items():
-        print(f" >> Testing {name}")
-        clone(vectorizer).fit(X=[diag3[0], diag3[0]])
-
-
 def test_transform():
     print(f" > Testing `transform`.")
     for name, vectorizer in vectorizers.items():

--- a/src/python/test/test_representations_interface.py
+++ b/src/python/test/test_representations_interface.py
@@ -1,3 +1,5 @@
+# The following tests only check that the program runs, not what it outputs
+
 import numpy as np
 
 from sklearn.base import clone

--- a/src/python/test/test_representations_interface.py
+++ b/src/python/test/test_representations_interface.py
@@ -1,0 +1,90 @@
+from copy import deepcopy
+import numpy as np
+
+from sklearn.cluster import KMeans
+
+from gudhi.representations import (Atol, Landscape, Silhouette, BettiCurve, ComplexPolynomial, \
+                                   TopologicalVector, PersistenceImage, Entropy)
+
+vectorizers = {
+    "atol": Atol(quantiser=KMeans(n_clusters=2, random_state=202312, n_init="auto")),
+    # "betti": BettiCurve(),
+}
+
+diag1 = [np.array([[0., np.inf],
+                   [0., 8.94427191],
+                   [0., 7.28010989],
+                   [0., 6.08276253],
+                   [0., 5.83095189],
+                   [0., 5.38516481],
+                   [0., 5.]]),
+         np.array([[11., np.inf],
+                   [6.32455532, 6.70820393]]),
+         np.empty(shape=[0, 2])]
+
+diag2 = [np.array([[0., np.inf],
+                   [0., 8.94427191],
+                   [0., 7.28010989],
+                   [0., 6.08276253],
+                   [0., 5.83095189],
+                   [0., 5.38516481],
+                   [0., 5.]]),
+         np.array([[11., np.inf],
+                   [6.32455532, 6.70820393]]),
+         np.array([[0., np.inf],
+                   [0., 1]])]
+
+diag3 = [np.empty(shape=[0, 2])]
+
+
+def test_fit():
+    print(f" > Testing `fit`.")
+    for name, vectorizer in vectorizers.items():
+        print(f" >> Testing {name}")
+        deepcopy(vectorizer).fit(X=[diag1[0], diag2[0]])
+
+
+def test_fit_empty():
+    print(f" > Testing `fit_empty`.")
+    for name, vectorizer in vectorizers.items():
+        print(f" >> Testing {name}")
+        deepcopy(vectorizer).fit(X=[diag3[0], diag3[0]])
+
+
+def test_transform():
+    print(f" > Testing `transform`.")
+    for name, vectorizer in vectorizers.items():
+        print(f" >> Testing {name}")
+        deepcopy(vectorizer).fit_transform(X=[diag1[0], diag2[0], diag3[0]])
+
+
+def test_transform_empty():
+    print(f" > Testing `transform_empty`.")
+    for name, vectorizer in vectorizers.items():
+        print(f" >> Testing {name}")
+        copy_vec = deepcopy(vectorizer).fit(X=[diag1[0], diag2[0]])
+        copy_vec.transform(X=[diag3[0], diag3[0]])
+
+
+def test_set_output():
+    print(f" > Testing `set_output`.")
+    try:
+        import pandas
+        for name, vectorizer in vectorizers.items():
+            print(f" >> Testing {name}")
+            deepcopy(vectorizer).set_output(transform="pandas")
+    except ImportError:
+        print("Missing pandas, skipping set_output test")
+
+
+def test_compose():
+    print(f" > Testing composition with `sklearn.compose.ColumnTransformer`.")
+    from sklearn.compose import ColumnTransformer
+    for name, vectorizer in vectorizers.items():
+        print(f" >> Testing {name}")
+        ct = ColumnTransformer([
+            (f"{name}-0", deepcopy(vectorizer), 0),
+            (f"{name}-1", deepcopy(vectorizer), 1),
+            (f"{name}-2", deepcopy(vectorizer), 2)]
+        )
+        ct.fit_transform(X=[diag1, diag2])

--- a/src/python/test/test_representations_interface.py
+++ b/src/python/test/test_representations_interface.py
@@ -1,6 +1,6 @@
-from copy import deepcopy
 import numpy as np
 
+from sklearn.base import clone
 from sklearn.cluster import KMeans
 
 from gudhi.representations import (Atol, Landscape, Silhouette, BettiCurve, ComplexPolynomial, \
@@ -41,28 +41,28 @@ def test_fit():
     print(f" > Testing `fit`.")
     for name, vectorizer in vectorizers.items():
         print(f" >> Testing {name}")
-        deepcopy(vectorizer).fit(X=[diag1[0], diag2[0]])
+        clone(vectorizer).fit(X=[diag1[0], diag2[0]])
 
 
 def test_fit_empty():
     print(f" > Testing `fit_empty`.")
     for name, vectorizer in vectorizers.items():
         print(f" >> Testing {name}")
-        deepcopy(vectorizer).fit(X=[diag3[0], diag3[0]])
+        clone(vectorizer).fit(X=[diag3[0], diag3[0]])
 
 
 def test_transform():
     print(f" > Testing `transform`.")
     for name, vectorizer in vectorizers.items():
         print(f" >> Testing {name}")
-        deepcopy(vectorizer).fit_transform(X=[diag1[0], diag2[0], diag3[0]])
+        clone(vectorizer).fit_transform(X=[diag1[0], diag2[0], diag3[0]])
 
 
 def test_transform_empty():
     print(f" > Testing `transform_empty`.")
     for name, vectorizer in vectorizers.items():
         print(f" >> Testing {name}")
-        copy_vec = deepcopy(vectorizer).fit(X=[diag1[0], diag2[0]])
+        copy_vec = clone(vectorizer).fit(X=[diag1[0], diag2[0]])
         copy_vec.transform(X=[diag3[0], diag3[0]])
 
 
@@ -72,7 +72,7 @@ def test_set_output():
         import pandas
         for name, vectorizer in vectorizers.items():
             print(f" >> Testing {name}")
-            deepcopy(vectorizer).set_output(transform="pandas")
+            clone(vectorizer).set_output(transform="pandas")
     except ImportError:
         print("Missing pandas, skipping set_output test")
 
@@ -83,8 +83,8 @@ def test_compose():
     for name, vectorizer in vectorizers.items():
         print(f" >> Testing {name}")
         ct = ColumnTransformer([
-            (f"{name}-0", deepcopy(vectorizer), 0),
-            (f"{name}-1", deepcopy(vectorizer), 1),
-            (f"{name}-2", deepcopy(vectorizer), 2)]
+            (f"{name}-0", clone(vectorizer), 0),
+            (f"{name}-1", clone(vectorizer), 1),
+            (f"{name}-2", clone(vectorizer), 2)]
         )
         ct.fit_transform(X=[diag1, diag2])


### PR DESCRIPTION
This introduces fixes that allow Atol to not crash on fitting, essentially by adding random points to the target.
This is a follow-up on PR #1017 that can now be dropped.

Option: I add a series of test that only test Atol for now, but are ready to be extended to all vectorization methods. So one could work on another vector method and directly use the same test battery to see if there's a problem with this method's:
    - fit,
    - fit on empty diagrams,
    - transform,
    - transform on empty diagrams,
    - using sklearn set_output,
    - using sklearn compose with ColumnTransformer (not sure how this could fail with all the other tests but who knows).
This test list comes as a sort of probe for a shared common interface of vectorizers, it could be enriched/edited on the way.

(naturally we could also work on the interface as a separate PR where we deal with the `transform_one` question too, see https://github.com/GUDHI/gudhi-devel/pull/1056#discussion_r1625083965.)