### PR TITLE
Allow node16 in github action

### DIFF
--- a/.github/workflows/pip-build-linux.yml
+++ b/.github/workflows/pip-build-linux.yml
@@ -2,6 +2,10 @@ name: pip build linux
 
 on: [push, pull_request]
 
+# Temporary workaround to allow node16
+env:
+  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
+
 jobs:
   build:
     name: build pip wheel


### PR DESCRIPTION
This is temporary, node16 may disappear any day.
Looking at https://github.com/pypa/manylinux, I guess we could base our Dockerfile on manylinux_2_28, although it would remove support for Ubuntu 20.04.