### PR TITLE
[Persistence matrix] barcode index shift fix

### DIFF
--- a/src/Persistence_matrix/include/gudhi/Persistence_matrix/base_pairing.h
+++ b/src/Persistence_matrix/include/gudhi/Persistence_matrix/base_pairing.h
@@ -96,7 +96,8 @@ class Base_pairing : public std::conditional<
   using id_index = typename Master_matrix::id_index;
   using dictionary_type = typename Master_matrix::bar_dictionary_type;
   using base_matrix = typename Master_matrix::Boundary_matrix_type;
-  using RUM = typename std::conditional<Master_matrix::Option_list::has_removable_columns,
+  //PIDM = Position to ID Map
+  using PIDM = typename std::conditional<Master_matrix::Option_list::has_removable_columns,
                                         Face_position_to_ID_mapper<id_index, pos_index>,
                                         Dummy_pos_mapper
                                        >::type;
@@ -118,7 +119,7 @@ class Base_pairing : public std::conditional<
 };
 
 template <class Master_matrix>
-inline Base_pairing<Master_matrix>::Base_pairing() : RUM(), isReduced_(false) 
+inline Base_pairing<Master_matrix>::Base_pairing() : PIDM(), isReduced_(false) 
 {}
 
 template <class Master_matrix>
@@ -210,10 +211,10 @@ inline void Base_pairing<Master_matrix>::_remove_last(pos_index columnIndex)
     };
   }
 
-  auto it = RUM::map_.find(columnIndex);
-  if (it != RUM::map_.end()){
+  auto it = PIDM::map_.find(columnIndex);
+  if (it != PIDM::map_.end()){
     idToPosition_.erase(it->second);
-    RUM::map_.erase(it);
+    PIDM::map_.erase(it);
   }
 }
 

--- a/src/Persistence_matrix/include/gudhi/Persistence_matrix/base_pairing.h
+++ b/src/Persistence_matrix/include/gudhi/Persistence_matrix/base_pairing.h
@@ -78,10 +78,6 @@ class Base_pairing : public std::conditional<
   const barcode_type& get_current_barcode();
 
   /**
-   * @brief Assign operator.
-   */
-  Base_pairing& operator=(Base_pairing other);
-  /**
    * @brief Swap operator.
    */
   friend void swap(Base_pairing& pairing1, Base_pairing& pairing2) {
@@ -219,17 +215,6 @@ inline void Base_pairing<Master_matrix>::_remove_last(pos_index columnIndex)
     idToPosition_.erase(it->second);
     RUM::map_.erase(it);
   }
-}
-
-template <class Master_matrix>
-inline Base_pairing<Master_matrix>& Base_pairing<Master_matrix>::operator=(Base_pairing<Master_matrix> other) 
-{
-  RUM::operator=(other);
-  barcode_.swap(other.barcode_);
-  deathToBar_.swap(other.deathToBar_);
-  idToPosition_.swap(other.idToPosition_);
-  std::swap(isReduced_, other.isReduced_);
-  return *this;
 }
 
 }  // namespace persistence_matrix

--- a/src/Persistence_matrix/include/gudhi/Persistence_matrix/base_pairing.h
+++ b/src/Persistence_matrix/include/gudhi/Persistence_matrix/base_pairing.h
@@ -65,18 +65,6 @@ class Base_pairing : public std::conditional<
    * @brief Default constructor.
    */
   Base_pairing();
-  /**
-   * @brief Copy constructor.
-   * 
-   * @param matrixToCopy Matrix to copy.
-   */
-  Base_pairing(const Base_pairing& matrixToCopy);
-  /**
-   * @brief Move constructor.
-   * 
-   * @param other Matrix to move.
-   */
-  Base_pairing(Base_pairing&& other) noexcept;
 
   /**
    * @brief Reduces the matrix stored in @ref Boundary_matrix and computes the corresponding barcode.
@@ -135,24 +123,6 @@ class Base_pairing : public std::conditional<
 
 template <class Master_matrix>
 inline Base_pairing<Master_matrix>::Base_pairing() : RUM(), isReduced_(false) 
-{}
-
-template <class Master_matrix>
-inline Base_pairing<Master_matrix>::Base_pairing(const Base_pairing& matrixToCopy)
-    : RUM(static_cast<const RUM&>(matrixToCopy)),
-      barcode_(matrixToCopy.barcode_),
-      deathToBar_(matrixToCopy.deathToBar_),
-      idToPosition_(matrixToCopy.idToPosition_),
-      isReduced_(matrixToCopy.isReduced_)
-{}
-
-template <class Master_matrix>
-inline Base_pairing<Master_matrix>::Base_pairing(Base_pairing<Master_matrix>&& other) noexcept
-    : RUM(std::move(static_cast<RUM&>(other))),
-      barcode_(std::move(other.barcode_)),
-      deathToBar_(std::move(other.deathToBar_)),
-      idToPosition_(std::move(other.idToPosition_)),
-      isReduced_(std::move(other.isReduced_)) 
 {}
 
 template <class Master_matrix>

--- a/src/Persistence_matrix/include/gudhi/Persistence_matrix/base_pairing.h
+++ b/src/Persistence_matrix/include/gudhi/Persistence_matrix/base_pairing.h
@@ -23,6 +23,8 @@
 #include <algorithm>
 #include <vector>
 
+#include "boundary_face_position_to_id_mapper.h"
+
 namespace Gudhi {
 namespace persistence_matrix {
 
@@ -46,7 +48,11 @@ struct Dummy_base_pairing {
  * @tparam Master_matrix An instanciation of @ref Matrix from which all types and options are deduced.
  */
 template <class Master_matrix>
-class Base_pairing 
+class Base_pairing : public std::conditional<
+                       Master_matrix::Option_list::has_removable_columns,
+                       Face_position_to_ID_mapper<typename Master_matrix::id_index, typename Master_matrix::pos_index>,
+                       Dummy_pos_mapper
+                    >::type
 {
  public:
   using Bar = typename Master_matrix::Bar;                            /**< Bar type. */
@@ -91,18 +97,32 @@ class Base_pairing
    * @brief Swap operator.
    */
   friend void swap(Base_pairing& pairing1, Base_pairing& pairing2) {
+    if constexpr (Master_matrix::Option_list::has_removable_columns) {
+      swap(static_cast<Face_position_to_ID_mapper<id_index, pos_index>&>(pairing1),
+           static_cast<Face_position_to_ID_mapper<id_index, pos_index>&>(pairing2));
+    }
     pairing1.barcode_.swap(pairing2.barcode_);
     pairing1.deathToBar_.swap(pairing2.deathToBar_);
+    pairing1.idToPosition_.swap(pairing2.idToPosition_);
     std::swap(pairing1.isReduced_, pairing2.isReduced_);
   }
 
  protected:
   using pos_index = typename Master_matrix::pos_index;
+  using id_index = typename Master_matrix::id_index;
   using dictionnary_type = typename Master_matrix::bar_dictionnary_type;
   using base_matrix = typename Master_matrix::Boundary_matrix_type;
+  using RUM = typename std::conditional<Master_matrix::Option_list::has_removable_columns,
+                                        Face_position_to_ID_mapper<id_index, pos_index>,
+                                        Dummy_pos_mapper
+                                       >::type;
 
   barcode_type barcode_;        /**< Bar container. */
   dictionnary_type deathToBar_; /**< Map from death index to bar index. */
+  /**
+   * @brief Map from face ID to face position. Only stores a pair if ID != position.
+   */
+  std::unordered_map<id_index, pos_index> idToPosition_;  //TODO: test other map types
   bool isReduced_;              /**< True if `_reduce()` was called. */
 
   void _reduce();
@@ -114,18 +134,24 @@ class Base_pairing
 };
 
 template <class Master_matrix>
-inline Base_pairing<Master_matrix>::Base_pairing() : isReduced_(false) 
+inline Base_pairing<Master_matrix>::Base_pairing() : RUM(), isReduced_(false) 
 {}
 
 template <class Master_matrix>
 inline Base_pairing<Master_matrix>::Base_pairing(const Base_pairing& matrixToCopy)
-    : barcode_(matrixToCopy.barcode_), deathToBar_(matrixToCopy.deathToBar_), isReduced_(matrixToCopy.isReduced_) 
+    : RUM(static_cast<const RUM&>(matrixToCopy)),
+      barcode_(matrixToCopy.barcode_),
+      deathToBar_(matrixToCopy.deathToBar_),
+      idToPosition_(matrixToCopy.idToPosition_),
+      isReduced_(matrixToCopy.isReduced_)
 {}
 
 template <class Master_matrix>
 inline Base_pairing<Master_matrix>::Base_pairing(Base_pairing<Master_matrix>&& other) noexcept
-    : barcode_(std::move(other.barcode_)),
+    : RUM(std::move(static_cast<RUM&>(other))),
+      barcode_(std::move(other.barcode_)),
       deathToBar_(std::move(other.deathToBar_)),
+      idToPosition_(std::move(other.idToPosition_)),
       isReduced_(std::move(other.isReduced_)) 
 {}
 
@@ -139,7 +165,6 @@ inline const typename Base_pairing<Master_matrix>::barcode_type& Base_pairing<Ma
 template <class Master_matrix>
 inline void Base_pairing<Master_matrix>::_reduce() 
 {
-  using id_index = typename Master_matrix::index;
   std::unordered_map<id_index, index> pivotsToColumn(_matrix()->get_number_of_columns());
 
   auto dim = _matrix()->get_max_dimension();
@@ -175,8 +200,10 @@ inline void Base_pairing<Master_matrix>::_reduce()
 
         if (pivot != static_cast<id_index>(-1)) {
           pivotsToColumn.emplace(pivot, i);
-          _matrix()->get_column(pivot).clear();
-          barcode_.emplace_back(pivot, i, dim - 1);
+          auto it = idToPosition_.find(pivot);
+          auto pivotColumnNumber = it == idToPosition_.end() ? pivot : it->second;
+          _matrix()->get_column(pivotColumnNumber).clear();
+          barcode_.emplace_back(pivotColumnNumber, i, dim - 1);
         } else {
           curr.clear();
           barcode_.emplace_back(i, -1, dim);
@@ -216,13 +243,21 @@ inline void Base_pairing<Master_matrix>::_remove_last(pos_index columnIndex)
       deathToBar_.erase(it);
     };
   }
+
+  auto it = RUM::map_.find(columnIndex);
+  if (it != RUM::map_.end()){
+    idToPosition_.erase(it->second);
+    RUM::map_.erase(it);
+  }
 }
 
 template <class Master_matrix>
 inline Base_pairing<Master_matrix>& Base_pairing<Master_matrix>::operator=(Base_pairing<Master_matrix> other) 
 {
+  RUM::operator=(other);
   barcode_.swap(other.barcode_);
   deathToBar_.swap(other.deathToBar_);
+  idToPosition_.swap(other.idToPosition_);
   std::swap(isReduced_, other.isReduced_);
   return *this;
 }

--- a/src/Persistence_matrix/include/gudhi/Persistence_matrix/boundary_face_position_to_id_mapper.h
+++ b/src/Persistence_matrix/include/gudhi/Persistence_matrix/boundary_face_position_to_id_mapper.h
@@ -1,0 +1,60 @@
+/*    This file is part of the Gudhi Library - https://gudhi.inria.fr/ - which is released under MIT.
+ *    See file LICENSE or go to https://gudhi.inria.fr/licensing/ for full license details.
+ *    Author(s):       Hannah Schreiber
+ *
+ *    Copyright (C) 2022-24 Inria
+ *
+ *    Modification(s):
+ *      - YYYY/MM Author: Description of the modification
+ */
+
+/**
+ * @file base_pairing.h
+ * @author Hannah Schreiber
+ * @brief Contains the @ref Gudhi::persistence_matrix::Base_pairing class and
+ * @ref Gudhi::persistence_matrix::Dummy_base_pairing structure.
+ */
+
+#ifndef PM_ID_POS_MAPPER_H
+#define PM_ID_POS_MAPPER_H
+
+#include <unordered_map>
+
+namespace Gudhi {
+namespace persistence_matrix {
+
+/**
+ * @private
+ * @ingroup persistence_matrix
+ *
+ * @brief Empty structure.
+ * Inherited instead of @ref Face_position_to_ID_mapper.
+ */
+struct Dummy_pos_mapper {
+  friend void swap([[maybe_unused]] Dummy_pos_mapper& d1, [[maybe_unused]] Dummy_pos_mapper& d2) {}
+};
+
+/**
+ * @private
+ * @ingroup persistence_matrix
+ *
+ * @brief Map from face position to face ID. Only stores a pair if ID != position and has_removable_column is true.
+ * 
+ * @tparam id_index @ref IDIdx index type
+ * @tparam pos_index @ref PosIdx index type
+ */
+template<typename id_index, typename pos_index>
+struct Face_position_to_ID_mapper {
+  using map_type = std::unordered_map<pos_index,id_index>; //TODO: test other map types
+
+  map_type map_;
+
+  friend void swap(Face_position_to_ID_mapper& mapper1, Face_position_to_ID_mapper& mapper2) {
+    mapper1.map_.swap(mapper2.map_);
+  }
+};
+
+}  // namespace persistence_matrix
+}  // namespace Gudhi
+
+#endif  // PM_ID_POS_MAPPER_H

--- a/src/Persistence_matrix/include/gudhi/Persistence_matrix/boundary_matrix.h
+++ b/src/Persistence_matrix/include/gudhi/Persistence_matrix/boundary_matrix.h
@@ -506,7 +506,7 @@ inline typename Boundary_matrix<Master_matrix>::index Boundary_matrix<Master_mat
     if (faceIndex != nextInsertIndex_){
       pair_opt::idToPosition_.emplace(faceIndex, nextInsertIndex_);
       if constexpr (Master_matrix::Option_list::has_removable_columns){
-        pair_opt::RUM::map_.emplace(nextInsertIndex_, faceIndex);
+        pair_opt::PIDM::map_.emplace(nextInsertIndex_, faceIndex);
       }
     }
   }

--- a/src/Persistence_matrix/include/gudhi/Persistence_matrix/boundary_matrix.h
+++ b/src/Persistence_matrix/include/gudhi/Persistence_matrix/boundary_matrix.h
@@ -474,14 +474,16 @@ inline typename Boundary_matrix<Master_matrix>::index Boundary_matrix<Master_mat
 
   //updates container sizes
   if constexpr (Master_matrix::Option_list::has_row_access && !Master_matrix::Option_list::has_removable_rows) {
-    id_index pivot;
-    if constexpr (Master_matrix::Option_list::is_z2) {
-      pivot = *std::prev(boundary.end());
-    } else {
-      pivot = std::prev(boundary.end())->first;
+    if (boundary.size() != 0){
+      id_index pivot;
+      if constexpr (Master_matrix::Option_list::is_z2) {
+        pivot = *std::prev(boundary.end());
+      } else {
+        pivot = std::prev(boundary.end())->first;
+      }
+      //row container
+      if (ra_opt::rows_->size() <= pivot) ra_opt::rows_->resize(pivot + 1);
     }
-    //row container
-    if (ra_opt::rows_->size() <= pivot) ra_opt::rows_->resize(pivot + 1);
   }
 
   //row swap map containers
@@ -495,6 +497,16 @@ inline typename Boundary_matrix<Master_matrix>::index Boundary_matrix<Master_mat
       for (index i = swap_opt::indexToRow_.size(); i <= faceIndex; ++i) {
         swap_opt::indexToRow_.push_back(i);
         swap_opt::rowToIndex_.push_back(i);
+      }
+    }
+  }
+
+  //maps for possible shifting between column content and position indices used for birth events
+  if constexpr (activePairingOption){
+    if (faceIndex != nextInsertIndex_){
+      pair_opt::idToPosition_.emplace(faceIndex, nextInsertIndex_);
+      if constexpr (Master_matrix::Option_list::has_removable_columns){
+        pair_opt::RUM::map_.emplace(nextInsertIndex_, faceIndex);
       }
     }
   }

--- a/src/Persistence_matrix/include/gudhi/Persistence_matrix/chain_vine_swap.h
+++ b/src/Persistence_matrix/include/gudhi/Persistence_matrix/chain_vine_swap.h
@@ -84,6 +84,7 @@ class Chain_barcode_swap : public Chain_pairing<Master_matrix>
  public:
   using id_index = typename Master_matrix::id_index;    /**< @ref IDIdx index type. */
   using pos_index = typename Master_matrix::pos_index;  /**< @ref PosIdx index type. */
+  //CP = Chain Pairing
   using CP = Chain_pairing<Master_matrix>;
 
   /**

--- a/src/Persistence_matrix/include/gudhi/Persistence_matrix/overlay_ididx_to_matidx.h
+++ b/src/Persistence_matrix/include/gudhi/Persistence_matrix/overlay_ididx_to_matidx.h
@@ -622,6 +622,7 @@ class Id_to_index_overlay
 
   void _initialize_map(unsigned int size);
   index _id_to_index(id_index id) const;
+  index& _id_to_index(id_index id);
 };
 
 template <class Matrix_type, class Master_matrix_type>
@@ -640,7 +641,7 @@ inline Id_to_index_overlay<Matrix_type, Master_matrix_type>::Id_to_index_overlay
   _initialize_map(orderedBoundaries.size());
   if constexpr (Master_matrix_type::Option_list::is_of_boundary_type) {
     for (unsigned int i = 0; i < orderedBoundaries.size(); i++) {
-      idToIndex_->operator[](i) = i;
+      _id_to_index(i) = i;
     }
   }
 }
@@ -678,7 +679,7 @@ inline Id_to_index_overlay<Matrix_type, Master_matrix_type>::Id_to_index_overlay
   _initialize_map(orderedBoundaries.size());
   if constexpr (Master_matrix_type::Option_list::is_of_boundary_type) {
     for (unsigned int i = 0; i < orderedBoundaries.size(); i++) {
-      idToIndex_->operator[](i) = i;
+      _id_to_index(i) = i;
     }
   }
 }
@@ -739,7 +740,7 @@ inline void Id_to_index_overlay<Matrix_type, Master_matrix_type>::insert_boundar
       if (idToIndex_->size() == nextIndex_) {
         idToIndex_->push_back(nextIndex_);
       } else {
-        idToIndex_->operator[](nextIndex_) = nextIndex_;
+        _id_to_index(nextIndex_) = nextIndex_;
       }
     }
     ++nextIndex_;
@@ -756,7 +757,7 @@ inline void Id_to_index_overlay<Matrix_type, Master_matrix_type>::insert_boundar
     GUDHI_CHECK(idToIndex_->find(faceIndex) == idToIndex_->end(),
                 std::invalid_argument("Id_to_index_overlay::insert_boundary - Index for simplex already chosen!"));
   } else {
-    GUDHI_CHECK((idToIndex_->size() <= faceIndex || idToIndex_->operator[](faceIndex) == static_cast<index>(-1)),
+    GUDHI_CHECK((idToIndex_->size() <= faceIndex || _id_to_index(faceIndex) == static_cast<index>(-1)),
                 std::invalid_argument("Id_to_index_overlay::insert_boundary - Index for simplex already chosen!"));
   }
   matrix_.insert_boundary(faceIndex, boundary, dim);
@@ -767,7 +768,7 @@ inline void Id_to_index_overlay<Matrix_type, Master_matrix_type>::insert_boundar
       if (idToIndex_->size() <= faceIndex) {
         idToIndex_->resize(faceIndex + 1, -1);
       }
-      idToIndex_->operator[](faceIndex) = nextIndex_;
+      _id_to_index(faceIndex) = nextIndex_;
     }
     ++nextIndex_;
   }
@@ -804,7 +805,7 @@ inline void Id_to_index_overlay<Matrix_type, Master_matrix_type>::remove_maximal
       }
     } else {
       for (id_index i = 0; i < idToIndex_->size(); ++i) {
-        if (idToIndex_->operator[](i) != static_cast<index>(-1)) indexToID[idToIndex_->operator[](i)] = i;
+        if (_id_to_index(i) != static_cast<index>(-1)) indexToID[_id_to_index(i)] = i;
       }
     }
     --nextIndex_;
@@ -819,7 +820,7 @@ inline void Id_to_index_overlay<Matrix_type, Master_matrix_type>::remove_maximal
     if constexpr (Master_matrix_type::Option_list::has_map_column_container) {
       idToIndex_->erase(faceID);
     } else {
-      idToIndex_->operator[](faceID) = -1;
+      _id_to_index(faceID) = -1;
     }
   } else {
     matrix_.remove_maximal_face(faceID);
@@ -853,10 +854,10 @@ inline void Id_to_index_overlay<Matrix_type, Master_matrix_type>::remove_last()
       idToIndex_->erase(it);
     } else {
       index id = idToIndex_->size() - 1;
-      while (idToIndex_->operator[](id) == static_cast<index>(-1)) --id;  // should always stop before reaching -1
-      GUDHI_CHECK(idToIndex_->operator[](id) == nextIndex_,
+      while (_id_to_index(id) == static_cast<index>(-1)) --id;  // should always stop before reaching -1
+      GUDHI_CHECK(_id_to_index(id) == nextIndex_,
                   std::logic_error("Id_to_index_overlay::remove_last - Indexation problem."));
-      idToIndex_->operator[](id) = -1;
+      _id_to_index(id) = -1;
     }
   }
 }
@@ -1086,6 +1087,13 @@ Id_to_index_overlay<Matrix_type, Master_matrix_type>::_id_to_index(id_index id) 
   } else {
     return idToIndex_->operator[](id);
   }
+}
+
+template <class Matrix_type, class Master_matrix_type>
+inline typename Id_to_index_overlay<Matrix_type, Master_matrix_type>::index&
+Id_to_index_overlay<Matrix_type, Master_matrix_type>::_id_to_index(id_index id)
+{
+  return idToIndex_->operator[](id);  //for maps, the entry is created if not existing as needed in the constructors
 }
 
 }  // namespace persistence_matrix

--- a/src/Persistence_matrix/include/gudhi/Persistence_matrix/overlay_ididx_to_matidx.h
+++ b/src/Persistence_matrix/include/gudhi/Persistence_matrix/overlay_ididx_to_matidx.h
@@ -756,7 +756,7 @@ inline void Id_to_index_overlay<Matrix_type, Master_matrix_type>::insert_boundar
     GUDHI_CHECK(idToIndex_->find(faceIndex) == idToIndex_->end(),
                 std::invalid_argument("Id_to_index_overlay::insert_boundary - Index for simplex already chosen!"));
   } else {
-    GUDHI_CHECK((idToIndex_->size() <= faceIndex || idToIndex_[faceIndex] == static_cast<index>(-1)),
+    GUDHI_CHECK((idToIndex_->size() <= faceIndex || idToIndex_->operator[](faceIndex) == static_cast<index>(-1)),
                 std::invalid_argument("Id_to_index_overlay::insert_boundary - Index for simplex already chosen!"));
   }
   matrix_.insert_boundary(faceIndex, boundary, dim);

--- a/src/Persistence_matrix/include/gudhi/Persistence_matrix/ru_matrix.h
+++ b/src/Persistence_matrix/include/gudhi/Persistence_matrix/ru_matrix.h
@@ -536,7 +536,7 @@ inline void RU_matrix<Master_matrix>::insert_boundary(id_index faceIndex,
     if (faceIndex != nextEventIndex_){
       pair_opt::idToPosition_.emplace(faceIndex, nextEventIndex_);
       if constexpr (Master_matrix::Option_list::has_removable_columns){
-        pair_opt::RUM::map_.emplace(nextEventIndex_, faceIndex);
+        pair_opt::PIDM::map_.emplace(nextEventIndex_, faceIndex);
       }
     }
   }

--- a/src/Persistence_matrix/include/gudhi/Persistence_matrix/ru_pairing.h
+++ b/src/Persistence_matrix/include/gudhi/Persistence_matrix/ru_pairing.h
@@ -54,7 +54,8 @@ class RU_pairing : public std::conditional<
  protected:
   using pos_index = typename Master_matrix::pos_index;
   using id_index = typename Master_matrix::id_index;
-  using RUM = typename std::conditional<Master_matrix::Option_list::has_removable_columns,
+  //PIDM = Position to ID Map
+  using PIDM = typename std::conditional<Master_matrix::Option_list::has_removable_columns,
                                         Face_position_to_ID_mapper<id_index, pos_index>,
                                         Dummy_pos_mapper
                                        >::type;
@@ -65,7 +66,7 @@ class RU_pairing : public std::conditional<
   /**
    * @brief Default constructor.
    */
-  RU_pairing() : RUM() {}
+  RU_pairing() : PIDM() {}
 
   /**
    * @brief Returns the current barcode which is maintained at any insertion, removal or vine swap.
@@ -78,7 +79,7 @@ class RU_pairing : public std::conditional<
    * @brief Swap operator.
    */
   friend void swap(RU_pairing& pairing1, RU_pairing& pairing2) {
-    swap(static_cast<RUM&>(pairing1), static_cast<RUM&>(pairing2));
+    swap(static_cast<PIDM&>(pairing1), static_cast<PIDM&>(pairing2));
     pairing1.barcode_.swap(pairing2.barcode_);
     pairing1.indexToBar_.swap(pairing2.indexToBar_);
     pairing1.idToPosition_.swap(pairing2.idToPosition_);
@@ -140,10 +141,10 @@ class RU_pairing : public std::conditional<
       indexToBar_.erase(it);
     }
 
-    auto it = RUM::map_.find(eventIndex);
-    if (it != RUM::map_.end()){
+    auto it = PIDM::map_.find(eventIndex);
+    if (it != PIDM::map_.end()){
       idToPosition_.erase(it->second);
-      RUM::map_.erase(it);
+      PIDM::map_.erase(it);
     }
   }
 };

--- a/src/Persistence_matrix/include/gudhi/Persistence_matrix/ru_pairing.h
+++ b/src/Persistence_matrix/include/gudhi/Persistence_matrix/ru_pairing.h
@@ -18,7 +18,9 @@
 #ifndef PM_RU_PAIRING_H
 #define PM_RU_PAIRING_H
 
-#include <utility>  //std::move
+#include <unordered_map>
+
+#include "boundary_face_position_to_id_mapper.h"
 
 namespace Gudhi {
 namespace persistence_matrix {
@@ -43,81 +45,108 @@ struct Dummy_ru_pairing {
  * @tparam Master_matrix An instanciation of @ref Matrix from which all types and options are deduced.
  */
 template <class Master_matrix>
-class RU_pairing 
+class RU_pairing : public std::conditional<
+                       Master_matrix::Option_list::has_removable_columns,
+                       Face_position_to_ID_mapper<typename Master_matrix::id_index, typename Master_matrix::pos_index>,
+                       Dummy_pos_mapper
+                    >::type
 {
+ protected:
+  using pos_index = typename Master_matrix::pos_index;
+  using id_index = typename Master_matrix::id_index;
+  using RUM = typename std::conditional<Master_matrix::Option_list::has_removable_columns,
+                                        Face_position_to_ID_mapper<id_index, pos_index>,
+                                        Dummy_pos_mapper
+                                       >::type;
+
  public:
   using barcode_type = typename Master_matrix::barcode_type;  /**< Barcode type. */
 
   /**
    * @brief Default constructor.
    */
-  RU_pairing();
-  /**
-   * @brief Copy constructor.
-   * 
-   * @param matrixToCopy Matrix to copy.
-   */
-  RU_pairing(const RU_pairing& matrixToCopy);
-  /**
-   * @brief Move constructor.
-   * 
-   * @param other Matrix to move.
-   */
-  RU_pairing(RU_pairing&& other) noexcept;
+  RU_pairing() : RUM() {}
 
   /**
    * @brief Returns the current barcode which is maintained at any insertion, removal or vine swap.
    * 
    * @return Const reference to the barcode.
    */
-  const barcode_type& get_current_barcode() const;
+  const barcode_type& get_current_barcode() const { return barcode_; }
 
-  /**
-   * @brief Assign operator.
-   */
-  RU_pairing& operator=(RU_pairing other);
   /**
    * @brief Swap operator.
    */
   friend void swap(RU_pairing& pairing1, RU_pairing& pairing2) {
+    swap(static_cast<RUM&>(pairing1), static_cast<RUM&>(pairing2));
     pairing1.barcode_.swap(pairing2.barcode_);
     pairing1.indexToBar_.swap(pairing2.indexToBar_);
+    pairing1.idToPosition_.swap(pairing2.idToPosition_);
   }
 
  protected:
+  using dimension_type = typename Master_matrix::dimension_type;
   using dictionnary_type = typename Master_matrix::bar_dictionnary_type;
 
   barcode_type barcode_;        /**< Bar container. */
   dictionnary_type indexToBar_; /**< Map from @ref MatIdx index to bar index. */
+  /**
+   * @brief Map from face ID to face position. Only stores a pair if ID != position.
+   */
+  std::unordered_map<id_index, pos_index> idToPosition_;  //TODO: test other map types
+
+  void _update_barcode(id_index birthPivot, pos_index death) {
+    auto it = idToPosition_.find(birthPivot);
+    pos_index pivotBirth = it == idToPosition_.end() ? birthPivot : it->second;
+    if constexpr (Master_matrix::hasFixedBarcode || !Master_matrix::Option_list::has_removable_columns) {
+      barcode_[indexToBar_[pivotBirth]].death = death;
+      indexToBar_.push_back(indexToBar_[pivotBirth]);
+    } else {
+      auto& barIt = indexToBar_.at(pivotBirth);
+      barIt->death = death;
+      indexToBar_.try_emplace(death, barIt);  // list so iterators are stable
+    }
+  }
+
+  void _add_bar(dimension_type dim, pos_index birth) {
+    barcode_.emplace_back(birth, -1, dim);
+    if constexpr (Master_matrix::hasFixedBarcode || !Master_matrix::Option_list::has_removable_columns) {
+      indexToBar_.push_back(barcode_.size() - 1);
+    } else {
+      indexToBar_.try_emplace(birth, --barcode_.end());
+    }
+  }
+
+  void _remove_last(pos_index eventIndex) {
+    static_assert(Master_matrix::Option_list::has_removable_columns, "_remove_last not available.");
+
+    if constexpr (Master_matrix::hasFixedBarcode) {
+      auto& bar = barcode_[indexToBar_[eventIndex]];
+      if (bar.death == static_cast<pos_index>(-1)) {  // birth
+        barcode_.pop_back();  // sorted by birth and eventIndex has to be the highest one
+      } else {                // death
+        bar.death = -1;
+      };
+      indexToBar_.pop_back();
+    } else {  // birth order eventually shuffled by vine updates. No sort possible to keep the matchings.
+      auto it = indexToBar_.find(eventIndex);
+      typename barcode_type::iterator bar = it->second;
+
+      if (bar->death == static_cast<pos_index>(-1))
+        barcode_.erase(bar);
+      else
+        bar->death = -1;
+
+      indexToBar_.erase(it);
+    }
+
+    auto it = RUM::map_.find(eventIndex);
+    if (it != RUM::map_.end()){
+      idToPosition_.erase(it->second);
+      RUM::map_.erase(it);
+    }
+  }
 };
-
-template <class Master_matrix>
-inline RU_pairing<Master_matrix>::RU_pairing() 
-{}
-
-template <class Master_matrix>
-inline RU_pairing<Master_matrix>::RU_pairing(const RU_pairing& matrixToCopy)
-    : barcode_(matrixToCopy.barcode_), indexToBar_(matrixToCopy.indexToBar_) 
-{}
-
-template <class Master_matrix>
-inline RU_pairing<Master_matrix>::RU_pairing(RU_pairing<Master_matrix>&& other) noexcept
-    : barcode_(std::move(other.barcode_)), indexToBar_(std::move(other.indexToBar_)) 
-{}
-
-template <class Master_matrix>
-inline const typename RU_pairing<Master_matrix>::barcode_type& RU_pairing<Master_matrix>::get_current_barcode() const 
-{
-  return barcode_;
-}
-
-template <class Master_matrix>
-inline RU_pairing<Master_matrix>& RU_pairing<Master_matrix>::operator=(RU_pairing<Master_matrix> other) 
-{
-  barcode_.swap(other.barcode_);
-  indexToBar_.swap(other.indexToBar_);
-  return *this;
-}
 
 }  // namespace persistence_matrix
 }  // namespace Gudhi

--- a/src/Persistence_matrix/include/gudhi/Persistence_matrix/ru_vine_swap.h
+++ b/src/Persistence_matrix/include/gudhi/Persistence_matrix/ru_vine_swap.h
@@ -527,7 +527,7 @@ template <class Master_matrix>
 inline constexpr auto& RU_vine_swap<Master_matrix>::_positionToRowIdx()
 {
   if constexpr (Master_matrix::Option_list::has_column_pairings && Master_matrix::Option_list::has_removable_columns)
-    return RUP::RUM::map_;
+    return RUP::PIDM::map_;
   else
     return RUM::map_;
 }

--- a/src/Persistence_matrix/include/gudhi/Persistence_matrix/ru_vine_swap.h
+++ b/src/Persistence_matrix/include/gudhi/Persistence_matrix/ru_vine_swap.h
@@ -22,10 +22,10 @@
 #include <utility>      //std::move
 #include <type_traits>  //std::conditional
 #include <cassert>
-#include <vector>
 #include <stdexcept>    //std::invalid_argument
 
 #include "ru_pairing.h"
+#include "boundary_face_position_to_id_mapper.h"
 
 namespace Gudhi {
 namespace persistence_matrix {
@@ -62,7 +62,13 @@ template <class Master_matrix>
 class RU_vine_swap : public std::conditional<Master_matrix::Option_list::has_column_pairings, 
                                              RU_pairing<Master_matrix>,
                                              Dummy_ru_vine_pairing
-                                            >::type 
+                                            >::type,
+                     public std::conditional<Master_matrix::Option_list::has_column_pairings &&
+                                                Master_matrix::Option_list::has_removable_columns, 
+                                             Dummy_pos_mapper,
+                                             Face_position_to_ID_mapper<typename Master_matrix::id_index,
+                                                                        typename Master_matrix::pos_index>
+                                            >::type
 {
  public:
   using index = typename Master_matrix::index;          /**< @ref MatIdx index type. */
@@ -120,20 +126,25 @@ class RU_vine_swap : public std::conditional<Master_matrix::Option_list::has_col
     if constexpr (Master_matrix::Option_list::has_column_pairings) {
       swap(static_cast<RU_pairing<Master_matrix>&>(swap1), static_cast<RU_pairing<Master_matrix>&>(swap2));
     }
-    swap1.positionToRowIdx_.swap(swap2.positionToRowIdx_);
+    if (!Master_matrix::Option_list::has_column_pairings || !Master_matrix::Option_list::has_removable_columns) {
+      swap(static_cast<Face_position_to_ID_mapper<id_index, pos_index>&>(swap1),
+           static_cast<Face_position_to_ID_mapper<id_index, pos_index>&>(swap2));
+    }
   }
 
  protected:
-  // only usefull when simplex id does not corresponds to position, so feels kinda useless most of the time...
-  // TODO: as it takes up some non trivial memory, see if this should not be optional
-  // or only remember the positions with a difference. but then a map is needed, ie find instead of [].
-  std::vector<id_index> positionToRowIdx_;  /**< Map from @ref PosIdx index to row index. */
-
- private:
   using RUP = typename std::conditional<Master_matrix::Option_list::has_column_pairings, 
                                         RU_pairing<Master_matrix>,
                                         Dummy_ru_vine_pairing
                                        >::type;
+  using RUM = typename std::conditional<Master_matrix::Option_list::has_column_pairings &&
+                                            Master_matrix::Option_list::has_removable_columns, 
+                                         Dummy_pos_mapper,
+                                         Face_position_to_ID_mapper<id_index,pos_index>
+                                       >::type;
+  constexpr auto& _positionToRowIdx();
+
+ private:
   using ru_matrix = typename Master_matrix::RU_matrix_type;
 
   bool _is_paired(index columnIndex);
@@ -154,22 +165,26 @@ class RU_vine_swap : public std::conditional<Master_matrix::Option_list::has_col
   pos_index _get_death(index simplexIndex);
   pos_index _get_birth(index simplexIndex);
 
+  id_index _get_row_id_from_position(pos_index position);
+
   constexpr ru_matrix* _matrix() { return static_cast<ru_matrix*>(this); }
   constexpr const ru_matrix* _matrix() const { return static_cast<const ru_matrix*>(this); }
 };
 
 template <class Master_matrix>
-inline RU_vine_swap<Master_matrix>::RU_vine_swap() : RUP() 
+inline RU_vine_swap<Master_matrix>::RU_vine_swap() : RUP(), RUM()
 {}
 
 template <class Master_matrix>
 inline RU_vine_swap<Master_matrix>::RU_vine_swap(const RU_vine_swap& matrixToCopy)
-    : RUP(static_cast<const RUP&>(matrixToCopy)), positionToRowIdx_(matrixToCopy.positionToRowIdx_) 
+    : RUP(static_cast<const RUP&>(matrixToCopy)),
+      RUM(static_cast<const RUM&>(matrixToCopy))
 {}
 
 template <class Master_matrix>
 inline RU_vine_swap<Master_matrix>::RU_vine_swap(RU_vine_swap<Master_matrix>&& other) noexcept
-    : RUP(std::move(static_cast<RUP&>(other))), positionToRowIdx_(std::move(other.positionToRowIdx_)) 
+    : RUP(std::move(static_cast<RUP&>(other))),
+      RUM(std::move(static_cast<RUM&>(other)))
 {}
 
 template <class Master_matrix>
@@ -182,7 +197,7 @@ inline bool RU_vine_swap<Master_matrix>::vine_swap_with_z_eq_1_case(pos_index in
   bool iiIsPositive = _matrix()->reducedMatrixR_.is_zero_column(index + 1);
 
   if (iIsPositive && iiIsPositive) {
-    _matrix()->mirrorMatrixU_.zero_cell(index, positionToRowIdx_[index + 1]);
+    _matrix()->mirrorMatrixU_.zero_cell(index, _get_row_id_from_position(index + 1));
     return _positive_vine_swap(index);
   } else if (!iIsPositive && !iiIsPositive) {
     return _negative_vine_swap(index);
@@ -209,14 +224,14 @@ inline bool RU_vine_swap<Master_matrix>::vine_swap(pos_index index)
       _swap_at_index(index);
       return true;
     }
-    if (!_matrix()->mirrorMatrixU_.is_zero_cell(index, positionToRowIdx_[index + 1])) {
-      _matrix()->mirrorMatrixU_.zero_cell(index, positionToRowIdx_[index + 1]);
+    if (!_matrix()->mirrorMatrixU_.is_zero_cell(index, _get_row_id_from_position(index + 1))) {
+      _matrix()->mirrorMatrixU_.zero_cell(index, _get_row_id_from_position(index + 1));
     }
     return _positive_vine_swap(index);
   } else if (!iIsPositive && !iiIsPositive) {
     if (_matrix()->reducedMatrixR_.get_column_dimension(index) !=
             _matrix()->reducedMatrixR_.get_column_dimension(index + 1) ||
-        _matrix()->mirrorMatrixU_.is_zero_cell(index, positionToRowIdx_[index + 1])) {
+        _matrix()->mirrorMatrixU_.is_zero_cell(index, _get_row_id_from_position(index + 1))) {
       _negative_transpose(index);
       _swap_at_index(index);
       return true;
@@ -225,7 +240,7 @@ inline bool RU_vine_swap<Master_matrix>::vine_swap(pos_index index)
   } else if (iIsPositive && !iiIsPositive) {
     if (_matrix()->reducedMatrixR_.get_column_dimension(index) !=
             _matrix()->reducedMatrixR_.get_column_dimension(index + 1) ||
-        _matrix()->mirrorMatrixU_.is_zero_cell(index, positionToRowIdx_[index + 1])) {
+        _matrix()->mirrorMatrixU_.is_zero_cell(index, _get_row_id_from_position(index + 1))) {
       _positive_negative_transpose(index);
       _swap_at_index(index);
       return true;
@@ -234,7 +249,7 @@ inline bool RU_vine_swap<Master_matrix>::vine_swap(pos_index index)
   } else {
     if (_matrix()->reducedMatrixR_.get_column_dimension(index) !=
             _matrix()->reducedMatrixR_.get_column_dimension(index + 1) ||
-        _matrix()->mirrorMatrixU_.is_zero_cell(index, positionToRowIdx_[index + 1])) {
+        _matrix()->mirrorMatrixU_.is_zero_cell(index, _get_row_id_from_position(index + 1))) {
       _negative_positive_transpose(index);
       _swap_at_index(index);
       return true;
@@ -247,7 +262,7 @@ template <class Master_matrix>
 inline RU_vine_swap<Master_matrix>& RU_vine_swap<Master_matrix>::operator=(RU_vine_swap<Master_matrix> other) 
 {
   RUP::operator=(other);
-  positionToRowIdx_.swap(other.positionToRowIdx_);
+  RUM::operator=(other);
   return *this;
 }
 
@@ -270,12 +285,14 @@ inline bool RU_vine_swap<Master_matrix>::_is_paired(index columnIndex)
 }
 
 template <class Master_matrix>
-inline void RU_vine_swap<Master_matrix>::_swap_at_index(index columnIndex) 
+inline void RU_vine_swap<Master_matrix>::_swap_at_index(index columnIndex)
 {
   _matrix()->reducedMatrixR_.swap_columns(columnIndex, columnIndex + 1);
-  _matrix()->reducedMatrixR_.swap_rows(positionToRowIdx_[columnIndex], positionToRowIdx_[columnIndex + 1]);
+  _matrix()->reducedMatrixR_.swap_rows(_get_row_id_from_position(columnIndex),
+                                       _get_row_id_from_position(columnIndex + 1));
   _matrix()->mirrorMatrixU_.swap_columns(columnIndex, columnIndex + 1);
-  _matrix()->mirrorMatrixU_.swap_rows(positionToRowIdx_[columnIndex], positionToRowIdx_[columnIndex + 1]);
+  _matrix()->mirrorMatrixU_.swap_rows(_get_row_id_from_position(columnIndex),
+                                      _get_row_id_from_position(columnIndex + 1));
 }
 
 template <class Master_matrix>
@@ -371,7 +388,7 @@ inline bool RU_vine_swap<Master_matrix>::_positive_vine_swap(index columnIndex)
   const pos_index iiDeath = _get_death(columnIndex + 1);
 
   if (iDeath != static_cast<pos_index>(-1) && iiDeath != static_cast<pos_index>(-1) &&
-      !(_matrix()->reducedMatrixR_.is_zero_cell(iiDeath, positionToRowIdx_[columnIndex]))) {
+      !(_matrix()->reducedMatrixR_.is_zero_cell(iiDeath, _get_row_id_from_position(columnIndex)))) {
     if (iDeath < iiDeath) {
       _swap_at_index(columnIndex);
       _add_to(iDeath, iiDeath);
@@ -387,7 +404,7 @@ inline bool RU_vine_swap<Master_matrix>::_positive_vine_swap(index columnIndex)
   _swap_at_index(columnIndex);
 
   if (iDeath != static_cast<pos_index>(-1) || iiDeath == static_cast<pos_index>(-1) ||
-      _matrix()->reducedMatrixR_.is_zero_cell(iiDeath, positionToRowIdx_[columnIndex + 1])) {
+      _matrix()->reducedMatrixR_.is_zero_cell(iiDeath, _get_row_id_from_position(columnIndex + 1))) {
     _positive_transpose(columnIndex);
     return true;
   }
@@ -416,7 +433,7 @@ inline bool RU_vine_swap<Master_matrix>::_negative_vine_swap(index columnIndex)
 template <class Master_matrix>
 inline bool RU_vine_swap<Master_matrix>::_positive_negative_vine_swap(index columnIndex) 
 {
-  _matrix()->mirrorMatrixU_.zero_cell(columnIndex, positionToRowIdx_[columnIndex + 1]);
+  _matrix()->mirrorMatrixU_.zero_cell(columnIndex, _get_row_id_from_position(columnIndex + 1));
 
   _swap_at_index(columnIndex);
   _positive_negative_transpose(columnIndex);
@@ -494,6 +511,23 @@ inline typename RU_vine_swap<Master_matrix>::pos_index RU_vine_swap<Master_matri
   } else {
     return _matrix()->reducedMatrixR_.get_pivot(negativeSimplexIndex);
   }
+}
+
+template <class Master_matrix>
+inline typename RU_vine_swap<Master_matrix>::id_index RU_vine_swap<Master_matrix>::_get_row_id_from_position(
+    pos_index position)
+{
+  auto it = _positionToRowIdx().find(position);
+  return it == _positionToRowIdx().end() ? position : it->second;
+}
+
+template <class Master_matrix>
+inline constexpr auto& RU_vine_swap<Master_matrix>::_positionToRowIdx()
+{
+  if constexpr (Master_matrix::Option_list::has_column_pairings && Master_matrix::Option_list::has_removable_columns)
+    return RUP::RUM::map_;
+  else
+    return RUM::map_;
 }
 
 }  // namespace persistence_matrix

--- a/src/Persistence_matrix/include/gudhi/Persistence_matrix/ru_vine_swap.h
+++ b/src/Persistence_matrix/include/gudhi/Persistence_matrix/ru_vine_swap.h
@@ -133,10 +133,12 @@ class RU_vine_swap : public std::conditional<Master_matrix::Option_list::has_col
   }
 
  protected:
+  //RUP = RU matrix Pairing
   using RUP = typename std::conditional<Master_matrix::Option_list::has_column_pairings, 
                                         RU_pairing<Master_matrix>,
                                         Dummy_ru_vine_pairing
                                        >::type;
+  //RUM = RU matrix position to id Map
   using RUM = typename std::conditional<Master_matrix::Option_list::has_column_pairings &&
                                             Master_matrix::Option_list::has_removable_columns, 
                                          Dummy_pos_mapper,

--- a/src/Persistence_matrix/include/gudhi/matrix.h
+++ b/src/Persistence_matrix/include/gudhi/matrix.h
@@ -786,7 +786,7 @@ class Matrix {
    * @return If it is a @ref chainmatrix "chain matrix", the method returns the @ref MatIdx indices of the unpaired
    * chains used to reduce the boundary. Otherwise, nothing.
    */
-  template <class Boundary_type>
+  template <class Boundary_type = boundary_type>
   insertion_return_type insert_boundary(id_index faceIndex, const Boundary_type& boundary, dimension_type dim = -1);
 
   /**

--- a/src/Persistence_matrix/include/gudhi/matrix.h
+++ b/src/Persistence_matrix/include/gudhi/matrix.h
@@ -573,7 +573,7 @@ class Matrix {
    * to be consecutive and starting with 0 (an empty boundary is interpreted as a vertex boundary and not as a non
    * existing simplex). All dimensions up to the maximal dimension of interest have to be present. If only a higher
    * dimension is of interest and not everything should be stored, then use the @ref insert_boundary method instead
-   * (after creating the matrix with the @ref Matrix(int numberOfColumns, characteristic_type characteristic)
+   * (after creating the matrix with the @ref Matrix(unsigned int numberOfColumns, characteristic_type characteristic)
    * constructor preferably). If the persistence barcode has to be computed from this matrix, the simplices are also
    * assumed to be ordered by appearance order in the filtration. Also, depending of the options, the matrix is
    * eventually reduced on the fly or converted into a chain complex base, so the new matrix is not always identical to
@@ -593,7 +593,7 @@ class Matrix {
    * @ref set_characteristic before calling for the first time a method needing it. Ignored if
    * @ref PersistenceMatrixOptions::is_z2 is true.
    */
-  Matrix(int numberOfColumns, characteristic_type characteristic = static_cast<characteristic_type>(-1));
+  Matrix(unsigned int numberOfColumns, characteristic_type characteristic = static_cast<characteristic_type>(-1));
   /**
    * @brief Constructs a new empty matrix with the given comparator functions. Only available when those comparators
    * are necessary.
@@ -1427,7 +1427,7 @@ inline Matrix<PersistenceMatrixOptions>::Matrix(const std::vector<Container_type
 }
 
 template <class PersistenceMatrixOptions>
-inline Matrix<PersistenceMatrixOptions>::Matrix(int numberOfColumns, characteristic_type characteristic)
+inline Matrix<PersistenceMatrixOptions>::Matrix(unsigned int numberOfColumns, characteristic_type characteristic)
     : colSettings_(new Column_settings(characteristic)),
       matrix_(numberOfColumns, colSettings_) 
 {

--- a/src/Persistence_matrix/test/Persistence_matrix_matrix_tests_z2_boundary.cpp
+++ b/src/Persistence_matrix/test/Persistence_matrix_matrix_tests_z2_boundary.cpp
@@ -64,6 +64,9 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(Boundary_matrix_z2_max_dimension, Matrix, max_dim_
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(Boundary_matrix_z2_operation, Matrix, full_matrices) { test_base_operation<Matrix>(); }
 
-BOOST_AUTO_TEST_CASE_TEMPLATE(Boundary_matrix_z2_barcode, Matrix, barcode_matrices) { test_barcode<Matrix>(); }
+BOOST_AUTO_TEST_CASE_TEMPLATE(Boundary_matrix_z2_barcode, Matrix, barcode_matrices) { 
+  test_barcode<Matrix>();
+  test_shifted_barcode<Matrix>();
+}
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(Boundary_matrix_z2_swaps, Matrix, swap_matrices) { test_base_swaps<Matrix>(); }

--- a/src/Persistence_matrix/test/Persistence_matrix_matrix_tests_z2_chain_barcode.cpp
+++ b/src/Persistence_matrix/test/Persistence_matrix_matrix_tests_z2_chain_barcode.cpp
@@ -87,4 +87,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(Chain_matrix_z2_barcode_operation, Matrix, full_ma
   test_chain_operation<Matrix>(m);
 }
 
-BOOST_AUTO_TEST_CASE_TEMPLATE(Chain_matrix_z2_barcode_barcode, Matrix, full_matrices) { test_barcode<Matrix>(); }
+BOOST_AUTO_TEST_CASE_TEMPLATE(Chain_matrix_z2_barcode_barcode, Matrix, full_matrices) {
+  test_barcode<Matrix>();
+  test_shifted_barcode<Matrix>();
+}

--- a/src/Persistence_matrix/test/Persistence_matrix_matrix_tests_z2_chain_rep.cpp
+++ b/src/Persistence_matrix/test/Persistence_matrix_matrix_tests_z2_chain_rep.cpp
@@ -86,7 +86,10 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(Chain_matrix_z2_rep_operation, Matrix, full_matric
   test_chain_operation<Matrix>(m);
 }
 
-BOOST_AUTO_TEST_CASE_TEMPLATE(Chain_matrix_z2_rep_barcode, Matrix, barcode_matrices) { test_barcode<Matrix>(); }
+BOOST_AUTO_TEST_CASE_TEMPLATE(Chain_matrix_z2_rep_barcode, Matrix, barcode_matrices) {
+  test_barcode<Matrix>();
+  test_shifted_barcode<Matrix>();
+}
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(Chain_matrix_z2_rep_representative_cycles, Matrix, full_matrices) {
   auto columns = build_longer_boundary_matrix<typename Matrix::Column_type>();

--- a/src/Persistence_matrix/test/Persistence_matrix_matrix_tests_z2_chain_vine.cpp
+++ b/src/Persistence_matrix/test/Persistence_matrix_matrix_tests_z2_chain_vine.cpp
@@ -104,7 +104,10 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(Chain_matrix_z2_vine_operation, Matrix, full_matri
   test_chain_operation<Matrix>(m);
 }
 
-BOOST_AUTO_TEST_CASE_TEMPLATE(Chain_matrix_z2_vine_barcode, Matrix, full_matrices) { test_barcode<Matrix>(); }
+BOOST_AUTO_TEST_CASE_TEMPLATE(Chain_matrix_z2_vine_barcode, Matrix, full_matrices) {
+  test_barcode<Matrix>();
+  test_shifted_barcode<Matrix>();
+}
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(Chain_matrix_z2_vine, Matrix, full_matrices) {
   auto columns = build_longer_boundary_matrix<typename Matrix::Column_type>();

--- a/src/Persistence_matrix/test/Persistence_matrix_matrix_tests_z2_ru_rep.cpp
+++ b/src/Persistence_matrix/test/Persistence_matrix_matrix_tests_z2_ru_rep.cpp
@@ -74,7 +74,10 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(RU_matrix_z2_rep_max_dimension, Matrix, full_matri
 BOOST_AUTO_TEST_CASE_TEMPLATE(RU_matrix_z2_rep_operation, Matrix, full_matrices) { test_ru_operation<Matrix>(); }
 
 #ifdef PM_TEST_BARCODE
-BOOST_AUTO_TEST_CASE_TEMPLATE(RU_matrix_z2_rep_barcode, Matrix, full_matrices) { test_barcode<Matrix>(); }
+BOOST_AUTO_TEST_CASE_TEMPLATE(RU_matrix_z2_rep_barcode, Matrix, full_matrices) {
+  test_barcode<Matrix>();
+  test_shifted_barcode<Matrix>();
+}
 #endif
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(RU_matrix_z2_rep_representative_cycles, Matrix, full_matrices) {

--- a/src/Persistence_matrix/test/Persistence_matrix_matrix_tests_z2_ru_vine.cpp
+++ b/src/Persistence_matrix/test/Persistence_matrix_matrix_tests_z2_ru_vine.cpp
@@ -75,7 +75,10 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(RU_matrix_z2_vine_max_dimension, Matrix, full_matr
 BOOST_AUTO_TEST_CASE_TEMPLATE(RU_matrix_z2_vine_operation, Matrix, full_matrices) { test_ru_operation<Matrix>(); }
 
 #ifdef PM_TEST_BARCODE
-BOOST_AUTO_TEST_CASE_TEMPLATE(RU_matrix_z2_vine_barcode, Matrix, full_matrices) { test_barcode<Matrix>(); }
+BOOST_AUTO_TEST_CASE_TEMPLATE(RU_matrix_z2_vine_barcode, Matrix, full_matrices) {
+  test_barcode<Matrix>();
+  test_shifted_barcode<Matrix>();
+}
 #endif
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(RU_matrix_z2_vine_representative_cycles, Matrix, rep_matrices) {

--- a/src/Persistence_matrix/test/Persistence_matrix_matrix_tests_zp_boundary.cpp
+++ b/src/Persistence_matrix/test/Persistence_matrix_matrix_tests_zp_boundary.cpp
@@ -64,6 +64,9 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(Boundary_matrix_zp_max_dimension, Matrix, max_dim_
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(Boundary_matrix_zp_operation, Matrix, full_matrices) { test_base_operation<Matrix>(); }
 
-BOOST_AUTO_TEST_CASE_TEMPLATE(Boundary_matrix_zp_barcode, Matrix, barcode_matrices) { test_barcode<Matrix>(); }
+BOOST_AUTO_TEST_CASE_TEMPLATE(Boundary_matrix_zp_barcode, Matrix, barcode_matrices) {
+  test_barcode<Matrix>();
+  test_shifted_barcode<Matrix>();
+}
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(Boundary_matrix_zp_swaps, Matrix, swap_matrices) { test_base_swaps<Matrix>(); }

--- a/src/Persistence_matrix/test/Persistence_matrix_matrix_tests_zp_chain_barcode.cpp
+++ b/src/Persistence_matrix/test/Persistence_matrix_matrix_tests_zp_chain_barcode.cpp
@@ -88,4 +88,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(Chain_matrix_zp_barcode_operation, Matrix, full_ma
   test_chain_operation<Matrix>(m);
 }
 
-BOOST_AUTO_TEST_CASE_TEMPLATE(Chain_matrix_zp_barcode_barcode, Matrix, full_matrices) { test_barcode<Matrix>(); }
+BOOST_AUTO_TEST_CASE_TEMPLATE(Chain_matrix_zp_barcode_barcode, Matrix, full_matrices) {
+  test_barcode<Matrix>();
+  test_shifted_barcode<Matrix>();
+}

--- a/src/Persistence_matrix/test/Persistence_matrix_matrix_tests_zp_chain_rep.cpp
+++ b/src/Persistence_matrix/test/Persistence_matrix_matrix_tests_zp_chain_rep.cpp
@@ -87,7 +87,10 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(Chain_matrix_zp_rep_operation, Matrix, full_matric
   test_chain_operation<Matrix>(m);
 }
 
-BOOST_AUTO_TEST_CASE_TEMPLATE(Chain_matrix_zp_rep_barcode, Matrix, barcode_matrices) { test_barcode<Matrix>(); }
+BOOST_AUTO_TEST_CASE_TEMPLATE(Chain_matrix_zp_rep_barcode, Matrix, barcode_matrices) {
+  test_barcode<Matrix>();
+  test_shifted_barcode<Matrix>();
+}
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(Chain_matrix_zp_rep_representative_cycles, Matrix, full_matrices) {
   auto columns = build_longer_boundary_matrix<typename Matrix::Column_type>();

--- a/src/Persistence_matrix/test/Persistence_matrix_matrix_tests_zp_ru_rep.cpp
+++ b/src/Persistence_matrix/test/Persistence_matrix_matrix_tests_zp_ru_rep.cpp
@@ -74,7 +74,10 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(RU_matrix_zp_rep_max_dimension, Matrix, full_matri
 BOOST_AUTO_TEST_CASE_TEMPLATE(RU_matrix_zp_rep_operation, Matrix, full_matrices) { test_ru_operation<Matrix>(); }
 
 #ifdef PM_TEST_BARCODE
-BOOST_AUTO_TEST_CASE_TEMPLATE(RU_matrix_zp_rep_barcode, Matrix, full_matrices) { test_barcode<Matrix>(); }
+BOOST_AUTO_TEST_CASE_TEMPLATE(RU_matrix_zp_rep_barcode, Matrix, full_matrices) {
+  test_barcode<Matrix>();
+  test_shifted_barcode<Matrix>();
+}
 #endif
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(RU_matrix_zp_rep_representative_cycles, Matrix, full_matrices) {

--- a/src/Persistence_matrix/test/pm_matrix_tests.h
+++ b/src/Persistence_matrix/test/pm_matrix_tests.h
@@ -1456,6 +1456,127 @@ void test_barcode() {
 }
 
 template <class Matrix>
+void test_shifted_barcode() {
+  struct BarComp {
+    bool operator()(const std::tuple<int, int, int>& c1, const std::tuple<int, int, int>& c2) const {
+      if (std::get<0>(c1) == std::get<0>(c2)) return std::get<1>(c1) < std::get<1>(c2);
+      return std::get<0>(c1) < std::get<0>(c2);
+    }
+  };
+
+  Matrix m(9, 5);
+  if constexpr (is_z2<typename Matrix::Column_type>()) {
+    m.insert_boundary(2, {}, 0);
+    m.insert_boundary(3, {}, 0);
+    m.insert_boundary(5, {}, 0);
+    m.insert_boundary(7, {2, 3});
+    m.insert_boundary(8, {3, 5});
+    m.insert_boundary(9, {2, 5});
+    m.insert_boundary(10, {7, 8, 9});
+    m.insert_boundary(11, {}, 0);
+    m.insert_boundary(13, {3, 11});
+  } else {
+    m.insert_boundary(2, {}, 0);
+    m.insert_boundary(3, {}, 0);
+    m.insert_boundary(5, {}, 0);
+    m.insert_boundary(7, {{2, 1}, {3, 4}});
+    m.insert_boundary(8, {{3, 1}, {5, 4}});
+    m.insert_boundary(9, {{2, 1}, {5, 4}});
+    m.insert_boundary(10, {{7, 1}, {8, 1}, {9, 4}});
+    m.insert_boundary(11, {}, 0);
+    m.insert_boundary(13, {{3, 1}, {11, 4}});
+  }
+
+  const auto& barcode = m.get_current_barcode();
+
+  std::vector<witness_content<typename Matrix::Column_type> > reducedMatrix;
+  if constexpr (is_z2<typename Matrix::Column_type>()) {
+    if constexpr (Matrix::Option_list::is_of_boundary_type) {
+      reducedMatrix.emplace_back();
+      reducedMatrix.emplace_back();
+      reducedMatrix.emplace_back();
+      reducedMatrix.push_back({2, 3});
+      reducedMatrix.push_back({3, 5});
+      reducedMatrix.emplace_back();
+      reducedMatrix.push_back({7, 8, 9});
+      reducedMatrix.emplace_back();
+      reducedMatrix.push_back({3, 11});
+    } else {
+      reducedMatrix.push_back({2});
+      reducedMatrix.push_back({2, 3});
+      reducedMatrix.push_back({2, 5});
+      reducedMatrix.push_back({7});
+      reducedMatrix.push_back({7, 8});
+      reducedMatrix.push_back({7, 8, 9});
+      reducedMatrix.push_back({10});
+      reducedMatrix.push_back({2, 11});
+      reducedMatrix.push_back({7, 13});
+    }
+  } else {
+    if constexpr (Matrix::Option_list::is_of_boundary_type) {
+      reducedMatrix.emplace_back();
+      reducedMatrix.emplace_back();
+      reducedMatrix.emplace_back();
+      reducedMatrix.push_back({{2, 1}, {3, 4}});
+      reducedMatrix.push_back({{3, 1}, {5, 4}});
+      reducedMatrix.emplace_back();
+      reducedMatrix.push_back({{7, 1}, {8, 1}, {9, 4}});
+      reducedMatrix.emplace_back();
+      reducedMatrix.push_back({{3, 1}, {11, 4}});
+    } else {
+      reducedMatrix.push_back({{2, 1}});
+      reducedMatrix.push_back({{2, 1}, {3, 4}});
+      reducedMatrix.push_back({{2, 1}, {5, 4}});
+      reducedMatrix.push_back({{7, 1}});
+      reducedMatrix.push_back({{7, 1}, {8, 1}});
+      reducedMatrix.push_back({{7, 1}, {8, 1}, {9, 4}});
+      reducedMatrix.push_back({{10, 1}});
+      reducedMatrix.push_back({{2, 1}, {11, 4}});
+      reducedMatrix.push_back({{7, 1}, {13, 1}});
+    }
+  }
+  test_content_equality(reducedMatrix, m);
+
+  std::set<std::tuple<int, int, int>, BarComp> bars1;
+  std::set<std::tuple<int, int, int>, BarComp> bars2;
+  std::set<std::tuple<int, int, int>, BarComp> bars3;
+  // bars are not ordered the same for all matrices
+  for (auto it = barcode.begin(); it != barcode.end(); ++it) {
+    //three access possibilities
+    bars1.emplace(it->dim, it->birth, it->death);
+    bars2.emplace(std::get<2>(*it), std::get<0>(*it), std::get<1>(*it));
+    auto [ x, y, z ] = *it;
+    bars3.emplace(z, x, y);
+  }
+  auto it = bars1.begin();
+  BOOST_CHECK_EQUAL(std::get<0>(*it), 0);
+  BOOST_CHECK_EQUAL(std::get<1>(*it), 0);
+  // TODO: verify why this -1 works...: it->death should be unsigned int, so double conversion
+  BOOST_CHECK_EQUAL(std::get<2>(*it), -1);
+  ++it;
+  BOOST_CHECK_EQUAL(std::get<0>(*it), 0);
+  BOOST_CHECK_EQUAL(std::get<1>(*it), 1);
+  BOOST_CHECK_EQUAL(std::get<2>(*it), 3);
+  ++it;
+  BOOST_CHECK_EQUAL(std::get<0>(*it), 0);
+  BOOST_CHECK_EQUAL(std::get<1>(*it), 2);
+  BOOST_CHECK_EQUAL(std::get<2>(*it), 4);
+  ++it;
+  BOOST_CHECK_EQUAL(std::get<0>(*it), 0);
+  BOOST_CHECK_EQUAL(std::get<1>(*it), 7);
+  BOOST_CHECK_EQUAL(std::get<2>(*it), 8);
+  ++it;
+  BOOST_CHECK_EQUAL(std::get<0>(*it), 1);
+  BOOST_CHECK_EQUAL(std::get<1>(*it), 5);
+  BOOST_CHECK_EQUAL(std::get<2>(*it), 6);
+  ++it;
+  BOOST_CHECK(it == bars1.end());
+
+  BOOST_CHECK(bars1 == bars2);
+  BOOST_CHECK(bars1 == bars3);
+}
+
+template <class Matrix>
 void test_base_swaps() {
   auto columns = build_simple_boundary_matrix<typename Matrix::Column_type>();
   Matrix m(columns, 5);

--- a/src/Persistence_matrix/test/pm_matrix_tests.h
+++ b/src/Persistence_matrix/test/pm_matrix_tests.h
@@ -875,7 +875,7 @@ void test_boundary_maximal_simplex_removal() {
 
   test_content_equality(columns, m);
   BOOST_CHECK_EQUAL(m.get_number_of_columns(), 7);
-  // pairing always true for boundary for now (only thing differentiating it from base)
+  // pairing always true for boundary for now (only thing differenciating it from base)
   BOOST_CHECK_EQUAL(m.get_current_barcode().back().death, 6);
 
   m.remove_last();
@@ -1457,6 +1457,7 @@ void test_barcode() {
 
 template <class Matrix>
 void test_shifted_barcode() {
+  using C = typename Matrix::Column_type;
   struct BarComp {
     bool operator()(const std::tuple<int, int, int>& c1, const std::tuple<int, int, int>& c2) const {
       if (std::get<0>(c1) == std::get<0>(c2)) return std::get<1>(c1) < std::get<1>(c2);
@@ -1465,7 +1466,7 @@ void test_shifted_barcode() {
   };
 
   Matrix m(9, 5);
-  if constexpr (is_z2<typename Matrix::Column_type>()) {
+  if constexpr (is_z2<C>()) {
     m.insert_boundary(2, {}, 0);
     m.insert_boundary(3, {}, 0);
     m.insert_boundary(5, {}, 0);
@@ -1489,8 +1490,8 @@ void test_shifted_barcode() {
 
   const auto& barcode = m.get_current_barcode();
 
-  std::vector<witness_content<typename Matrix::Column_type> > reducedMatrix;
-  if constexpr (is_z2<typename Matrix::Column_type>()) {
+  std::vector<witness_content<C> > reducedMatrix;
+  if constexpr (is_z2<C>()) {
     if constexpr (Matrix::Option_list::is_of_boundary_type) {
       reducedMatrix.emplace_back();
       reducedMatrix.emplace_back();
@@ -1535,7 +1536,19 @@ void test_shifted_barcode() {
       reducedMatrix.push_back({{7, 1}, {13, 1}});
     }
   }
-  test_content_equality(reducedMatrix, m);
+  if constexpr (Matrix::Option_list::column_indexation_type == Column_indexation_types::IDENTIFIER){
+    test_column_equality<C>(reducedMatrix[0], get_column_content_via_iterators(m.get_column(2)));
+    test_column_equality<C>(reducedMatrix[1], get_column_content_via_iterators(m.get_column(3)));
+    test_column_equality<C>(reducedMatrix[2], get_column_content_via_iterators(m.get_column(5)));
+    test_column_equality<C>(reducedMatrix[3], get_column_content_via_iterators(m.get_column(7)));
+    test_column_equality<C>(reducedMatrix[4], get_column_content_via_iterators(m.get_column(8)));
+    test_column_equality<C>(reducedMatrix[5], get_column_content_via_iterators(m.get_column(9)));
+    test_column_equality<C>(reducedMatrix[6], get_column_content_via_iterators(m.get_column(10)));
+    test_column_equality<C>(reducedMatrix[7], get_column_content_via_iterators(m.get_column(11)));
+    test_column_equality<C>(reducedMatrix[8], get_column_content_via_iterators(m.get_column(13)));
+  } else {
+    test_content_equality(reducedMatrix, m);
+  }
 
   std::set<std::tuple<int, int, int>, BarComp> bars1;
   std::set<std::tuple<int, int, int>, BarComp> bars2;

--- a/src/Persistence_matrix/test/pm_test_utilities.h
+++ b/src/Persistence_matrix/test/pm_test_utilities.h
@@ -160,6 +160,7 @@ void test_content_equality(const std::vector<witness_content<typename Matrix::Co
     const auto& col = m.get_column(i++);  // to force the const version
     test_column_equality<typename Matrix::Column_type>(b, get_column_content_via_iterators(col));
   }
+  BOOST_CHECK_EQUAL(m.get_number_of_columns(), i);
 }
 
 #endif  // PM_TEST_UTILITIES_H


### PR DESCRIPTION
There was a problem with the indices returned for the barcode in R/RU. The birth indices were row indices (ie IDs) while death were column indices (ie positions). In most of the cases, the two coincide, so I missed it. Now, everything should correspond to positions. I also added a test for it.