### PR TITLE
[Persistence_matrix] Type renaming to be more coherent with Gudhi conventions

### DIFF
--- a/src/Persistence_matrix/concept/FieldOperators.h
+++ b/src/Persistence_matrix/concept/FieldOperators.h
@@ -30,8 +30,8 @@ namespace persistence_matrix {
 class FieldOperators 
 {
  public:
-  using element_type = unspecified;         /**< Type for the elements in the field. */
-  using characteristic_type = unspecified;  /**< Type for the field characteristic. */
+  using Element = unspecified;         /**< Type for the elements in the field. */
+  using Characteristic = unspecified;  /**< Type for the field characteristic. */
 
   /**
    * @brief Default constructor. If a non-zero characteristic is given, initializes the field with it.
@@ -39,7 +39,7 @@ class FieldOperators
    *
    * @param characteristic Prime number corresponding to the desired characteristic of the field.
    */
-  FieldOperators(characteristic_type characteristic = 0);
+  FieldOperators(Characteristic characteristic = 0);
 
   /**
    * @brief Sets the characteristic of the field. Can eventually be omitted if the characteristic of the class
@@ -47,13 +47,13 @@ class FieldOperators
    * 
    * @param characteristic Prime number corresponding to the desired characteristic of the field.
    */
-  void set_characteristic(const characteristic_type& characteristic);
+  void set_characteristic(const Characteristic& characteristic);
   /**
    * @brief Returns the current characteristic.
    * 
    * @return The value of the current characteristic.
    */
-  const characteristic_type& get_characteristic() const;
+  const Characteristic& get_characteristic() const;
 
   /**
    * @brief Returns the value of an integer in the field.
@@ -64,9 +64,9 @@ class FieldOperators
    * @return @p e modulo the current characteristic, such that the result is positive.
    */
   template <typename Integer_type>
-  element_type get_value(Integer_type e) const;
+  Element get_value(Integer_type e) const;
 
-  // void get_value(element_type& e) const;
+  // void get_value(Element& e) const;
 
   /**
    * @brief Stores in the first element the sum of two given elements in the field, that is
@@ -75,7 +75,7 @@ class FieldOperators
    * @param e1 First element.
    * @param e2 Second element.
    */
-  void add_inplace(element_type& e1, const element_type& e2) const;
+  void add_inplace(Element& e1, const Element& e2) const;
 
   /**
    * @brief Stores in the first element the multiplication of two given elements in the field,
@@ -84,7 +84,7 @@ class FieldOperators
    * @param e1 First element.
    * @param e2 Second element.
    */
-  void multiply_inplace(element_type& e1, const element_type& e2) const;
+  void multiply_inplace(Element& e1, const Element& e2) const;
 
   /**
    * @brief Multiplies the first element with the second one and adds the third one, that is
@@ -94,7 +94,7 @@ class FieldOperators
    * @param m Second element.
    * @param a Third element.
    */
-  void multiply_and_add_inplace_front(element_type& e, const element_type& m, const element_type& a) const;
+  void multiply_and_add_inplace_front(Element& e, const Element& m, const Element& a) const;
   /**
    * @brief Multiplies the first element with the second one and adds the third one, that is
    * `(e * m + a) % characteristic`, such that the result is positive. Stores the result in the third element.
@@ -103,7 +103,7 @@ class FieldOperators
    * @param m Second element.
    * @param a Third element.
    */
-  void multiply_and_add_inplace_back(const element_type& e, const element_type& m, element_type& a) const;
+  void multiply_and_add_inplace_back(const Element& e, const Element& m, Element& a) const;
 
   /**
    * @brief Returns the inverse of the given element in the field.
@@ -111,20 +111,20 @@ class FieldOperators
    * @param e Element to get the inverse from.
    * @return Inverse in the current field of `e % characteristic`.
    */
-  element_type get_inverse(const element_type& e) const;
+  Element get_inverse(const Element& e) const;
 
   /**
    * @brief Returns the additive identity of the field.
    * 
    * @return The additive identity of the field.
    */
-  static const element_type& get_additive_identity();
+  static const Element& get_additive_identity();
   /**
    * @brief Returns the multiplicative identity of the field.
    * 
    * @return The multiplicative identity of the field.
    */
-  static const element_type& get_multiplicative_identity();
+  static const Element& get_multiplicative_identity();
 
   /**
    * @brief Assign operator.

--- a/src/Persistence_matrix/concept/PersistenceMatrixColumn.h
+++ b/src/Persistence_matrix/concept/PersistenceMatrixColumn.h
@@ -61,10 +61,10 @@ class PersistenceMatrixColumn :
 {
  public:
   using Master = unspecified;                 /**< Master matrix, that is a templated @ref Matrix. */
-  using index = unspecified;                  /**< Type of @ref MatIdx index. */
-  using id_index = unspecified;               /**< Type of @ref IDIdx index. */
-  using dimension_type = unspecified;         /**< Type for dimension value. */
-  using Field_element_type = unspecified;     /**< Type of a field element. */
+  using Index = unspecified;                  /**< Type of @ref MatIdx index. */
+  using ID_index = unspecified;               /**< Type of @ref IDIdx index. */
+  using Dimension = unspecified;         /**< Type for dimension value. */
+  using Field_element = unspecified;     /**< Type of a field element. */
   using Cell = unspecified;                   /**< @ref Cell. */
   using Column_settings = unspecified;        /**< Structure giving access to external classes eventually necessary,
                                                    like a cell pool for example. */
@@ -85,76 +85,76 @@ class PersistenceMatrixColumn :
    */
   PersistenceMatrixColumn(Column_settings* colSettings = nullptr);
   /**
-   * @brief Constructs a column from the given range of @ref Matrix::cell_rep_type. If the dimension is stored,
+   * @brief Constructs a column from the given range of @ref Matrix::Cell_representative. If the dimension is stored,
    * the face is assumed to be simplicial and its dimension to be `nonZeroRowIndices length - 1` or `0`.
    * Otherwise, the dimension should be specified with another constructor.
    * 
-   * @tparam Container_type Range of @ref Matrix::cell_rep_type. Assumed to have a %begin(), %end() and %size() method.
-   * @param nonZeroRowIndices Range of @ref Matrix::cell_rep_type representing all rows with non zero values.
+   * @tparam Container Range of @ref Matrix::Cell_representative. Assumed to have a %begin(), %end() and %size() method.
+   * @param nonZeroRowIndices Range of @ref Matrix::Cell_representative representing all rows with non zero values.
    * @param colSettings Pointer to an existing setting structure. The structure should contain all the necessary
    * classes specific to the column type, such as custom allocators. The specificities are this way hidden behind
    * a commun interface for all column types.
    */
-  template <class Container_type = typename Master_matrix::boundary_type>
-  PersistenceMatrixColumn(const Container_type& nonZeroRowIndices, 
+  template <class Container = typename Master_matrix::Boundary>
+  PersistenceMatrixColumn(const Container& nonZeroRowIndices, 
                           Column_settings* colSettings);
   /**
-   * @brief Constructs a column from the given range of @ref Matrix::cell_rep_type such that the rows can be accessed.
+   * @brief Constructs a column from the given range of @ref Matrix::Cell_representative such that the rows can be accessed.
    * Each new cell in the column is also inserted in a row using @ref Row_access::insert_cell.
    * If the dimension is stored, the face is assumed to be simplicial and its dimension to be
    * `nonZeroRowIndices length - 1` or `0`. Otherwise, the dimension should be specified with another constructor.
    * 
-   * @tparam Container_type Range of @ref Matrix::cell_rep_type. Assumed to have a %begin(), %end() and %size() method.
-   * @tparam Row_container_type Either std::map if @ref PersistenceMatrixOptions::has_removable_rows is true or
-   * std::vector<Row_type>.
+   * @tparam Container Range of @ref Matrix::Cell_representative. Assumed to have a %begin(), %end() and %size() method.
+   * @tparam Row_container Either std::map if @ref PersistenceMatrixOptions::has_removable_rows is true or
+   * std::vector<Row>.
    * @param columnIndex @ref MatIdx column index that should be specified to the cells.
-   * @param nonZeroRowIndices Range of @ref Matrix::cell_rep_type representing all rows with non zero values.
+   * @param nonZeroRowIndices Range of @ref Matrix::Cell_representative representing all rows with non zero values.
    * @param rowContainer Pointer to the row container that will be forwarded to @ref Row_access at construction.
    * @param colSettings Pointer to an existing setting structure. The structure should contain all the necessary
    * classes specific to the column type, such as custom allocators. The specificities are this way hidden behind
    * a commun interface for all column types.
    */
-  template <class Container_type = typename Master_matrix::boundary_type, class Row_container_type>
-  PersistenceMatrixColumn(index columnIndex, 
-                          const Container_type& nonZeroRowIndices, 
-                          Row_container_type* rowContainer,
+  template <class Container = typename Master_matrix::Boundary, class Row_container>
+  PersistenceMatrixColumn(Index columnIndex, 
+                          const Container& nonZeroRowIndices, 
+                          Row_container* rowContainer,
                           Column_settings* colSettings);
   /**
-   * @brief Constructs a column from the given range of @ref Matrix::cell_rep_type and stores the given dimension
+   * @brief Constructs a column from the given range of @ref Matrix::Cell_representative and stores the given dimension
    * if @ref Column_dimension_option is not a dummy.
    * 
-   * @tparam Container_type Range of @ref Matrix::cell_rep_type. Assumed to have a %begin(), %end() and %size() method.
-   * @param nonZeroChainRowIndices Range of @ref Matrix::cell_rep_type representing all rows with non zero values.
+   * @tparam Container Range of @ref Matrix::Cell_representative. Assumed to have a %begin(), %end() and %size() method.
+   * @param nonZeroChainRowIndices Range of @ref Matrix::Cell_representative representing all rows with non zero values.
    * @param dimension Dimension of the column. Is ignored if the dimension is not stored.
    * @param colSettings Pointer to an existing setting structure. The structure should contain all the necessary
    * classes specific to the column type, such as custom allocators. The specificities are this way hidden behind
    * a commun interface for all column types.
    */
-  template <class Container_type = typename Master_matrix::boundary_type>
-  PersistenceMatrixColumn(const Container_type& nonZeroChainRowIndices, 
-                          dimension_type dimension,
+  template <class Container = typename Master_matrix::Boundary>
+  PersistenceMatrixColumn(const Container& nonZeroChainRowIndices, 
+                          Dimension dimension,
                           Column_settings* colSettings);
   /**
-   * @brief Constructs a column from the given range of @ref Matrix::cell_rep_type such that the rows can be accessed.
+   * @brief Constructs a column from the given range of @ref Matrix::Cell_representative such that the rows can be accessed.
    * Each new cell in the column is also inserted in a row using @ref Row_access::insert_cell.
    * Stores the given dimension if @ref Column_dimension_option is not a dummy.
    * 
-   * @tparam Container_type Range of @ref Matrix::cell_rep_type. Assumed to have a %begin(), %end() and %size() method.
-   * @tparam Row_container_type Either std::map if @ref PersistenceMatrixOptions::has_removable_rows is true or
-   * std::vector<Row_type>.
+   * @tparam Container Range of @ref Matrix::Cell_representative. Assumed to have a %begin(), %end() and %size() method.
+   * @tparam Row_container Either std::map if @ref PersistenceMatrixOptions::has_removable_rows is true or
+   * std::vector<Row>.
    * @param columnIndex @ref MatIdx column index that should be specified to the cells.
-   * @param nonZeroChainRowIndices Range of @ref Matrix::cell_rep_type representing all rows with non zero values.
+   * @param nonZeroChainRowIndices Range of @ref Matrix::Cell_representative representing all rows with non zero values.
    * @param dimension Dimension of the column. Is ignored if the dimension is not stored.
    * @param rowContainer Pointer to the row container that will be forwarded to @ref Row_access at construction.
    * @param colSettings Pointer to an existing setting structure. The structure should contain all the necessary
    * classes specific to the column type, such as custom allocators. The specificities are this way hidden behind
    * a commun interface for all column types.
    */
-  template <class Container_type = typename Master_matrix::boundary_type, class Row_container_type>
-  PersistenceMatrixColumn(index columnIndex, 
-                          const Container_type& nonZeroChainRowIndices, 
-                          dimension_type dimension,
-                          Row_container_type* rowContainer, 
+  template <class Container = typename Master_matrix::Boundary, class Row_container>
+  PersistenceMatrixColumn(Index columnIndex, 
+                          const Container& nonZeroChainRowIndices, 
+                          Dimension dimension,
+                          Row_container* rowContainer, 
                           Column_settings* colSettings);
   /**
    * @brief Copy constructor. If @p operators or @p cellConstructor is not a null pointer, its value is kept
@@ -173,8 +173,8 @@ class PersistenceMatrixColumn :
    * If @p operators or @p cellConstructor is not a null pointer, its value is kept
    * instead of the one in the copied column.
    * 
-   * @tparam Row_container_type  Either std::map if @ref PersistenceMatrixOptions::has_removable_rows is true or
-   * std::vector<Row_type>.
+   * @tparam Row_container  Either std::map if @ref PersistenceMatrixOptions::has_removable_rows is true or
+   * std::vector<Row>.
    * @param column Column to copy.
    * @param columnIndex @ref MatIdx column index of the new column once copied.
    * @param rowContainer Pointer to the row container that will be forwarded to @ref Row_access.
@@ -183,10 +183,10 @@ class PersistenceMatrixColumn :
    * a commun interface for all column types. If @p colSettings is not specified or is equal to `nullptr`, the structure
    * stored in @p column is used instead.
    */
-  template <class Row_container_type>
+  template <class Row_container>
   PersistenceMatrixColumn(const PersistenceMatrixColumn& column, 
-                          index columnIndex, 
-                          Row_container_type* rowContainer,
+                          Index columnIndex, 
+                          Row_container* rowContainer,
                           Column_settings* colSettings = nullptr);
   /**
    * @brief Move constructor.
@@ -204,10 +204,10 @@ class PersistenceMatrixColumn :
    * 
    * @param columnLength Number of rows to be returned. If -1, the number of rows is fixed at the biggest 
    * row index with non zero value. Default value: -1.
-   * @return Vector of @ref Field_element_type. At element \f$ i \f$ of the vector will be stored the value
+   * @return Vector of @ref Field_element. At element \f$ i \f$ of the vector will be stored the value
    * at row \f$ i \f$ of the column.
    */
-  std::vector<Field_element_type> get_content(int columnLength = -1) const;
+  std::vector<Field_element> get_content(int columnLength = -1) const;
   /**
    * @brief Indicates if the cell at given row index has value zero.
    * 
@@ -215,7 +215,7 @@ class PersistenceMatrixColumn :
    * @return true If the cell has value zero.
    * @return false Otherwise.
    */
-  bool is_non_zero(id_index rowIndex) const;
+  bool is_non_zero(ID_index rowIndex) const;
   /**
    * @brief Indicates if the column is empty or has only zero values.
    * 
@@ -240,14 +240,14 @@ class PersistenceMatrixColumn :
    *
    * Only useful for @ref basematrix "base" and @ref boundarymatrix "boundary matrices" using lazy swaps.
    * 
-   * @tparam Map_type Map with an %at() method.
+   * @tparam Row_index_map Map with an %at() method.
    * @param valueMap Map such that `valueMap.at(i)` indicates the new row index of the cell
    * at current row index `i`.
    * @param columnIndex New @ref MatIdx column index of the column. If -1, the index does not change. Ignored if
    * the row access is not enabled. Default value: -1.
    */
-  template <class Map_type>
-  void reorder(const Map_type& valueMap, [[maybe_unused]] index columnIndex = -1);
+  template <class Row_index_map>
+  void reorder(const Row_index_map& valueMap, [[maybe_unused]] Index columnIndex = -1);
   /**
    * @brief Zeros/empties the column.
    * 
@@ -266,7 +266,7 @@ class PersistenceMatrixColumn :
    * 
    * @param rowIndex Row index of the cell to zero.
    */
-  void clear(id_index rowIndex);
+  void clear(ID_index rowIndex);
 
   /**
    * @brief Returns the row index of the pivot. If the column does not have a pivot, returns -1.
@@ -275,7 +275,7 @@ class PersistenceMatrixColumn :
    * 
    * @return Row index of the pivot or -1.
    */
-  id_index get_pivot();
+  ID_index get_pivot();
   /**
    * @brief Returns the value of the pivot. If the column does not have a pivot, returns 0.
    *
@@ -285,7 +285,7 @@ class PersistenceMatrixColumn :
    * 
    * @return The value of the pivot or 0.
    */
-  Field_element_type get_pivot_value();
+  Field_element get_pivot_value();
 
   /**
    * @brief Returns a begin @ref Cell iterator to iterate over all cells contained in the underlying container.
@@ -388,7 +388,7 @@ class PersistenceMatrixColumn :
    * @param val Value to multiply.
    * @return Reference to this column.
    */
-  PersistenceMatrixColumn& operator*=(const Field_element_type& val);
+  PersistenceMatrixColumn& operator*=(const Field_element& val);
 
   /**
    * @brief `this = val * this + column`
@@ -402,7 +402,7 @@ class PersistenceMatrixColumn :
    * @return Reference to this column.
    */
   template <class Cell_range>
-  PersistenceMatrixColumn& multiply_target_and_add(const Field_element_type& val, const Cell_range& column);
+  PersistenceMatrixColumn& multiply_target_and_add(const Field_element& val, const Cell_range& column);
 
   /**
    * @brief `this = this + column * val`
@@ -416,12 +416,12 @@ class PersistenceMatrixColumn :
    * @return Reference to this column.
    */
   template <class Cell_range>
-  PersistenceMatrixColumn& multiply_source_and_add(const Cell_range& column, const Field_element_type& val);
+  PersistenceMatrixColumn& multiply_source_and_add(const Cell_range& column, const Field_element& val);
 
   /**
    * @brief Equality comparator. Equal in the sense that what is "supposed" to be contained in the columns is equal,
    * not what is actually stored in the underlying container. For example, the underlying container of 
-   * @ref Vector_column can contain cells which were erased explicitly by @ref clear(index). Those cells should not
+   * @ref Vector_column can contain cells which were erased explicitly by @ref clear(Index). Those cells should not
    * be taken into account while comparing.
    * 
    * @param c1 First column to compare.
@@ -434,7 +434,7 @@ class PersistenceMatrixColumn :
    * @brief "Strictly smaller than" comparator. Usually a lexicographical order, but what matters is that the
    * order is total. The order should apply on what is "supposed" to be contained in the columns,
    * not what is actually stored in the underlying container. For example, the underlying container of 
-   * @ref Vector_column can contain cells which were erased explicitly by @ref clear(index). Those cells should not
+   * @ref Vector_column can contain cells which were erased explicitly by @ref clear(Index). Those cells should not
    * be taken into account while comparing.
    * 
    * @param c1 First column to compare.

--- a/src/Persistence_matrix/concept/PersistenceMatrixOptions.h
+++ b/src/Persistence_matrix/concept/PersistenceMatrixOptions.h
@@ -39,13 +39,13 @@ struct PersistenceMatrixOptions
    * @brief Type for the dimension. Has to be an integer type.
    * If unsigned, the maximal value of the type should not be attained during a run.
    */
-  using dimension_type = unspecified;
+  using Dimension = unspecified;
   /**
    * @brief Type for the different indexation types and should be able to contain the maximal number of columns
    * of the matrix during a run. Has to be an integer type.
    * If unsigned, the maximal value of the type should not be attained during a run.
    */
-  using index_type = unspecified;
+  using Index = unspecified;
 
   /**
    * @brief If true, indicates that the values contained in the matrix are in \f$ Z_2 \f$ and can therefore
@@ -72,12 +72,12 @@ struct PersistenceMatrixOptions
    * by a same column.
    *
    * Note that some methods of the @ref basematrix "base matrix" are not available when true:
-   * - @ref Matrix::insert_column(const Container_type&, index_type) "insert_column(const Container_type&, index)",
-   * - @ref Matrix::zero_column(index_type) "zero_column(index)",
-   * - @ref Matrix::zero_cell(index_type, index_type) "zero_cell(index, id_index)",
-   * - @ref Matrix::swap_columns(index_type, index_type) "swap_columns(index, index)",
-   * - @ref Matrix::swap_rows(index_type, index_type) "swap_rows(index, index)",
-   * - @ref Matrix::remove_column(index_type) "remove_column(index)",
+   * - @ref Matrix::insert_column(const Container&, Index) "insert_column(const Container&, Index)",
+   * - @ref Matrix::zero_column(Index) "zero_column(Index)",
+   * - @ref Matrix::zero_cell(Index, Index) "zero_cell(Index, ID_index)",
+   * - @ref Matrix::swap_columns(Index, Index) "swap_columns(Index, Index)",
+   * - @ref Matrix::swap_rows(Index, Index) "swap_rows(Index, Index)",
+   * - @ref Matrix::remove_column(Index) "remove_column(Index)",
    * - @ref Matrix::remove_last "remove_last()".
    */
   static const bool has_column_compression;
@@ -92,10 +92,10 @@ struct PersistenceMatrixOptions
    * @brief If set to true, the underlying container containing the matrix columns is an std::unordered_map. 
    * If set to false, the container is a std::vector. By default, it is recommended to set it to false, but some 
    * methods require it to be true to be enabled: 
-   * - @ref Matrix::remove_column(index_type) "remove_column(index)" for @ref basematrix "base matrices",
-   * - @ref Matrix::remove_maximal_face(index_type) "remove_maximal_face(index)" for @ref chainmatrix "chain matrices",
-   * - @ref Matrix::remove_maximal_face(index_type, const std::vector<index_type>&)
-   *  "remove_maximal_face(id_index, const std::vector<id_index>&)" for @ref chainmatrix "chain matrices",
+   * - @ref Matrix::remove_column(Index) "remove_column(Index)" for @ref basematrix "base matrices",
+   * - @ref Matrix::remove_maximal_face(Index) "remove_maximal_face(Index)" for @ref chainmatrix "chain matrices",
+   * - @ref Matrix::remove_maximal_face(Index, const std::vector<Index>&)
+   *  "remove_maximal_face(ID_index, const std::vector<ID_index>&)" for @ref chainmatrix "chain matrices",
    * - @ref Matrix::remove_last "remove_last()" for @ref chainmatrix "chain matrices" if @ref has_vine_update is true.
    */
   static const bool has_map_column_container;

--- a/src/Persistence_matrix/include/gudhi/Fields/Multi_field.h
+++ b/src/Persistence_matrix/include/gudhi/Fields/Multi_field.h
@@ -38,8 +38,8 @@ namespace persistence_fields {
 template <unsigned int minimum, unsigned int maximum>
 class Multi_field_element {
  public:
-  using element_type = mpz_class;           /**< Type for the elements in the field. */
-  using characteristic_type = element_type; /**< Type for the field characteristic. */
+  using Element = mpz_class;           /**< Type for the elements in the field. */
+  using Characteristic = Element; /**< Type for the field characteristic. */
 
   /**
    * @brief Default constructor. Sets the element to 0.
@@ -50,7 +50,7 @@ class Multi_field_element {
    *
    * @param element Value of the element.
    */
-  Multi_field_element(const element_type& element);
+  Multi_field_element(const Element& element);
   /**
    * @brief Copy constructor.
    *
@@ -81,21 +81,21 @@ class Multi_field_element {
   /**
    * @brief operator+=
    */
-  friend void operator+=(Multi_field_element& f, const element_type& v) {
+  friend void operator+=(Multi_field_element& f, const Element& v) {
     f.element_ += v;
     mpz_mod(f.element_.get_mpz_t(), f.element_.get_mpz_t(), productOfAllCharacteristics_.get_mpz_t());
   }
   /**
    * @brief operator+
    */
-  friend Multi_field_element operator+(Multi_field_element f, const element_type& v) {
+  friend Multi_field_element operator+(Multi_field_element f, const Element& v) {
     f += v;
     return f;
   }
   /**
    * @brief operator+
    */
-  friend element_type operator+(element_type v, Multi_field_element const& f) {
+  friend Element operator+(Element v, Multi_field_element const& f) {
     v += f.element_;
     mpz_mod(v.get_mpz_t(), v.get_mpz_t(), productOfAllCharacteristics_.get_mpz_t());
     return v;
@@ -118,22 +118,22 @@ class Multi_field_element {
   /**
    * @brief operator-=
    */
-  friend void operator-=(Multi_field_element& f, const element_type& v) {
+  friend void operator-=(Multi_field_element& f, const Element& v) {
     f.element_ -= v;
     mpz_mod(f.element_.get_mpz_t(), f.element_.get_mpz_t(), productOfAllCharacteristics_.get_mpz_t());
   }
   /**
    * @brief operator-
    */
-  friend Multi_field_element operator-(Multi_field_element f, const element_type& v) {
+  friend Multi_field_element operator-(Multi_field_element f, const Element& v) {
     f -= v;
     return f;
   }
   /**
    * @brief operator-
    */
-  friend element_type operator-(element_type v, Multi_field_element const& f) {
-    // element_type e(v);
+  friend Element operator-(Element v, Multi_field_element const& f) {
+    // Element e(v);
     if (v >= productOfAllCharacteristics_)
       mpz_mod(v.get_mpz_t(), v.get_mpz_t(), productOfAllCharacteristics_.get_mpz_t());
     if (f.element_ > v) v += productOfAllCharacteristics_;
@@ -158,21 +158,21 @@ class Multi_field_element {
   /**
    * @brief operator*=
    */
-  friend void operator*=(Multi_field_element& f, const element_type& v) {
+  friend void operator*=(Multi_field_element& f, const Element& v) {
     f.element_ *= v;
     mpz_mod(f.element_.get_mpz_t(), f.element_.get_mpz_t(), productOfAllCharacteristics_.get_mpz_t());
   }
   /**
    * @brief operator*
    */
-  friend Multi_field_element operator*(Multi_field_element f, const element_type& v) {
+  friend Multi_field_element operator*(Multi_field_element f, const Element& v) {
     f *= v;
     return f;
   }
   /**
    * @brief operator*
    */
-  friend element_type operator*(element_type v, Multi_field_element const& f) {
+  friend Element operator*(Element v, Multi_field_element const& f) {
     v *= f.element_;
     mpz_mod(v.get_mpz_t(), v.get_mpz_t(), productOfAllCharacteristics_.get_mpz_t());
     return v;
@@ -187,18 +187,18 @@ class Multi_field_element {
   /**
    * @brief operator==
    */
-  friend bool operator==(const element_type& v, const Multi_field_element& f) {
+  friend bool operator==(const Element& v, const Multi_field_element& f) {
     if (v < productOfAllCharacteristics_) return v == f.element_;
-    element_type e(v);
+    Element e(v);
     mpz_mod(e.get_mpz_t(), e.get_mpz_t(), productOfAllCharacteristics_.get_mpz_t());
     return e == f.element_;
   }
   /**
    * @brief operator==
    */
-  friend bool operator==(const Multi_field_element& f, const element_type& v) {
+  friend bool operator==(const Multi_field_element& f, const Element& v) {
     if (v < productOfAllCharacteristics_) return v == f.element_;
-    element_type e(v);
+    Element e(v);
     mpz_mod(e.get_mpz_t(), e.get_mpz_t(), productOfAllCharacteristics_.get_mpz_t());
     return e == f.element_;
   }
@@ -209,11 +209,11 @@ class Multi_field_element {
   /**
    * @brief operator!=
    */
-  friend bool operator!=(const element_type& v, const Multi_field_element& f) { return !(v == f); }
+  friend bool operator!=(const Element& v, const Multi_field_element& f) { return !(v == f); }
   /**
    * @brief operator!=
    */
-  friend bool operator!=(const Multi_field_element& f, const element_type& v) { return !(v == f); }
+  friend bool operator!=(const Multi_field_element& f, const Element& v) { return !(v == f); }
 
   /**
    * @brief Assign operator.
@@ -222,7 +222,7 @@ class Multi_field_element {
   /**
    * @brief Assign operator.
    */
-  Multi_field_element& operator=(const element_type& value);
+  Multi_field_element& operator=(const Element& value);
   /**
    * @brief Swap operator.
    */
@@ -250,8 +250,8 @@ class Multi_field_element {
    * @param productOfCharacteristics Sub-product of the characteristics.
    * @return Pair of the inverse and the characteristic the inverse corresponds to.
    */
-  std::pair<Multi_field_element, characteristic_type> get_partial_inverse(
-      const characteristic_type& productOfCharacteristics) const;
+  std::pair<Multi_field_element, Characteristic> get_partial_inverse(
+      const Characteristic& productOfCharacteristics) const;
 
   /**
    * @brief Returns the additive identity of a field.
@@ -272,25 +272,25 @@ class Multi_field_element {
    * @param productOfCharacteristics Product of the different characteristics to take into account in the multi-field.
    * @return The partial multiplicative identity of the multi-field.
    */
-  static Multi_field_element get_partial_multiplicative_identity(const characteristic_type& productOfCharacteristics);
+  static Multi_field_element get_partial_multiplicative_identity(const Characteristic& productOfCharacteristics);
   /**
    * @brief Returns the product of all characteristics.
    *
    * @return The product of all characteristics.
    */
-  static characteristic_type get_characteristic();
+  static Characteristic get_characteristic();
 
   /**
    * @brief Returns the value of the element.
    *
    * @return Value of the element.
    */
-  element_type get_value() const;
+  Element get_value() const;
 
   // static constexpr bool handles_only_z2() { return false; }
 
  private:
-  element_type element_;
+  Element element_;
   static inline const std::vector<unsigned int> primes_ = []() {
     std::vector<unsigned int> res;
 
@@ -314,16 +314,16 @@ class Multi_field_element {
 
     return res;
   }();
-  static inline const characteristic_type productOfAllCharacteristics_ = []() {
-    characteristic_type res = 1;
+  static inline const Characteristic productOfAllCharacteristics_ = []() {
+    Characteristic res = 1;
     for (const auto p : primes_) {
       res *= p;
     }
 
     return res;
   }();
-  static inline const std::vector<characteristic_type> partials_ = []() {
-    std::vector<characteristic_type> res;
+  static inline const std::vector<Characteristic> partials_ = []() {
+    std::vector<Characteristic> res;
 
     if (productOfAllCharacteristics_ == 1) return res;
 
@@ -337,7 +337,7 @@ class Multi_field_element {
   }();
   // If I understood the paper well, multiplicativeID_ always equals to 1. But in Clement's code,
   // multiplicativeID_ is computed (see commented lambda function below). TODO: verify with Clement.
-  static inline const element_type multiplicativeID_ = 1; /*[](){
+  static inline const Element multiplicativeID_ = 1; /*[](){
            mpz_class res = 0;
            for (unsigned int i = 0; i < partials_.size(); ++i){
                    res = (res + partials_[i]) % productOfAllCharacteristics_;
@@ -360,7 +360,7 @@ inline Multi_field_element<minimum, maximum>::Multi_field_element() : element_(0
 }
 
 template <unsigned int minimum, unsigned int maximum>
-inline Multi_field_element<minimum, maximum>::Multi_field_element(const element_type& element) : element_(element) {
+inline Multi_field_element<minimum, maximum>::Multi_field_element(const Element& element) : element_(element) {
   static_assert(maximum >= 2, "Characteristics has to be positive.");
   static_assert(minimum <= maximum, "The given interval is not valid.");
   static_assert(minimum != maximum || _is_prime(minimum), "The given interval does not contain a prime number.");
@@ -389,7 +389,7 @@ inline Multi_field_element<minimum, maximum>& Multi_field_element<minimum, maxim
 
 template <unsigned int minimum, unsigned int maximum>
 inline Multi_field_element<minimum, maximum>& Multi_field_element<minimum, maximum>::operator=(
-    const element_type& value) {
+    const Element& value) {
   mpz_mod(element_.get_mpz_t(), value.get_mpz_t(), productOfAllCharacteristics_.get_mpz_t());
   return *this;
 }
@@ -411,16 +411,16 @@ inline Multi_field_element<minimum, maximum> Multi_field_element<minimum, maximu
 
 template <unsigned int minimum, unsigned int maximum>
 inline std::pair<Multi_field_element<minimum, maximum>,
-                 typename Multi_field_element<minimum, maximum>::characteristic_type>
-Multi_field_element<minimum, maximum>::get_partial_inverse(const characteristic_type& productOfCharacteristics) const {
-  characteristic_type QR;
+                 typename Multi_field_element<minimum, maximum>::Characteristic>
+Multi_field_element<minimum, maximum>::get_partial_inverse(const Characteristic& productOfCharacteristics) const {
+  Characteristic QR;
   mpz_gcd(QR.get_mpz_t(), element_.get_mpz_t(), productOfCharacteristics.get_mpz_t());  // QR <- gcd(x,QS)
 
   if (QR == productOfCharacteristics) return {Multi_field_element(), multiplicativeID_};  // partial inverse is 0
 
-  characteristic_type QT = productOfCharacteristics / QR;
+  Characteristic QT = productOfCharacteristics / QR;
 
-  characteristic_type inv_qt;
+  Characteristic inv_qt;
   mpz_invert(inv_qt.get_mpz_t(), element_.get_mpz_t(), QT.get_mpz_t());
 
   auto res = get_partial_multiplicative_identity(QT);
@@ -441,7 +441,7 @@ inline Multi_field_element<minimum, maximum> Multi_field_element<minimum, maximu
 
 template <unsigned int minimum, unsigned int maximum>
 inline Multi_field_element<minimum, maximum> Multi_field_element<minimum, maximum>::get_partial_multiplicative_identity(
-    const characteristic_type& productOfCharacteristics) {
+    const Characteristic& productOfCharacteristics) {
   if (productOfCharacteristics == 0) {
     return Multi_field_element<minimum, maximum>(multiplicativeID_);
   }
@@ -455,13 +455,13 @@ inline Multi_field_element<minimum, maximum> Multi_field_element<minimum, maximu
 }
 
 template <unsigned int minimum, unsigned int maximum>
-inline typename Multi_field_element<minimum, maximum>::characteristic_type
+inline typename Multi_field_element<minimum, maximum>::Characteristic
 Multi_field_element<minimum, maximum>::get_characteristic() {
   return productOfAllCharacteristics_;
 }
 
 template <unsigned int minimum, unsigned int maximum>
-inline typename Multi_field_element<minimum, maximum>::element_type Multi_field_element<minimum, maximum>::get_value()
+inline typename Multi_field_element<minimum, maximum>::Element Multi_field_element<minimum, maximum>::get_value()
     const {
   return element_;
 }

--- a/src/Persistence_matrix/include/gudhi/Fields/Multi_field_operators.h
+++ b/src/Persistence_matrix/include/gudhi/Fields/Multi_field_operators.h
@@ -34,8 +34,8 @@ namespace persistence_fields {
 class Multi_field_operators
 {
  public:
-  using element_type = mpz_class;             /**< Type for the elements in the field. */
-  using characteristic_type = element_type;   /**< Type for the field characteristic. */
+  using Element = mpz_class;             /**< Type for the elements in the field. */
+  using Characteristic = Element;   /**< Type for the field characteristic. */
 
   /**
    * @brief Default constructor, sets the product of all characteristics to 0.
@@ -133,7 +133,7 @@ class Multi_field_operators
    * 
    * @return The value of the current characteristic.
    */
-  const characteristic_type& get_characteristic() const { return productOfAllCharacteristics_; }
+  const Characteristic& get_characteristic() const { return productOfAllCharacteristics_; }
 
   /**
    * @brief Returns the value of an element in the field.
@@ -142,7 +142,7 @@ class Multi_field_operators
    * @param e Element to return the value from.
    * @return @p e modulo the current characteristic, such that the result is positive.
    */
-  element_type get_value(element_type e) const {
+  Element get_value(Element e) const {
     get_value_inplace(e);
     return e;
   }
@@ -153,7 +153,7 @@ class Multi_field_operators
    * 
    * @param e Element to return the value from.
    */
-  void get_value_inplace(element_type& e) const {
+  void get_value_inplace(Element& e) const {
     if (e >= productOfAllCharacteristics_ || e < -productOfAllCharacteristics_)
       mpz_mod(e.get_mpz_t(), e.get_mpz_t(), productOfAllCharacteristics_.get_mpz_t());
     if (e < 0) e += productOfAllCharacteristics_;
@@ -166,7 +166,7 @@ class Multi_field_operators
    * @param e2 Second element.
    * @return `(e1 + e2) % productOfAllCharacteristics`, such that the result is positive.
    */
-  element_type add(element_type e1, const element_type& e2) const {
+  Element add(Element e1, const Element& e2) const {
     add_inplace(e1, e2);
     return e1;
   }
@@ -178,7 +178,7 @@ class Multi_field_operators
    * @param e1 First element.
    * @param e2 Second element.
    */
-  void add_inplace(element_type& e1, const element_type& e2) const {
+  void add_inplace(Element& e1, const Element& e2) const {
     e1 += e2;
     get_value_inplace(e1);
   }
@@ -190,7 +190,7 @@ class Multi_field_operators
    * @param e2 Second element.
    * @return `(e1 - e2) % productOfAllCharacteristics`, such that the result is positive.
    */
-  element_type subtract(element_type e1, const element_type& e2) const {
+  Element subtract(Element e1, const Element& e2) const {
     subtract_inplace_front(e1, e2);
     return e1;
   }
@@ -202,7 +202,7 @@ class Multi_field_operators
    * @param e1 First element.
    * @param e2 Second element.
    */
-  void subtract_inplace_front(element_type& e1, const element_type& e2) const {
+  void subtract_inplace_front(Element& e1, const Element& e2) const {
     e1 -= e2;
     get_value_inplace(e1);
   }
@@ -213,7 +213,7 @@ class Multi_field_operators
    * @param e1 First element.
    * @param e2 Second element.
    */
-  void subtract_inplace_back(const element_type& e1, element_type& e2) const {
+  void subtract_inplace_back(const Element& e1, Element& e2) const {
     mpz_sub(e2.get_mpz_t(), e1.get_mpz_t(), e2.get_mpz_t());
     get_value_inplace(e2);
   }
@@ -225,7 +225,7 @@ class Multi_field_operators
    * @param e2 Second element.
    * @return `(e1 * e2) % productOfAllCharacteristics`, such that the result is positive.
    */
-  element_type multiply(element_type e1, const element_type& e2) const {
+  Element multiply(Element e1, const Element& e2) const {
     multiply_inplace(e1, e2);
     return e1;
   }
@@ -237,7 +237,7 @@ class Multi_field_operators
    * @param e1 First element.
    * @param e2 Second element.
    */
-  void multiply_inplace(element_type& e1, const element_type& e2) const {
+  void multiply_inplace(Element& e1, const Element& e2) const {
     e1 *= e2;
     get_value_inplace(e1);
   }
@@ -250,7 +250,7 @@ class Multi_field_operators
    * @param a Third element.
    * @return `(e * m + a) % productOfAllCharacteristics`, such that the result is positive.
    */
-  element_type multiply_and_add(element_type e, const element_type& m, const element_type& a) const {
+  Element multiply_and_add(Element e, const Element& m, const Element& a) const {
     multiply_and_add_inplace_front(e, m, a);
     return e;
   }
@@ -264,7 +264,7 @@ class Multi_field_operators
    * @param m Second element.
    * @param a Third element.
    */
-  void multiply_and_add_inplace_front(element_type& e, const element_type& m, const element_type& a) const {
+  void multiply_and_add_inplace_front(Element& e, const Element& m, const Element& a) const {
     e *= m;
     e += a;
     get_value_inplace(e);
@@ -278,7 +278,7 @@ class Multi_field_operators
    * @param m Second element.
    * @param a Third element.
    */
-  void multiply_and_add_inplace_back(const element_type& e, const element_type& m, element_type& a) const {
+  void multiply_and_add_inplace_back(const Element& e, const Element& m, Element& a) const {
     a += e * m;
     get_value_inplace(a);
   }
@@ -292,7 +292,7 @@ class Multi_field_operators
    * @param m Third element.
    * @return `((e + a) * m) % productOfAllCharacteristics`, such that the result is positive.
    */
-  element_type add_and_multiply(element_type e, const element_type& a, const element_type& m) const {
+  Element add_and_multiply(Element e, const Element& a, const Element& m) const {
     add_and_multiply_inplace_front(e, a, m);
     return e;
   }
@@ -306,7 +306,7 @@ class Multi_field_operators
    * @param a Second element.
    * @param m Third element.
    */
-  void add_and_multiply_inplace_front(element_type& e, const element_type& a, const element_type& m) const {
+  void add_and_multiply_inplace_front(Element& e, const Element& a, const Element& m) const {
     e += a;
     e *= m;
     get_value_inplace(e);
@@ -320,7 +320,7 @@ class Multi_field_operators
    * @param a Second element.
    * @param m Third element.
    */
-  void add_and_multiply_inplace_back(const element_type& e, const element_type& a, element_type& m) const {
+  void add_and_multiply_inplace_back(const Element& e, const Element& a, Element& m) const {
     m *= e + a;
     get_value_inplace(m);
   }
@@ -333,7 +333,7 @@ class Multi_field_operators
    * @return true If `e1 % productOfAllCharacteristics == e2 % productOfAllCharacteristics`.
    * @return false Otherwise.
    */
-  bool are_equal(const element_type& e1, const element_type& e2) const {
+  bool are_equal(const Element& e1, const Element& e2) const {
     if (e1 == e2) return true;
     return get_value(e1) == get_value(e2);
   }
@@ -345,7 +345,7 @@ class Multi_field_operators
    * @param e Element to get the inverse from.
    * @return Inverse in the current field.
    */
-  element_type get_inverse(const element_type& e) const {
+  Element get_inverse(const Element& e) const {
     return get_partial_inverse(e, productOfAllCharacteristics_).first;
   }
   /**
@@ -356,19 +356,19 @@ class Multi_field_operators
    * @param productOfCharacteristics Product of the different characteristics to take into account in the multi-field.
    * @return Pair of the inverse of @p e and the characteristic the inverse is coming from.
    */
-  std::pair<element_type, characteristic_type> get_partial_inverse(
-      const element_type& e, const characteristic_type& productOfCharacteristics) const {
-    characteristic_type QR;
+  std::pair<Element, Characteristic> get_partial_inverse(
+      const Element& e, const Characteristic& productOfCharacteristics) const {
+    Characteristic QR;
     mpz_gcd(QR.get_mpz_t(), e.get_mpz_t(), productOfCharacteristics.get_mpz_t());  // QR <- gcd(x,QS)
 
     if (QR == productOfCharacteristics) return {0, get_multiplicative_identity()};  // partial inverse is 0
 
-    characteristic_type QT = productOfCharacteristics / QR;
+    Characteristic QT = productOfCharacteristics / QR;
 
-    characteristic_type inv_qt;
+    Characteristic inv_qt;
     mpz_invert(inv_qt.get_mpz_t(), e.get_mpz_t(), QT.get_mpz_t());
 
-    std::pair<element_type, characteristic_type> res(get_partial_multiplicative_identity(QT), QT);
+    std::pair<Element, Characteristic> res(get_partial_multiplicative_identity(QT), QT);
     res.first *= inv_qt;
     get_value_inplace(res.first);
 
@@ -380,13 +380,13 @@ class Multi_field_operators
    * 
    * @return The additive identity of a field.
    */
-  static const element_type& get_additive_identity() { return additiveID_; }
+  static const Element& get_additive_identity() { return additiveID_; }
   /**
    * @brief Returns the multiplicative identity of a field.
    * 
    * @return The multiplicative identity of a field.
    */
-  static const element_type& get_multiplicative_identity() { return multiplicativeID_; }
+  static const Element& get_multiplicative_identity() { return multiplicativeID_; }
 
   /**
    * @brief Returns the partial multiplicative identity of the multi-field from the given product.
@@ -395,11 +395,11 @@ class Multi_field_operators
    * @param productOfCharacteristics Product of the different characteristics to take into account in the multi-field.
    * @return The partial multiplicative identity of the multi-field.
    */
-  element_type get_partial_multiplicative_identity(const characteristic_type& productOfCharacteristics) const {
+  Element get_partial_multiplicative_identity(const Characteristic& productOfCharacteristics) const {
     if (productOfCharacteristics == 0) {
       return get_multiplicative_identity();
     }
-    element_type multIdentity(0);
+    Element multIdentity(0);
     for (unsigned int idx = 0; idx < primes_.size(); ++idx) {
       if ((productOfCharacteristics % primes_[idx]) == 0) {
         multIdentity += partials_[idx];
@@ -432,10 +432,10 @@ class Multi_field_operators
 
  private:
   std::vector<unsigned int> primes_;                /**< All characteristics. */
-  characteristic_type productOfAllCharacteristics_; /**< Product of all characteristics. */
-  std::vector<characteristic_type> partials_;       /**< Partial products of the characteristics. */
-  inline static const element_type multiplicativeID_ = 1;
-  inline static const element_type additiveID_ = 0;
+  Characteristic productOfAllCharacteristics_; /**< Product of all characteristics. */
+  std::vector<Characteristic> partials_;       /**< Partial products of the characteristics. */
+  inline static const Element multiplicativeID_ = 1;
+  inline static const Element additiveID_ = 0;
 
   static constexpr bool _is_prime(const int p) {
     if (p <= 1) return false;

--- a/src/Persistence_matrix/include/gudhi/Fields/Multi_field_shared.h
+++ b/src/Persistence_matrix/include/gudhi/Fields/Multi_field_shared.h
@@ -37,8 +37,8 @@ namespace persistence_fields {
 class Shared_multi_field_element 
 {
  public:
-  using element_type = mpz_class;           /**< Type for the elements in the field. */
-  using characteristic_type = element_type; /**< Type for the field characteristic. */
+  using Element = mpz_class;           /**< Type for the elements in the field. */
+  using Characteristic = Element; /**< Type for the field characteristic. */
 
   /**
    * @brief Default constructor. Sets the element to 0.
@@ -49,7 +49,7 @@ class Shared_multi_field_element
    * 
    * @param element Value of the element.
    */
-  Shared_multi_field_element(element_type element);
+  Shared_multi_field_element(Element element);
   /**
    * @brief Copy constructor.
    * 
@@ -89,21 +89,21 @@ class Shared_multi_field_element
   /**
    * @brief operator+=
    */
-  friend void operator+=(Shared_multi_field_element& f, element_type const v) {
+  friend void operator+=(Shared_multi_field_element& f, Element const v) {
     f.element_ += v;
     mpz_mod(f.element_.get_mpz_t(), f.element_.get_mpz_t(), productOfAllCharacteristics_.get_mpz_t());
   }
   /**
    * @brief operator+
    */
-  friend Shared_multi_field_element operator+(Shared_multi_field_element f, element_type const v) {
+  friend Shared_multi_field_element operator+(Shared_multi_field_element f, Element const v) {
     f += v;
     return f;
   }
   /**
    * @brief operator+
    */
-  friend element_type operator+(element_type v, Shared_multi_field_element const& f) {
+  friend Element operator+(Element v, Shared_multi_field_element const& f) {
     v += f.element_;
     mpz_mod(v.get_mpz_t(), v.get_mpz_t(), productOfAllCharacteristics_.get_mpz_t());
     return v;
@@ -126,21 +126,21 @@ class Shared_multi_field_element
   /**
    * @brief operator-=
    */
-  friend void operator-=(Shared_multi_field_element& f, element_type const v) {
+  friend void operator-=(Shared_multi_field_element& f, Element const v) {
     f.element_ -= v;
     mpz_mod(f.element_.get_mpz_t(), f.element_.get_mpz_t(), productOfAllCharacteristics_.get_mpz_t());
   }
   /**
    * @brief operator-
    */
-  friend Shared_multi_field_element operator-(Shared_multi_field_element f, element_type const v) {
+  friend Shared_multi_field_element operator-(Shared_multi_field_element f, Element const v) {
     f -= v;
     return f;
   }
   /**
    * @brief operator-
    */
-  friend element_type operator-(element_type v, Shared_multi_field_element const& f) {
+  friend Element operator-(Element v, Shared_multi_field_element const& f) {
     if (v >= productOfAllCharacteristics_)
       mpz_mod(v.get_mpz_t(), v.get_mpz_t(), productOfAllCharacteristics_.get_mpz_t());
     if (f.element_ > v) v += productOfAllCharacteristics_;
@@ -165,21 +165,21 @@ class Shared_multi_field_element
   /**
    * @brief operator*=
    */
-  friend void operator*=(Shared_multi_field_element& f, element_type const v) {
+  friend void operator*=(Shared_multi_field_element& f, Element const v) {
     f.element_ *= v;
     mpz_mod(f.element_.get_mpz_t(), f.element_.get_mpz_t(), productOfAllCharacteristics_.get_mpz_t());
   }
   /**
    * @brief operator*
    */
-  friend Shared_multi_field_element operator*(Shared_multi_field_element f, element_type const v) {
+  friend Shared_multi_field_element operator*(Shared_multi_field_element f, Element const v) {
     f *= v;
     return f;
   }
   /**
    * @brief operator*
    */
-  friend element_type operator*(element_type v, Shared_multi_field_element const& f) {
+  friend Element operator*(Element v, Shared_multi_field_element const& f) {
     v *= f.element_;
     mpz_mod(v.get_mpz_t(), v.get_mpz_t(), productOfAllCharacteristics_.get_mpz_t());
     return v;
@@ -194,18 +194,18 @@ class Shared_multi_field_element
   /**
    * @brief operator==
    */
-  friend bool operator==(const element_type& v, const Shared_multi_field_element& f) {
+  friend bool operator==(const Element& v, const Shared_multi_field_element& f) {
     if (v < productOfAllCharacteristics_) return v == f.element_;
-    element_type e(v);
+    Element e(v);
     mpz_mod(e.get_mpz_t(), e.get_mpz_t(), productOfAllCharacteristics_.get_mpz_t());
     return e == f.element_;
   }
   /**
    * @brief operator==
    */
-  friend bool operator==(const Shared_multi_field_element& f, const element_type& v) {
+  friend bool operator==(const Shared_multi_field_element& f, const Element& v) {
     if (v < productOfAllCharacteristics_) return v == f.element_;
-    element_type e(v);
+    Element e(v);
     mpz_mod(e.get_mpz_t(), e.get_mpz_t(), productOfAllCharacteristics_.get_mpz_t());
     return e == f.element_;
   }
@@ -218,11 +218,11 @@ class Shared_multi_field_element
   /**
    * @brief operator!=
    */
-  friend bool operator!=(const element_type& v, const Shared_multi_field_element& f) { return !(v == f); }
+  friend bool operator!=(const Element& v, const Shared_multi_field_element& f) { return !(v == f); }
   /**
    * @brief operator!=
    */
-  friend bool operator!=(const Shared_multi_field_element& f, const element_type& v) { return !(v == f); }
+  friend bool operator!=(const Shared_multi_field_element& f, const Element& v) { return !(v == f); }
 
   /**
    * @brief Assign operator.
@@ -231,7 +231,7 @@ class Shared_multi_field_element
   /**
    * @brief Assign operator.
    */
-  Shared_multi_field_element& operator=(const element_type& value);
+  Shared_multi_field_element& operator=(const Element& value);
   /**
    * @brief Swap operator.
    */
@@ -261,8 +261,8 @@ class Shared_multi_field_element
    * @param productOfCharacteristics Sub-product of the characteristics.
    * @return Pair of the inverse and the characteristic the inverse corresponds to.
    */
-  std::pair<Shared_multi_field_element, characteristic_type> get_partial_inverse(
-      const characteristic_type& productOfCharacteristics) const;
+  std::pair<Shared_multi_field_element, Characteristic> get_partial_inverse(
+      const Characteristic& productOfCharacteristics) const;
 
   /**
    * @brief Returns the additive identity of a field.
@@ -284,36 +284,36 @@ class Shared_multi_field_element
    * @return The partial multiplicative identity of the multi-field.
    */
   static Shared_multi_field_element get_partial_multiplicative_identity(
-      const characteristic_type& productOfCharacteristics);
+      const Characteristic& productOfCharacteristics);
   /**
    * @brief Returns the product of all characteristics.
    * 
    * @return The product of all characteristics.
    */
-  static characteristic_type get_characteristic();
+  static Characteristic get_characteristic();
 
   /**
    * @brief Returns the value of the element.
    * 
    * @return Value of the element.
    */
-  element_type get_value() const;
+  Element get_value() const;
 
   // static constexpr bool handles_only_z2() { return false; }
 
  private:
-  element_type element_;                                       /**< Element. */
+  Element element_;                                       /**< Element. */
   static inline std::vector<unsigned int> primes_;          /**< All characteristics. */
-  static inline characteristic_type productOfAllCharacteristics_ = 0; /**< Product of all characteristics. */
-  static inline std::vector<element_type> partials_;           /**< Partial products of the characteristics. */
-  static inline const element_type multiplicativeID_ = 1;      /**< Multiplicative identity. */
+  static inline Characteristic productOfAllCharacteristics_ = 0; /**< Product of all characteristics. */
+  static inline std::vector<Element> partials_;           /**< Partial products of the characteristics. */
+  static inline const Element multiplicativeID_ = 1;      /**< Multiplicative identity. */
 
   static constexpr bool _is_prime(const int p);
 };
 
 inline Shared_multi_field_element::Shared_multi_field_element() : element_(0) {}
 
-inline Shared_multi_field_element::Shared_multi_field_element(element_type element) : element_(element) {
+inline Shared_multi_field_element::Shared_multi_field_element(Element element) : element_(element) {
   mpz_mod(element_.get_mpz_t(), element_.get_mpz_t(), productOfAllCharacteristics_.get_mpz_t());
 }
 
@@ -374,7 +374,7 @@ inline Shared_multi_field_element& Shared_multi_field_element::operator=(Shared_
   return *this;
 }
 
-inline Shared_multi_field_element& Shared_multi_field_element::operator=(const element_type& value) {
+inline Shared_multi_field_element& Shared_multi_field_element::operator=(const Element& value) {
   mpz_mod(element_.get_mpz_t(), value.get_mpz_t(), productOfAllCharacteristics_.get_mpz_t());
   return *this;
 }
@@ -387,16 +387,16 @@ inline Shared_multi_field_element Shared_multi_field_element::get_inverse() cons
   return get_partial_inverse(productOfAllCharacteristics_).first;
 }
 
-inline std::pair<Shared_multi_field_element, Shared_multi_field_element::characteristic_type>
-Shared_multi_field_element::get_partial_inverse(const characteristic_type& productOfCharacteristics) const {
-  element_type QR;
+inline std::pair<Shared_multi_field_element, Shared_multi_field_element::Characteristic>
+Shared_multi_field_element::get_partial_inverse(const Characteristic& productOfCharacteristics) const {
+  Element QR;
   mpz_gcd(QR.get_mpz_t(), element_.get_mpz_t(), productOfCharacteristics.get_mpz_t());  // QR <- gcd(x,QS)
 
   if (QR == productOfCharacteristics) return {Shared_multi_field_element(), multiplicativeID_};  // partial inverse is 0
 
-  element_type QT = productOfCharacteristics / QR;
+  Element QT = productOfCharacteristics / QR;
 
-  element_type inv_qt;
+  Element inv_qt;
   mpz_invert(inv_qt.get_mpz_t(), element_.get_mpz_t(), QT.get_mpz_t());
 
   auto res = get_partial_multiplicative_identity(QT);
@@ -414,7 +414,7 @@ inline Shared_multi_field_element Shared_multi_field_element::get_multiplicative
 }
 
 inline Shared_multi_field_element Shared_multi_field_element::get_partial_multiplicative_identity(
-    const characteristic_type& productOfCharacteristics) {
+    const Characteristic& productOfCharacteristics) {
   if (productOfCharacteristics == 0) {
     return Shared_multi_field_element(multiplicativeID_);
   }
@@ -427,11 +427,11 @@ inline Shared_multi_field_element Shared_multi_field_element::get_partial_multip
   return mult;
 }
 
-inline Shared_multi_field_element::characteristic_type Shared_multi_field_element::get_characteristic() {
+inline Shared_multi_field_element::Characteristic Shared_multi_field_element::get_characteristic() {
   return productOfAllCharacteristics_;
 }
 
-inline Shared_multi_field_element::element_type Shared_multi_field_element::get_value() const { return element_; }
+inline Shared_multi_field_element::Element Shared_multi_field_element::get_value() const { return element_; }
 
 inline constexpr bool Shared_multi_field_element::_is_prime(const int p) {
   if (p <= 1) return false;

--- a/src/Persistence_matrix/include/gudhi/Fields/Multi_field_small.h
+++ b/src/Persistence_matrix/include/gudhi/Fields/Multi_field_small.h
@@ -42,8 +42,8 @@ template <unsigned int minimum, unsigned int maximum, typename Unsigned_integer_
           class = std::enable_if_t<std::is_unsigned_v<Unsigned_integer_type> > >
 class Multi_field_element_with_small_characteristics {
  public:
-  using element_type = Unsigned_integer_type; /**< Type for the elements in the field. */
-  using characteristic_type = element_type;   /**< Type for the field characteristic. */
+  using Element = Unsigned_integer_type; /**< Type for the elements in the field. */
+  using Characteristic = Element;   /**< Type for the field characteristic. */
   template <class T>
   using isInteger = std::enable_if_t<std::is_integral_v<T> >;
 
@@ -317,16 +317,16 @@ class Multi_field_element_with_small_characteristics {
    * @param productOfCharacteristics Sub-product of the characteristics.
    * @return Pair of the inverse and the characteristic the inverse corresponds to.
    */
-  std::pair<Multi_field_element_with_small_characteristics,characteristic_type> get_partial_inverse(
-      characteristic_type productOfCharacteristics) const {
-    characteristic_type gcd = std::gcd(element_, productOfAllCharacteristics_);
+  std::pair<Multi_field_element_with_small_characteristics,Characteristic> get_partial_inverse(
+      Characteristic productOfCharacteristics) const {
+    Characteristic gcd = std::gcd(element_, productOfAllCharacteristics_);
 
     if (gcd == productOfCharacteristics)
       return {Multi_field_element_with_small_characteristics(), multiplicativeID_};  // partial inverse is 0
 
-    characteristic_type QT = productOfCharacteristics / gcd;
+    Characteristic QT = productOfCharacteristics / gcd;
 
-    const element_type inv_qt = _get_inverse(element_, QT);
+    const Element inv_qt = _get_inverse(element_, QT);
 
     auto res = get_partial_multiplicative_identity(QT);
     res *= inv_qt;
@@ -358,12 +358,12 @@ class Multi_field_element_with_small_characteristics {
    * @return The partial multiplicative identity of the multi-field.
    */
   static Multi_field_element_with_small_characteristics get_partial_multiplicative_identity(
-      const characteristic_type& productOfCharacteristics) {
+      const Characteristic& productOfCharacteristics) {
     if (productOfCharacteristics == 0) {
       return Multi_field_element_with_small_characteristics<minimum, maximum>(multiplicativeID_);
     }
     Multi_field_element_with_small_characteristics<minimum, maximum> mult;
-    for (characteristic_type idx = 0; idx < primes_.size(); ++idx) {
+    for (Characteristic idx = 0; idx < primes_.size(); ++idx) {
       if ((productOfCharacteristics % primes_[idx]) == 0) {
         mult += partials_[idx];
       }
@@ -375,14 +375,14 @@ class Multi_field_element_with_small_characteristics {
    *
    * @return The product of all characteristics.
    */
-  static constexpr characteristic_type get_characteristic() { return productOfAllCharacteristics_; }
+  static constexpr Characteristic get_characteristic() { return productOfAllCharacteristics_; }
 
   /**
    * @brief Returns the value of the element.
    *
    * @return Value of the element.
    */
-  element_type get_value() const { return element_; }
+  Element get_value() const { return element_; }
 
   // static constexpr bool handles_only_z2() { return false; }
 
@@ -397,9 +397,9 @@ class Multi_field_element_with_small_characteristics {
 
     return true;
   }
-  static constexpr element_type _multiply(element_type a, element_type b) {
-    element_type res = 0;
-    element_type temp_b = 0;
+  static constexpr Element _multiply(Element a, Element b) {
+    Element res = 0;
+    Element temp_b = 0;
 
     if (b < a) std::swap(a, b);
 
@@ -418,7 +418,7 @@ class Multi_field_element_with_small_characteristics {
     }
     return res;
   }
-  static constexpr element_type _add(element_type element, element_type v) {
+  static constexpr Element _add(Element element, Element v) {
     if (UINT_MAX - element < v) {
       // automatic unsigned integer overflow behaviour will make it work
       element += v;
@@ -431,7 +431,7 @@ class Multi_field_element_with_small_characteristics {
 
     return element;
   }
-  static constexpr element_type _subtract(element_type element, element_type v) {
+  static constexpr Element _subtract(Element element, Element v) {
     if (element < v) {
       element += productOfAllCharacteristics_;
     }
@@ -439,7 +439,7 @@ class Multi_field_element_with_small_characteristics {
 
     return element;
   }
-  static constexpr int _get_inverse(element_type element, const element_type mod) {
+  static constexpr int _get_inverse(Element element, const Element mod) {
     // to solve: Ax + My = 1
     int M = mod;
     int A = element;
@@ -462,7 +462,7 @@ class Multi_field_element_with_small_characteristics {
   }
 
   template <typename Integer_type, class = isInteger<Integer_type> >
-  static constexpr element_type _get_value(Integer_type e) {
+  static constexpr Element _get_value(Integer_type e) {
     if constexpr (std::is_signed_v<Integer_type>){
       if (e < -static_cast<Integer_type>(productOfAllCharacteristics_)) e = e % productOfAllCharacteristics_;
       if (e < 0) return e += productOfAllCharacteristics_;
@@ -472,34 +472,34 @@ class Multi_field_element_with_small_characteristics {
     }
   }
 
-  element_type element_;
-  static inline const std::vector<characteristic_type> primes_ = []() {
-    std::vector<characteristic_type> res;
-    for (characteristic_type i = minimum; i <= maximum; ++i) {
+  Element element_;
+  static inline const std::vector<Characteristic> primes_ = []() {
+    std::vector<Characteristic> res;
+    for (Characteristic i = minimum; i <= maximum; ++i) {
       if (_is_prime(i)) {
         res.push_back(i);
       }
     }
     return res;
   }();
-  static inline constexpr characteristic_type productOfAllCharacteristics_ = []() {
-    characteristic_type res = 1;
-    for (characteristic_type i = minimum; i <= maximum; ++i) {
+  static inline constexpr Characteristic productOfAllCharacteristics_ = []() {
+    Characteristic res = 1;
+    for (Characteristic i = minimum; i <= maximum; ++i) {
       if (_is_prime(i)) {
         res *= i;
       }
     }
     return res;
   }();
-  static inline const std::vector<characteristic_type> partials_ = []() {
-    std::vector<characteristic_type> res;
+  static inline const std::vector<Characteristic> partials_ = []() {
+    std::vector<Characteristic> res;
 
     if (productOfAllCharacteristics_ == 1) return res;
 
-    for (characteristic_type i = 0; i < primes_.size(); ++i) {
-      characteristic_type p = primes_[i];
-      characteristic_type base = productOfAllCharacteristics_ / p;
-      characteristic_type exp = p - 1;
+    for (Characteristic i = 0; i < primes_.size(); ++i) {
+      Characteristic p = primes_[i];
+      Characteristic base = productOfAllCharacteristics_ / p;
+      Characteristic exp = p - 1;
       res.push_back(1);
 
       while (exp > 0) {
@@ -515,7 +515,7 @@ class Multi_field_element_with_small_characteristics {
   }();
   // If I understood the paper well, multiplicativeID_ always equals to 1. But in Clement's code,
   // multiplicativeID_ is computed (see commented lambda function below). TODO: verify with Clement.
-  static inline constexpr element_type multiplicativeID_ = 1; /*= [](){
+  static inline constexpr Element multiplicativeID_ = 1; /*= [](){
           unsigned int res = 0;
           for (unsigned int i = 0; i < partials_.size(); ++i){
                   res = (res + partials_[i]) % productOfAllCharacteristics_;

--- a/src/Persistence_matrix/include/gudhi/Fields/Multi_field_small_operators.h
+++ b/src/Persistence_matrix/include/gudhi/Fields/Multi_field_small_operators.h
@@ -37,8 +37,8 @@ namespace persistence_fields {
 class Multi_field_operators_with_small_characteristics 
 {
  public:
-  using element_type = unsigned int;          /**< Type for the elements in the field. */
-  using characteristic_type = element_type;   /**< Type for the field characteristic. */
+  using Element = unsigned int;          /**< Type for the elements in the field. */
+  using Characteristic = Element;   /**< Type for the field characteristic. */
 
   /**
    * @brief Default constructor, sets the product of all characteristics to 0.
@@ -108,7 +108,7 @@ class Multi_field_operators_with_small_characteristics
     partials_.resize(primes_.size());
     for (unsigned int i = 0; i < primes_.size(); ++i) {
       unsigned int p = primes_[i];
-      characteristic_type base = productOfAllCharacteristics_ / p;
+      Characteristic base = productOfAllCharacteristics_ / p;
       unsigned int exp = p - 1;
       partials_[i] = 1;
 
@@ -132,7 +132,7 @@ class Multi_field_operators_with_small_characteristics
    * 
    * @return The value of the current characteristic.
    */
-  const characteristic_type& get_characteristic() const { return productOfAllCharacteristics_; }
+  const Characteristic& get_characteristic() const { return productOfAllCharacteristics_; }
 
   /**
    * @brief Returns the value of an element in the field.
@@ -141,7 +141,7 @@ class Multi_field_operators_with_small_characteristics
    * @param e Integer to return the value from.
    * @return @p e modulo the current characteristic, such that the result is positive.
    */
-  element_type get_value(element_type e) const {
+  Element get_value(Element e) const {
     return e < productOfAllCharacteristics_ ? e : e % productOfAllCharacteristics_;
   }
 
@@ -152,7 +152,7 @@ class Multi_field_operators_with_small_characteristics
    * @param e2 Second element.
    * @return `(e1 + e2) % productOfAllCharacteristics`, such that the result is positive.
    */
-  element_type add(element_type e1, element_type e2) const {
+  Element add(Element e1, Element e2) const {
     return _add(get_value(e1), get_value(e2), productOfAllCharacteristics_);
   }
 
@@ -163,7 +163,7 @@ class Multi_field_operators_with_small_characteristics
    * @param e1 First element.
    * @param e2 Second element.
    */
-  void add_inplace(element_type& e1, element_type e2) const {
+  void add_inplace(Element& e1, Element e2) const {
     e1 = _add(get_value(e1), get_value(e2), productOfAllCharacteristics_);
   }
 
@@ -174,7 +174,7 @@ class Multi_field_operators_with_small_characteristics
    * @param e2 Second element.
    * @return `(e1 - e2) % productOfAllCharacteristics`, such that the result is positive.
    */
-  element_type subtract(element_type e1, element_type e2) const {
+  Element subtract(Element e1, Element e2) const {
     return _subtract(get_value(e1), get_value(e2), productOfAllCharacteristics_);
   }
 
@@ -185,7 +185,7 @@ class Multi_field_operators_with_small_characteristics
    * @param e1 First element.
    * @param e2 Second element.
    */
-  void subtract_inplace_front(element_type& e1, element_type e2) const {
+  void subtract_inplace_front(Element& e1, Element e2) const {
     e1 = _subtract(get_value(e1), get_value(e2), productOfAllCharacteristics_);
   }
   /**
@@ -195,7 +195,7 @@ class Multi_field_operators_with_small_characteristics
    * @param e1 First element.
    * @param e2 Second element.
    */
-  void subtract_inplace_back(element_type e1, element_type& e2) const {
+  void subtract_inplace_back(Element e1, Element& e2) const {
     e2 = _subtract(get_value(e1), get_value(e2), productOfAllCharacteristics_);
   }
 
@@ -206,7 +206,7 @@ class Multi_field_operators_with_small_characteristics
    * @param e2 Second element.
    * @return `(e1 * e2) % productOfAllCharacteristics`, such that the result is positive.
    */
-  element_type multiply(element_type e1, element_type e2) const {
+  Element multiply(Element e1, Element e2) const {
     return _multiply(get_value(e1), get_value(e2), productOfAllCharacteristics_);
   }
 
@@ -217,7 +217,7 @@ class Multi_field_operators_with_small_characteristics
    * @param e1 First element.
    * @param e2 Second element.
    */
-  void multiply_inplace(element_type& e1, element_type e2) const {
+  void multiply_inplace(Element& e1, Element e2) const {
     e1 = _multiply(get_value(e1), get_value(e2), productOfAllCharacteristics_);
   }
 
@@ -231,7 +231,7 @@ class Multi_field_operators_with_small_characteristics
    * @param a Third element.
    * @return `(e * m + a) % productOfAllCharacteristics`, such that the result is positive.
    */
-  element_type multiply_and_add(element_type e, element_type m, element_type a) const { return get_value(e * m + a); }
+  Element multiply_and_add(Element e, Element m, Element a) const { return get_value(e * m + a); }
 
   /**
    * @brief Multiplies the first element with the second one and adds the third one, that is
@@ -244,7 +244,7 @@ class Multi_field_operators_with_small_characteristics
    * @param m Second element.
    * @param a Third element.
    */
-  void multiply_and_add_inplace_front(element_type& e, element_type m, element_type a) const {
+  void multiply_and_add_inplace_front(Element& e, Element m, Element a) const {
     e = get_value(e * m + a);
   }
   /**
@@ -258,7 +258,7 @@ class Multi_field_operators_with_small_characteristics
    * @param m Second element.
    * @param a Third element.
    */
-  void multiply_and_add_inplace_back(element_type e, element_type m, element_type& a) const {
+  void multiply_and_add_inplace_back(Element e, Element m, Element& a) const {
     a = get_value(e * m + a);
   }
 
@@ -273,7 +273,7 @@ class Multi_field_operators_with_small_characteristics
    * @param m Third element.
    * @return `((e + a) * m) % productOfAllCharacteristics`, such that the result is positive.
    */
-  element_type add_and_multiply(element_type e, element_type a, element_type m) const { return get_value((e + a) * m); }
+  Element add_and_multiply(Element e, Element a, Element m) const { return get_value((e + a) * m); }
 
   /**
    * @brief Adds the first element to the second one and multiplies the third one with it, that is
@@ -286,7 +286,7 @@ class Multi_field_operators_with_small_characteristics
    * @param a Second element.
    * @param m Third element.
    */
-  void add_and_multiply_inplace_front(element_type& e, element_type a, element_type m) const {
+  void add_and_multiply_inplace_front(Element& e, Element a, Element m) const {
     e = get_value((e + a) * m);
   }
   /**
@@ -300,7 +300,7 @@ class Multi_field_operators_with_small_characteristics
    * @param a Second element.
    * @param m Third element.
    */
-  void add_and_multiply_inplace_back(element_type e, element_type a, element_type& m) const {
+  void add_and_multiply_inplace_back(Element e, Element a, Element& m) const {
     m = get_value((e + a) * m);
   }
 
@@ -312,7 +312,7 @@ class Multi_field_operators_with_small_characteristics
    * @return true If `e1 % productOfAllCharacteristics == e2 % productOfAllCharacteristics`.
    * @return false Otherwise.
    */
-  bool are_equal(element_type e1, element_type e2) const { return get_value(e1) == get_value(e2); }
+  bool are_equal(Element e1, Element e2) const { return get_value(e1) == get_value(e2); }
 
   /**
    * @brief Returns the inverse of the given element in the sense of @cite boissonnat:hal-00922572 with respect
@@ -321,7 +321,7 @@ class Multi_field_operators_with_small_characteristics
    * @param e Element to get the inverse from.
    * @return Inverse in the current field.
    */
-  element_type get_inverse(const element_type& e) const {
+  Element get_inverse(const Element& e) const {
     return get_partial_inverse(e, productOfAllCharacteristics_).first;
   }
   /**
@@ -332,15 +332,15 @@ class Multi_field_operators_with_small_characteristics
    * @param productOfCharacteristics Product of the different characteristics to take into account in the multi-field.
    * @return Pair of the inverse of @p e and the characteristic the inverse is coming from.
    */
-  std::pair<element_type, characteristic_type> get_partial_inverse(
-      const element_type& e, const characteristic_type& productOfCharacteristics) const {
-    characteristic_type gcd = std::gcd(e, productOfAllCharacteristics_);
+  std::pair<Element, Characteristic> get_partial_inverse(
+      const Element& e, const Characteristic& productOfCharacteristics) const {
+    Characteristic gcd = std::gcd(e, productOfAllCharacteristics_);
 
     if (gcd == productOfCharacteristics) return {0, get_multiplicative_identity()};  // partial inverse is 0
 
-    characteristic_type QT = productOfCharacteristics / gcd;
+    Characteristic QT = productOfCharacteristics / gcd;
 
-    const characteristic_type inv_qt = _get_inverse(e, QT);
+    const Characteristic inv_qt = _get_inverse(e, QT);
 
     auto res = get_partial_multiplicative_identity(QT);
     res = _multiply(res, inv_qt, productOfAllCharacteristics_);
@@ -353,14 +353,14 @@ class Multi_field_operators_with_small_characteristics
    * 
    * @return The additive identity of a field.
    */
-  static constexpr element_type get_additive_identity() { return 0; }
+  static constexpr Element get_additive_identity() { return 0; }
   /**
    * @brief Returns the multiplicative identity of a field.
    * 
    * @return The multiplicative identity of a field.
    */
-  static constexpr element_type get_multiplicative_identity() { return 1; }
-  // static element_type get_multiplicative_identity(){ return multiplicativeID_; }
+  static constexpr Element get_multiplicative_identity() { return 1; }
+  // static Element get_multiplicative_identity(){ return multiplicativeID_; }
   /**
    * @brief Returns the partial multiplicative identity of the multi-field from the given product.
    * See @cite boissonnat:hal-00922572 for more details.
@@ -368,11 +368,11 @@ class Multi_field_operators_with_small_characteristics
    * @param productOfCharacteristics Product of the different characteristics to take into account in the multi-field.
    * @return The partial multiplicative identity of the multi-field.
    */
-  element_type get_partial_multiplicative_identity(const characteristic_type& productOfCharacteristics) const {
+  Element get_partial_multiplicative_identity(const Characteristic& productOfCharacteristics) const {
     if (productOfCharacteristics == 0) {
       return get_multiplicative_identity();
     }
-    element_type multIdentity = 0;
+    Element multIdentity = 0;
     for (unsigned int idx = 0; idx < primes_.size(); ++idx) {
       if ((productOfCharacteristics % primes_[idx]) == 0) {
         multIdentity = _add(multIdentity, partials_[idx], productOfAllCharacteristics_);
@@ -405,20 +405,20 @@ class Multi_field_operators_with_small_characteristics
 
  private:
   std::vector<unsigned int> primes_;                /**< All characteristics. */
-  characteristic_type productOfAllCharacteristics_; /**< Product of all characteristics. */
-  std::vector<characteristic_type> partials_;       /**< Partial products of the characteristics. */
+  Characteristic productOfAllCharacteristics_; /**< Product of all characteristics. */
+  std::vector<Characteristic> partials_;       /**< Partial products of the characteristics. */
   // static inline constexpr unsigned int multiplicativeID_ = 1;
 
-  static element_type _add(element_type element, element_type v, characteristic_type characteristic);
-  static element_type _subtract(element_type element, element_type v, characteristic_type characteristic);
-  static element_type _multiply(element_type a, element_type b, characteristic_type characteristic);
-  static constexpr long int _get_inverse(element_type element, characteristic_type mod);
+  static Element _add(Element element, Element v, Characteristic characteristic);
+  static Element _subtract(Element element, Element v, Characteristic characteristic);
+  static Element _multiply(Element a, Element b, Characteristic characteristic);
+  static constexpr long int _get_inverse(Element element, Characteristic mod);
   static constexpr bool _is_prime(const int p);
 };
 
-inline Multi_field_operators_with_small_characteristics::element_type
-Multi_field_operators_with_small_characteristics::_add(element_type element, element_type v,
-                                                       characteristic_type characteristic) {
+inline Multi_field_operators_with_small_characteristics::Element
+Multi_field_operators_with_small_characteristics::_add(Element element, Element v,
+                                                       Characteristic characteristic) {
   if (UINT_MAX - element < v) {
     // automatic unsigned integer overflow behaviour will make it work
     element += v;
@@ -432,9 +432,9 @@ Multi_field_operators_with_small_characteristics::_add(element_type element, ele
   return element;
 }
 
-inline Multi_field_operators_with_small_characteristics::element_type
-Multi_field_operators_with_small_characteristics::_subtract(element_type element, element_type v,
-                                                             characteristic_type characteristic) {
+inline Multi_field_operators_with_small_characteristics::Element
+Multi_field_operators_with_small_characteristics::_subtract(Element element, Element v,
+                                                             Characteristic characteristic) {
   if (element < v) {
     element += characteristic;
   }
@@ -443,11 +443,11 @@ Multi_field_operators_with_small_characteristics::_subtract(element_type element
   return element;
 }
 
-inline Multi_field_operators_with_small_characteristics::element_type
-Multi_field_operators_with_small_characteristics::_multiply(element_type a, element_type b,
-                                                            characteristic_type characteristic) {
-  element_type res = 0;
-  element_type temp_b = 0;
+inline Multi_field_operators_with_small_characteristics::Element
+Multi_field_operators_with_small_characteristics::_multiply(Element a, Element b,
+                                                            Characteristic characteristic) {
+  Element res = 0;
+  Element temp_b = 0;
 
   if (b < a) std::swap(a, b);
 
@@ -467,11 +467,11 @@ Multi_field_operators_with_small_characteristics::_multiply(element_type a, elem
   return res;
 }
 
-inline constexpr long int Multi_field_operators_with_small_characteristics::_get_inverse(element_type element,
-                                                                                         characteristic_type mod) {
+inline constexpr long int Multi_field_operators_with_small_characteristics::_get_inverse(Element element,
+                                                                                         Characteristic mod) {
   // to solve: Ax + My = 1
-  element_type M = mod;
-  element_type A = element;
+  Element M = mod;
+  Element A = element;
   long int y = 0, x = 1;
   // extended euclidean division
   while (A > 1) {

--- a/src/Persistence_matrix/include/gudhi/Fields/Multi_field_small_shared.h
+++ b/src/Persistence_matrix/include/gudhi/Fields/Multi_field_small_shared.h
@@ -44,8 +44,8 @@ template <typename Unsigned_integer_type = unsigned int,
           class = std::enable_if_t<std::is_unsigned_v<Unsigned_integer_type> > >
 class Shared_multi_field_element_with_small_characteristics {
  public:
-  using element_type = Unsigned_integer_type; /**< Type for the elements in the field. */
-  using characteristic_type = element_type;   /**< Type for the field characteristic. */
+  using Element = Unsigned_integer_type; /**< Type for the elements in the field. */
+  using Characteristic = Element;   /**< Type for the field characteristic. */
   template <class T>
   using isInteger = std::enable_if_t<std::is_integral_v<T> >;
 
@@ -104,10 +104,10 @@ class Shared_multi_field_element_with_small_characteristics {
     if (primes_.empty()) throw std::invalid_argument("The given interval does not contain a prime number.");
 
     partials_.resize(primes_.size());
-    for (characteristic_type i = 0; i < primes_.size(); ++i) {
-      characteristic_type p = primes_[i];
-      characteristic_type base = productOfAllCharacteristics_ / p;
-      characteristic_type exp = p - 1;
+    for (Characteristic i = 0; i < primes_.size(); ++i) {
+      Characteristic p = primes_[i];
+      Characteristic base = productOfAllCharacteristics_ / p;
+      Characteristic exp = p - 1;
       partials_[i] = 1;
 
       while (exp > 0) {
@@ -363,16 +363,16 @@ class Shared_multi_field_element_with_small_characteristics {
    * @param productOfCharacteristics Sub-product of the characteristics.
    * @return Pair of the inverse and the characteristic the inverse corresponds to.
    */
-  std::pair<Shared_multi_field_element_with_small_characteristics,characteristic_type> get_partial_inverse(
-      characteristic_type productOfCharacteristics) const {
-    characteristic_type gcd = std::gcd(element_, productOfAllCharacteristics_);
+  std::pair<Shared_multi_field_element_with_small_characteristics,Characteristic> get_partial_inverse(
+      Characteristic productOfCharacteristics) const {
+    Characteristic gcd = std::gcd(element_, productOfAllCharacteristics_);
 
     if (gcd == productOfCharacteristics)
       return {Shared_multi_field_element_with_small_characteristics(), multiplicativeID_};  // partial inverse is 0
 
-    characteristic_type QT = productOfCharacteristics / gcd;
+    Characteristic QT = productOfCharacteristics / gcd;
 
-    const element_type inv_qt = _get_inverse(element_, QT);
+    const Element inv_qt = _get_inverse(element_, QT);
 
     auto res = get_partial_multiplicative_identity(QT);
     res *= inv_qt;
@@ -404,12 +404,12 @@ class Shared_multi_field_element_with_small_characteristics {
    * @return The partial multiplicative identity of the multi-field.
    */
   static Shared_multi_field_element_with_small_characteristics get_partial_multiplicative_identity(
-      const characteristic_type& productOfCharacteristics) {
+      const Characteristic& productOfCharacteristics) {
     if (productOfCharacteristics == 0) {
       return Shared_multi_field_element_with_small_characteristics(multiplicativeID_);
     }
     Shared_multi_field_element_with_small_characteristics mult;
-    for (characteristic_type idx = 0; idx < primes_.size(); ++idx) {
+    for (Characteristic idx = 0; idx < primes_.size(); ++idx) {
       if ((productOfCharacteristics % primes_[idx]) == 0) {
         mult += partials_[idx];
       }
@@ -421,14 +421,14 @@ class Shared_multi_field_element_with_small_characteristics {
    *
    * @return The product of all characteristics.
    */
-  static characteristic_type get_characteristic() { return productOfAllCharacteristics_; }
+  static Characteristic get_characteristic() { return productOfAllCharacteristics_; }
 
   /**
    * @brief Returns the value of the element.
    *
    * @return Value of the element.
    */
-  element_type get_value() const { return element_; }
+  Element get_value() const { return element_; }
 
   // static constexpr bool handles_only_z2() { return false; }
 
@@ -443,9 +443,9 @@ class Shared_multi_field_element_with_small_characteristics {
 
     return true;
   }
-  static element_type _multiply(element_type a, element_type b) {
-    element_type res = 0;
-    element_type temp_b = 0;
+  static Element _multiply(Element a, Element b) {
+    Element res = 0;
+    Element temp_b = 0;
 
     if (b < a) std::swap(a, b);
 
@@ -464,7 +464,7 @@ class Shared_multi_field_element_with_small_characteristics {
     }
     return res;
   }
-  static element_type _add(element_type element, element_type v) {
+  static Element _add(Element element, Element v) {
     if (UINT_MAX - element < v) {
       // automatic unsigned integer overflow behaviour will make it work
       element += v;
@@ -477,7 +477,7 @@ class Shared_multi_field_element_with_small_characteristics {
 
     return element;
   }
-  static element_type _subtract(element_type element, element_type v) {
+  static Element _subtract(Element element, Element v) {
     if (element < v) {
       element += productOfAllCharacteristics_;
     }
@@ -485,7 +485,7 @@ class Shared_multi_field_element_with_small_characteristics {
 
     return element;
   }
-  static constexpr int _get_inverse(element_type element, const characteristic_type mod) {
+  static constexpr int _get_inverse(Element element, const Characteristic mod) {
     // to solve: Ax + My = 1
     int M = mod;
     int A = element;
@@ -508,7 +508,7 @@ class Shared_multi_field_element_with_small_characteristics {
   }
 
   template <typename Integer_type, class = isInteger<Integer_type> >
-  static constexpr element_type _get_value(Integer_type e) {
+  static constexpr Element _get_value(Integer_type e) {
     if constexpr (std::is_signed_v<Integer_type>){
       if (e < -static_cast<Integer_type>(productOfAllCharacteristics_)) e = e % productOfAllCharacteristics_;
       if (e < 0) return e += productOfAllCharacteristics_;
@@ -518,11 +518,11 @@ class Shared_multi_field_element_with_small_characteristics {
     }
   }
 
-  element_type element_;                                          /**< Element. */
-  static inline std::vector<characteristic_type> primes_;         /**< All characteristics. */
-  static inline characteristic_type productOfAllCharacteristics_; /**< Product of all characteristics. */
-  static inline std::vector<characteristic_type> partials_;       /**< Partial products of the characteristics. */
-  static inline constexpr element_type multiplicativeID_ = 1;     /**< Multiplicative identity. */
+  Element element_;                                          /**< Element. */
+  static inline std::vector<Characteristic> primes_;         /**< All characteristics. */
+  static inline Characteristic productOfAllCharacteristics_; /**< Product of all characteristics. */
+  static inline std::vector<Characteristic> partials_;       /**< Partial products of the characteristics. */
+  static inline constexpr Element multiplicativeID_ = 1;     /**< Multiplicative identity. */
 };
 
 }  // namespace persistence_fields

--- a/src/Persistence_matrix/include/gudhi/Fields/Z2_field.h
+++ b/src/Persistence_matrix/include/gudhi/Fields/Z2_field.h
@@ -31,7 +31,7 @@ namespace persistence_fields {
 class Z2_field_element
 {
  public:
-  using element_type = bool;  /**< Type for the elements in the field. */
+  using Element = bool;  /**< Type for the elements in the field. */
   template <class T>
   using isInteger = std::enable_if_t<std::is_integral_v<T> >;
 
@@ -288,15 +288,15 @@ class Z2_field_element
    * 
    * @return Value of the element.
    */
-  element_type get_value() const;
+  Element get_value() const;
 
   // static constexpr bool handles_only_z2() { return true; }
 
  private:
-  element_type element_;
+  Element element_;
 
   template <typename Integer_type, class = isInteger<Integer_type> >
-  static constexpr element_type _get_value(Integer_type e) {
+  static constexpr Element _get_value(Integer_type e) {
     if constexpr (std::is_same_v<Integer_type, bool>) {
       return e;
     } else {
@@ -347,7 +347,7 @@ inline Z2_field_element Z2_field_element::get_partial_multiplicative_identity(
 
 inline constexpr unsigned int Z2_field_element::get_characteristic() { return 2; }
 
-inline Z2_field_element::element_type Z2_field_element::get_value() const { return element_; }
+inline Z2_field_element::Element Z2_field_element::get_value() const { return element_; }
 
 }  // namespace persistence_fields
 }  // namespace Gudhi

--- a/src/Persistence_matrix/include/gudhi/Fields/Z2_field_operators.h
+++ b/src/Persistence_matrix/include/gudhi/Fields/Z2_field_operators.h
@@ -31,8 +31,8 @@ namespace persistence_fields {
 class Z2_field_operators
 {
  public:
-  using element_type = bool;                /**< Type for the elements in the field. */
-  using characteristic_type = unsigned int; /**< Type for the field characteristic. */
+  using Element = bool;                /**< Type for the elements in the field. */
+  using Characteristic = unsigned int; /**< Type for the field characteristic. */
   template <class T>
   using isUnsignedInteger = std::enable_if_t<std::is_unsigned_v<T> >;
   template <class T>
@@ -48,7 +48,7 @@ class Z2_field_operators
    * 
    * @return 2.
    */
-  static constexpr characteristic_type get_characteristic() { return 2; }
+  static constexpr Characteristic get_characteristic() { return 2; }
 
   /**
    * @brief Returns the value of an integer in the field.
@@ -59,7 +59,7 @@ class Z2_field_operators
    * @return A boolean representing `e % 2`.
    */
   template <typename Integer_type, class = isInteger<Integer_type> >
-  static element_type get_value(Integer_type e) {
+  static Element get_value(Integer_type e) {
     if constexpr (std::is_same_v<Integer_type, bool>) {
       return e;
     } else {
@@ -76,7 +76,7 @@ class Z2_field_operators
    * @return `(e1 + e2) % 2` as a boolean.
    */
   template <typename Unsigned_integer_type, class = isUnsignedInteger<Unsigned_integer_type> >
-  static element_type add(Unsigned_integer_type e1, Unsigned_integer_type e2) {
+  static Element add(Unsigned_integer_type e1, Unsigned_integer_type e2) {
     if constexpr (std::is_same_v<Unsigned_integer_type, bool>) {
       return e1 != e2;
     } else {
@@ -110,7 +110,7 @@ class Z2_field_operators
    * @return `(e1 - e2) % 2` as a boolean.
    */
   template <typename Unsigned_integer_type, class = isUnsignedInteger<Unsigned_integer_type> >
-  static element_type subtract(Unsigned_integer_type e1, Unsigned_integer_type e2) {
+  static Element subtract(Unsigned_integer_type e1, Unsigned_integer_type e2) {
     if constexpr (std::is_same_v<Unsigned_integer_type, bool>) {
       return e1 != e2;
     } else {
@@ -160,7 +160,7 @@ class Z2_field_operators
    * @return `(e1 * e2) % 2` as a boolean.
    */
   template <typename Unsigned_integer_type, class = isUnsignedInteger<Unsigned_integer_type> >
-  static element_type multiply(Unsigned_integer_type e1, Unsigned_integer_type e2) {
+  static Element multiply(Unsigned_integer_type e1, Unsigned_integer_type e2) {
     if constexpr (std::is_same_v<Unsigned_integer_type, bool>) {
       return e1 && e2;
     } else {
@@ -195,7 +195,7 @@ class Z2_field_operators
    * @return `(e * m + a) % 2` as a boolean.
    */
   template <typename Unsigned_integer_type, class = isUnsignedInteger<Unsigned_integer_type> >
-  static element_type multiply_and_add(Unsigned_integer_type e, Unsigned_integer_type m, Unsigned_integer_type a) {
+  static Element multiply_and_add(Unsigned_integer_type e, Unsigned_integer_type m, Unsigned_integer_type a) {
     if constexpr (std::is_same_v<Unsigned_integer_type, bool>) {
       return (e && m) != a;
     } else {
@@ -254,7 +254,7 @@ class Z2_field_operators
    * @return `((e + a) * m) % 2` as a boolean.
    */
   template <typename Unsigned_integer_type, class = isUnsignedInteger<Unsigned_integer_type> >
-  static element_type add_and_multiply(Unsigned_integer_type e, Unsigned_integer_type a, Unsigned_integer_type m) {
+  static Element add_and_multiply(Unsigned_integer_type e, Unsigned_integer_type a, Unsigned_integer_type m) {
     if constexpr (std::is_same_v<Unsigned_integer_type, bool>) {
       return (e != a) && m;
     } else {
@@ -323,7 +323,7 @@ class Z2_field_operators
    * @return Inverse in the current field of `e % 2`.
    */
   template <typename Unsigned_integer_type, class = isUnsignedInteger<Unsigned_integer_type> >
-  static element_type get_inverse(Unsigned_integer_type e) {
+  static Element get_inverse(Unsigned_integer_type e) {
     if constexpr (std::is_same_v<Unsigned_integer_type, bool>) {
       return e;
     } else {
@@ -339,8 +339,8 @@ class Z2_field_operators
    * @return Pair whose first element is the inverse of @p e and the second element is @p productOfCharacteristics.
    */
   template <typename Unsigned_integer_type, class = isUnsignedInteger<Unsigned_integer_type> >
-  static std::pair<element_type, characteristic_type> get_partial_inverse(
-      Unsigned_integer_type e, characteristic_type productOfCharacteristics) {
+  static std::pair<Element, Characteristic> get_partial_inverse(
+      Unsigned_integer_type e, Characteristic productOfCharacteristics) {
     return {get_inverse(e), productOfCharacteristics};
   }
 
@@ -349,21 +349,21 @@ class Z2_field_operators
    * 
    * @return false.
    */
-  static constexpr element_type get_additive_identity() { return false; }
+  static constexpr Element get_additive_identity() { return false; }
   /**
    * @brief Returns the multiplicative identity of the field.
    * 
    * @return true.
    */
-  static constexpr element_type get_multiplicative_identity() { return true; }
+  static constexpr Element get_multiplicative_identity() { return true; }
   /**
    * @brief For interface purposes with multi-fields. Returns the multiplicative identity of the field.
    * 
    * @param productOfCharacteristics Some value.
    * @return true.
    */
-  static constexpr element_type get_partial_multiplicative_identity(
-      [[maybe_unused]] characteristic_type productOfCharacteristics) {
+  static constexpr Element get_partial_multiplicative_identity(
+      [[maybe_unused]] Characteristic productOfCharacteristics) {
     return true;
   }
 

--- a/src/Persistence_matrix/include/gudhi/Fields/Zp_field.h
+++ b/src/Persistence_matrix/include/gudhi/Fields/Zp_field.h
@@ -38,8 +38,8 @@ template <unsigned int characteristic, typename Unsigned_integer_type = unsigned
           class = std::enable_if_t<std::is_unsigned_v<Unsigned_integer_type> > >
 class Zp_field_element {
  public:
-  using element_type = Unsigned_integer_type; /**< Type for the elements in the field. */
-  using characteristic_type = element_type;   /**< Type for the field characteristic. */
+  using Element = Unsigned_integer_type; /**< Type for the elements in the field. */
+  using Characteristic = Element;   /**< Type for the field characteristic. */
   template <class T>
   using isInteger = std::enable_if_t<std::is_integral_v<T> >;
 
@@ -321,15 +321,15 @@ class Zp_field_element {
    * 
    * @return Value of the element.
    */
-  element_type get_value() const { return element_; }
+  Element get_value() const { return element_; }
 
   // static constexpr bool handles_only_z2() { return false; }
 
  private:
-  element_type element_;                                            /**< Field element. */
+  Element element_;                                            /**< Field element. */
   static inline std::array<unsigned int, characteristic> inverse_;  /**< All inverse elements. */
 
-  static element_type _add(element_type element, element_type v) {
+  static Element _add(Element element, Element v) {
     if (UINT_MAX - element < v) {
       // automatic unsigned integer overflow behaviour will make it work
       element += v;
@@ -342,7 +342,7 @@ class Zp_field_element {
 
     return element;
   }
-  static element_type _subtract(element_type element, element_type v) {
+  static Element _subtract(Element element, Element v) {
     if (element < v) {
       element += characteristic;
     }
@@ -350,10 +350,10 @@ class Zp_field_element {
 
     return element;
   }
-  static element_type _multiply(element_type element, element_type v) {
-    element_type a = element;
+  static Element _multiply(Element element, Element v) {
+    Element a = element;
     element = 0;
-    element_type temp_b;
+    Element temp_b;
 
     while (a != 0) {
       if (a & 1) {
@@ -369,7 +369,7 @@ class Zp_field_element {
 
     return element;
   }
-  static int _get_inverse(element_type element) {
+  static int _get_inverse(Element element) {
     // to solve: Ax + My = 1
     int M = characteristic;
     int A = element;
@@ -392,7 +392,7 @@ class Zp_field_element {
   }
 
   template <typename Integer_type, class = isInteger<Integer_type> >
-  static constexpr element_type _get_value(Integer_type e) {
+  static constexpr Element _get_value(Integer_type e) {
     if constexpr (std::is_signed_v<Integer_type>) {
       if (e < -static_cast<Integer_type>(characteristic)) e = e % characteristic;
       if (e < 0) return e += characteristic;

--- a/src/Persistence_matrix/include/gudhi/Fields/Zp_field_operators.h
+++ b/src/Persistence_matrix/include/gudhi/Fields/Zp_field_operators.h
@@ -40,8 +40,8 @@ template <typename Unsigned_integer_type = unsigned int,
 class Zp_field_operators
 {
  public:
-  using element_type = Unsigned_integer_type; /**< Type for the elements in the field. */
-  using characteristic_type = element_type;   /**< Type for the field characteristic. */
+  using Element = Unsigned_integer_type; /**< Type for the elements in the field. */
+  using Characteristic = Element;   /**< Type for the field characteristic. */
   template <class T>
   using isSignedInteger = std::enable_if_t<std::is_signed_v<T> >;
 
@@ -51,7 +51,7 @@ class Zp_field_operators
    *
    * @param characteristic Prime number corresponding to the desired characteristic of the field.
    */
-  Zp_field_operators(characteristic_type characteristic = 0) : characteristic_(0) {
+  Zp_field_operators(Characteristic characteristic = 0) : characteristic_(0) {
     if (characteristic != 0) set_characteristic(characteristic);
   }
   /**
@@ -74,7 +74,7 @@ class Zp_field_operators
    * 
    * @param characteristic Prime number corresponding to the desired characteristic of the field.
    */
-  void set_characteristic(characteristic_type characteristic) {
+  void set_characteristic(Characteristic characteristic) {
     if (characteristic <= 1)
       throw std::invalid_argument("Characteristic must be strictly positive and a prime number.");
 
@@ -98,7 +98,7 @@ class Zp_field_operators
    * 
    * @return The value of the current characteristic.
    */
-  const characteristic_type& get_characteristic() const { return characteristic_; }
+  const Characteristic& get_characteristic() const { return characteristic_; }
 
   /**
    * @brief Returns the value of an integer in the field.
@@ -107,7 +107,7 @@ class Zp_field_operators
    * @param e Unsigned integer to return the value from.
    * @return @p e modulo the current characteristic, such that the result is positive.
    */
-  element_type get_value(element_type e) const { return e < characteristic_ ? e : e % characteristic_; }
+  Element get_value(Element e) const { return e < characteristic_ ? e : e % characteristic_; }
   /**
    * @brief Returns the value of an integer in the field.
    * That is the positive value of the integer modulo the current characteristic.
@@ -117,7 +117,7 @@ class Zp_field_operators
    * @return @p e modulo the current characteristic, such that the result is positive.
    */
   template <typename Signed_integer_type, class = isSignedInteger<Signed_integer_type> >
-  element_type get_value(Signed_integer_type e) const {
+  Element get_value(Signed_integer_type e) const {
     if (e < -static_cast<Signed_integer_type>(characteristic_)) e = e % characteristic_;
     if (e < 0) return e += characteristic_;
     return e < static_cast<Signed_integer_type>(characteristic_) ? e : e % characteristic_;
@@ -130,7 +130,7 @@ class Zp_field_operators
    * @param e2 Second element.
    * @return `(e1 + e2) % characteristic`, such that the result is positive.
    */
-  element_type add(element_type e1, element_type e2) const {
+  Element add(Element e1, Element e2) const {
     return _add(get_value(e1), get_value(e2), characteristic_);
   }
 
@@ -141,7 +141,7 @@ class Zp_field_operators
    * @param e1 First element.
    * @param e2 Second element.
    */
-  void add_inplace(element_type& e1, element_type e2) const {
+  void add_inplace(Element& e1, Element e2) const {
     e1 = _add(get_value(e1), get_value(e2), characteristic_);
   }
 
@@ -152,7 +152,7 @@ class Zp_field_operators
    * @param e2 Second element.
    * @return `(e1 - e2) % characteristic`, such that the result is positive.
    */
-  element_type subtract(element_type e1, element_type e2) const {
+  Element subtract(Element e1, Element e2) const {
     return _subtract(get_value(e1), get_value(e2), characteristic_);
   }
 
@@ -163,7 +163,7 @@ class Zp_field_operators
    * @param e1 First element.
    * @param e2 Second element.
    */
-  void subtract_inplace_front(element_type& e1, element_type e2) const {
+  void subtract_inplace_front(Element& e1, Element e2) const {
     e1 = _subtract(get_value(e1), get_value(e2), characteristic_);
   }
   /**
@@ -173,7 +173,7 @@ class Zp_field_operators
    * @param e1 First element.
    * @param e2 Second element.
    */
-  void subtract_inplace_back(element_type e1, element_type& e2) const {
+  void subtract_inplace_back(Element e1, Element& e2) const {
     e2 = _subtract(get_value(e1), get_value(e2), characteristic_);
   }
 
@@ -184,7 +184,7 @@ class Zp_field_operators
    * @param e2 Second element.
    * @return `(e1 * e2) % characteristic`, such that the result is positive.
    */
-  element_type multiply(element_type e1, element_type e2) const {
+  Element multiply(Element e1, Element e2) const {
     return _multiply(get_value(e1), get_value(e2), characteristic_);
   }
 
@@ -195,7 +195,7 @@ class Zp_field_operators
    * @param e1 First element.
    * @param e2 Second element.
    */
-  void multiply_inplace(element_type& e1, element_type e2) const {
+  void multiply_inplace(Element& e1, Element e2) const {
     e1 = _multiply(get_value(e1), get_value(e2), characteristic_);
   }
 
@@ -209,7 +209,7 @@ class Zp_field_operators
    * @param a Third element.
    * @return `(e * m + a) % characteristic`, such that the result is positive.
    */
-  element_type multiply_and_add(element_type e, element_type m, element_type a) const { return get_value(e * m + a); }
+  Element multiply_and_add(Element e, Element m, Element a) const { return get_value(e * m + a); }
 
   /**
    * @brief Multiplies the first element with the second one and adds the third one, that is
@@ -221,7 +221,7 @@ class Zp_field_operators
    * @param m Second element.
    * @param a Third element.
    */
-  void multiply_and_add_inplace_front(element_type& e, element_type m, element_type a) const {
+  void multiply_and_add_inplace_front(Element& e, Element m, Element a) const {
     e = get_value(e * m + a);
   }
   /**
@@ -234,7 +234,7 @@ class Zp_field_operators
    * @param m Second element.
    * @param a Third element.
    */
-  void multiply_and_add_inplace_back(element_type e, element_type m, element_type& a) const {
+  void multiply_and_add_inplace_back(Element e, Element m, Element& a) const {
     a = get_value(e * m + a);
   }
 
@@ -249,7 +249,7 @@ class Zp_field_operators
    * @param m Third element.
    * @return `((e + a) * m) % characteristic`, such that the result is positive.
    */
-  element_type add_and_multiply(element_type e, element_type a, element_type m) const { return get_value((e + a) * m); }
+  Element add_and_multiply(Element e, Element a, Element m) const { return get_value((e + a) * m); }
 
   /**
    * @brief Adds the first element to the second one and multiplies the third one with it, that is
@@ -261,7 +261,7 @@ class Zp_field_operators
    * @param a Second element.
    * @param m Third element.
    */
-  void add_and_multiply_inplace_front(element_type& e, element_type a, element_type m) const {
+  void add_and_multiply_inplace_front(Element& e, Element a, Element m) const {
     e = get_value((e + a) * m);
   }
   /**
@@ -274,7 +274,7 @@ class Zp_field_operators
    * @param a Second element.
    * @param m Third element.
    */
-  void add_and_multiply_inplace_back(element_type e, element_type a, element_type& m) const {
+  void add_and_multiply_inplace_back(Element e, Element a, Element& m) const {
     m = get_value((e + a) * m);
   }
 
@@ -286,7 +286,7 @@ class Zp_field_operators
    * @return true If `e1 % characteristic == e2 % characteristic`.
    * @return false Otherwise.
    */
-  bool are_equal(element_type e1, element_type e2) const { return get_value(e1) == get_value(e2); }
+  bool are_equal(Element e1, Element e2) const { return get_value(e1) == get_value(e2); }
 
   /**
    * @brief Returns the inverse of the given element in the field.
@@ -294,7 +294,7 @@ class Zp_field_operators
    * @param e Element to get the inverse from.
    * @return Inverse in the current field of `e % characteristic`.
    */
-  element_type get_inverse(element_type e) const { return inverse_[get_value(e)]; }
+  Element get_inverse(Element e) const { return inverse_[get_value(e)]; }
   /**
    * @brief For interface purposes with multi-fields. Returns the inverse together with the second argument.
    * 
@@ -302,8 +302,8 @@ class Zp_field_operators
    * @param productOfCharacteristics Some value.
    * @return Pair whose first element is the inverse of @p e and the second element is @p productOfCharacteristics.
    */
-  std::pair<element_type, characteristic_type> get_partial_inverse(element_type e,
-                                                                   characteristic_type productOfCharacteristics) const {
+  std::pair<Element, Characteristic> get_partial_inverse(Element e,
+                                                                   Characteristic productOfCharacteristics) const {
     return {get_inverse(e), productOfCharacteristics};
   }
 
@@ -312,21 +312,21 @@ class Zp_field_operators
    * 
    * @return 0.
    */
-  static constexpr element_type get_additive_identity() { return 0; }
+  static constexpr Element get_additive_identity() { return 0; }
   /**
    * @brief Returns the multiplicative identity of the field.
    * 
    * @return 1.
    */
-  static constexpr element_type get_multiplicative_identity() { return 1; }
+  static constexpr Element get_multiplicative_identity() { return 1; }
   /**
    * @brief For interface purposes with multi-fields. Returns the multiplicative identity of the field.
    * 
    * @param productOfCharacteristics Some value.
    * @return 1.
    */
-  static constexpr element_type get_partial_multiplicative_identity(
-      [[maybe_unused]] characteristic_type productOfCharacteristics) {
+  static constexpr Element get_partial_multiplicative_identity(
+      [[maybe_unused]] Characteristic productOfCharacteristics) {
     return 1;
   }
 
@@ -349,10 +349,10 @@ class Zp_field_operators
   }
 
  private:
-  characteristic_type characteristic_;  /**< Current characteristic of the field. */
-  std::vector<element_type> inverse_;   /**< All inverse elements. */
+  Characteristic characteristic_;  /**< Current characteristic of the field. */
+  std::vector<Element> inverse_;   /**< All inverse elements. */
 
-  static element_type _add(element_type e1, element_type e2, characteristic_type characteristic) {
+  static Element _add(Element e1, Element e2, Characteristic characteristic) {
     if (UINT_MAX - e1 < e2) {
       // automatic unsigned integer overflow behaviour will make it work
       e1 += e2;
@@ -365,7 +365,7 @@ class Zp_field_operators
 
     return e1;
   }
-  static element_type _subtract(element_type e1, element_type e2, characteristic_type characteristic) {
+  static Element _subtract(Element e1, Element e2, Characteristic characteristic) {
     if (e1 < e2) {
       e1 += characteristic;
     }
@@ -373,7 +373,7 @@ class Zp_field_operators
 
     return e1;
   }
-  static element_type _multiply(element_type e1, element_type e2, characteristic_type characteristic) {
+  static Element _multiply(Element e1, Element e2, Characteristic characteristic) {
     unsigned int a = e1;
     e1 = 0;
     unsigned int temp_b;

--- a/src/Persistence_matrix/include/gudhi/Fields/Zp_field_shared.h
+++ b/src/Persistence_matrix/include/gudhi/Fields/Zp_field_shared.h
@@ -41,8 +41,8 @@ template <typename Unsigned_integer_type = unsigned int,
           class = std::enable_if_t<std::is_unsigned_v<Unsigned_integer_type> > >
 class Shared_Zp_field_element {
  public:
-  using element_type = Unsigned_integer_type; /**< Type for the elements in the field. */
-  using characteristic_type = element_type;   /**< Type for the field characteristic. */
+  using Element = Unsigned_integer_type; /**< Type for the elements in the field. */
+  using Characteristic = Element;   /**< Type for the field characteristic. */
   template <class T>
   using isInteger = std::enable_if_t<std::is_integral_v<T> >;
 
@@ -77,15 +77,15 @@ class Shared_Zp_field_element {
    * 
    * @param characteristic Characteristic of the field. A positive prime number.
    */
-  static void initialize(characteristic_type characteristic) {
+  static void initialize(Characteristic characteristic) {
     if (characteristic <= 1)
       throw std::invalid_argument("Characteristic must be strictly positive and a prime number.");
 
     inverse_.resize(characteristic);
     inverse_[0] = 0;
-    for (element_type i = 1; i < characteristic; ++i) {
-      element_type inv = 1;
-      element_type mult = inv * i;
+    for (Element i = 1; i < characteristic; ++i) {
+      Element inv = 1;
+      Element mult = inv * i;
       while ((mult % characteristic) != 1) {
         ++inv;
         if (mult == characteristic) throw std::invalid_argument("Characteristic must be a prime number.");
@@ -102,7 +102,7 @@ class Shared_Zp_field_element {
    * 
    * @return Value of the element.
    */
-  element_type get_value() const { return element_; }
+  Element get_value() const { return element_; }
 
   /**
    * @brief operator+=
@@ -318,8 +318,8 @@ class Shared_Zp_field_element {
    * @param productOfCharacteristics Some value.
    * @return Pair whose first element is the inverse and the second element is @p productOfCharacteristics.
    */
-  std::pair<Shared_Zp_field_element, characteristic_type> get_partial_inverse(
-      characteristic_type productOfCharacteristics) const {
+  std::pair<Shared_Zp_field_element, Characteristic> get_partial_inverse(
+      Characteristic productOfCharacteristics) const {
     return {get_inverse(), productOfCharacteristics};
   }
 
@@ -342,7 +342,7 @@ class Shared_Zp_field_element {
    * @return 1.
    */
   static Shared_Zp_field_element get_partial_multiplicative_identity(
-      [[maybe_unused]] characteristic_type productOfCharacteristics) {
+      [[maybe_unused]] Characteristic productOfCharacteristics) {
     return Shared_Zp_field_element(1);
   }
   /**
@@ -350,16 +350,16 @@ class Shared_Zp_field_element {
    * 
    * @return The value of the current characteristic.
    */
-  static characteristic_type get_characteristic() { return characteristic_; }
+  static Characteristic get_characteristic() { return characteristic_; }
 
   // static constexpr bool handles_only_z2() { return false; }
 
  private:
-  element_type element_;                              /**< Field element. */
-  static inline characteristic_type characteristic_;  /**< Current characteristic of the field. */
-  static inline std::vector<element_type> inverse_;   /**< All inverse elements. */
+  Element element_;                              /**< Field element. */
+  static inline Characteristic characteristic_;  /**< Current characteristic of the field. */
+  static inline std::vector<Element> inverse_;   /**< All inverse elements. */
 
-  static element_type _add(element_type element, element_type v) {
+  static Element _add(Element element, Element v) {
     if (UINT_MAX - element < v) {
       // automatic unsigned integer overflow behaviour will make it work
       element += v;
@@ -372,7 +372,7 @@ class Shared_Zp_field_element {
 
     return element;
   }
-  static element_type _subtract(element_type element, element_type v) {
+  static Element _subtract(Element element, Element v) {
     if (element < v) {
       element += characteristic_;
     }
@@ -380,10 +380,10 @@ class Shared_Zp_field_element {
 
     return element;
   }
-  static element_type _multiply(element_type element, element_type v) {
-    element_type a = element;
+  static Element _multiply(Element element, Element v) {
+    Element a = element;
     element = 0;
-    element_type temp_b;
+    Element temp_b;
 
     while (a != 0) {
       if (a & 1) {
@@ -401,7 +401,7 @@ class Shared_Zp_field_element {
   }
 
   template <typename Integer_type, class = isInteger<Integer_type> >
-  static constexpr element_type _get_value(Integer_type e) {
+  static constexpr Element _get_value(Integer_type e) {
     if constexpr (std::is_signed_v<Integer_type>){
       if (e < -static_cast<Integer_type>(characteristic_)) e = e % characteristic_;
       if (e < 0) return e += characteristic_;

--- a/src/Persistence_matrix/include/gudhi/Persistence_matrix/base_matrix.h
+++ b/src/Persistence_matrix/include/gudhi/Persistence_matrix/base_matrix.h
@@ -38,16 +38,16 @@ class Base_matrix : public Master_matrix::template Base_swap_option<Base_matrix<
                     protected Master_matrix::Matrix_row_access_option 
 {
  public:
-  using index = typename Master_matrix::index;                        /**< Container index type. */
-  using dimension_type = typename Master_matrix::dimension_type;      /**< Dimension value type. */
+  using Index = typename Master_matrix::Index;                        /**< Container index type. */
+  using Dimension = typename Master_matrix::Dimension;                /**< Dimension value type. */
   /**
    * @brief Field operators class. Necessary only if @ref PersistenceMatrixOptions::is_z2 is false.
    */
   using Field_operators = typename Master_matrix::Field_operators;
-  using Field_element_type = typename Master_matrix::element_type;    /**< Type of a field element. */
-  using Column_type = typename Master_matrix::Column_type;            /**< Column type. */
-  using container_type = typename Master_matrix::boundary_type;       /**< Type of the column container. */
-  using Row_type = typename Master_matrix::Row_type;                  /**< Row type,
+  using Field_element = typename Master_matrix::Element;              /**< Type of a field element. */
+  using Column = typename Master_matrix::Column;                      /**< Column type. */
+  using Boundary = typename Master_matrix::Boundary;                  /**< Type of the column container. */
+  using Row = typename Master_matrix::Row;                            /**< Row type,
                                                                            only necessary with row access option. */
   using Cell_constructor = typename Master_matrix::Cell_constructor;  /**< Factory of @ref Cell classes. */
   using Column_settings = typename Master_matrix::Column_settings;    /**< Structure giving access to the columns to
@@ -63,15 +63,15 @@ class Base_matrix : public Master_matrix::template Base_swap_option<Base_matrix<
   /**
    * @brief Constructs a matrix from the given ordered columns. The columns are inserted in the given order.
    * 
-   * @tparam Container_type Range type for @ref Matrix::cell_rep_type ranges.
+   * @tparam Container Range type for @ref Matrix::Cell_representative ranges.
    * Assumed to have a begin(), end() and size() method.
-   * @param columns A vector of @ref Matrix::cell_rep_type ranges to construct the columns from.
+   * @param columns A vector of @ref Matrix::Cell_representative ranges to construct the columns from.
    * The content of the ranges are assumed to be sorted by increasing ID value.
    * @param colSettings Pointer to an existing setting structure for the columns. The structure should contain all
    * the necessary external classes specifically necessary for the choosen column type, such as custom allocators.
    */
-  template <class Container_type = container_type>
-  Base_matrix(const std::vector<Container_type>& columns, 
+  template <class Container = Boundary>
+  Base_matrix(const std::vector<Container>& columns, 
               Column_settings* colSettings);
   /**
    * @brief Constructs a new empty matrix and reserves space for the given number of columns.
@@ -101,37 +101,37 @@ class Base_matrix : public Master_matrix::template Base_swap_option<Base_matrix<
 
   /**
    * @brief Inserts a new ordered column at the end of the matrix by copying the given range of
-   * @ref Matrix::cell_rep_type. The content of the range is assumed to be sorted by increasing ID value.
+   * @ref Matrix::Cell_representative. The content of the range is assumed to be sorted by increasing ID value.
    * 
-   * @tparam Container_type Range of @ref Matrix::cell_rep_type. Assumed to have a begin(), end() and size() method.
-   * @param column Range of @ref Matrix::cell_rep_type from which the column has to be constructed. Assumed to be
+   * @tparam Container Range of @ref Matrix::Cell_representative. Assumed to have a begin(), end() and size() method.
+   * @param column Range of @ref Matrix::Cell_representative from which the column has to be constructed. Assumed to be
    * ordered by increasing ID value. 
    */
-  template <class Container_type = container_type>
-  void insert_column(const Container_type& column);
+  template <class Container = Boundary>
+  void insert_column(const Container& column);
   /**
-   * @brief Inserts a new ordered column at the given index by copying the given range of @ref Matrix::cell_rep_type.
+   * @brief Inserts a new ordered column at the given index by copying the given range of @ref Matrix::Cell_representative.
    * There should not be any other column inserted at that index which was not explicitly removed before.
    * The content of the range is assumed to be sorted by increasing ID value. 
    * Not available when row access is enabled.
    * 
-   * @tparam Container_type Range of @ref Matrix::cell_rep_type. Assumed to have a begin(), end() and size() method.
-   * @param column Range of @ref Matrix::cell_rep_type from which the column has to be constructed. Assumed to be
+   * @tparam Container Range of @ref Matrix::Cell_representative. Assumed to have a begin(), end() and size() method.
+   * @param column Range of @ref Matrix::Cell_representative from which the column has to be constructed. Assumed to be
    * ordered by increasing ID value. 
    * @param columnIndex @ref MatIdx index to which the column has to be inserted.
    */
-  template <class Container_type = container_type>
-  void insert_column(const Container_type& column, index columnIndex);
+  template <class Container = Boundary>
+  void insert_column(const Container& column, Index columnIndex);
   /**
    * @brief Same as @ref insert_column, only for interface purposes. The given dimension is ignored and not stored.
    * 
-   * @tparam Boundary_type Range of @ref Matrix::cell_rep_type. Assumed to have a begin(), end() and size() method.
-   * @param boundary Range of @ref Matrix::cell_rep_type from which the column has to be constructed. Assumed to be
+   * @tparam Boundary_container Range of @ref Matrix::Cell_representative. Assumed to have a begin(), end() and size() method.
+   * @param boundary Range of @ref Matrix::Cell_representative from which the column has to be constructed. Assumed to be
    * ordered by increasing ID value. 
    * @param dim Ignored.
    */
-  template <class Boundary_type>
-  void insert_boundary(const Boundary_type& boundary, dimension_type dim = -1);
+  template <class Boundary_container>
+  void insert_boundary(const Boundary_container& boundary, Dimension dim = -1);
   /**
    * @brief Returns the column at the given @ref MatIdx index.
    * The type of the column depends on the choosen options, see @ref PersistenceMatrixOptions::column_type.
@@ -143,7 +143,7 @@ class Base_matrix : public Master_matrix::template Base_swap_option<Base_matrix<
    * @param columnIndex @ref MatIdx index of the column to return.
    * @return Reference to the column.
    */
-  Column_type& get_column(index columnIndex);
+  Column& get_column(Index columnIndex);
   /**
    * @brief Only available if @ref PersistenceMatrixOptions::has_row_access is true.
    * Returns the row at the given @ref rowindex "row index" of the matrix.
@@ -156,13 +156,13 @@ class Base_matrix : public Master_matrix::template Base_swap_option<Base_matrix<
    * @param rowIndex @ref rowindex "Row index" of the row to return.
    * @return Reference to the row.
    */
-  Row_type& get_row(index rowIndex);
+  Row& get_row(Index rowIndex);
   /**
    * @brief Only available if @ref PersistenceMatrixOptions::has_map_column_container is true. Otherwise, see
    * @ref remove_last. Erases the given column from the matrix. If the given column index corresponded to the last
    * used column index, the "new last column index" will be `columnIndex - 1`, even if a column was never explicitly
    * inserted at this index (possible when
-   * @ref insert_column(const Container_type& column, index columnIndex) "insert_column(column, columnIndex)" was used).
+   * @ref insert_column(const Container& column, Index columnIndex) "insert_column(column, columnIndex)" was used).
    * If the column didn't existed, it will simply be considered as an empty column.
    *
    * If @ref PersistenceMatrixOptions::has_row_access is also true, the deleted column cells are also automatically
@@ -170,19 +170,19 @@ class Base_matrix : public Master_matrix::template Base_swap_option<Base_matrix<
    * 
    * @param columnIndex @ref MatIdx index of the column to remove.
    */
-  void remove_column(index columnIndex);
+  void remove_column(Index columnIndex);
   /**
    * @brief Removes the last column from the matrix. The last column is at index \f$ max(ins1, ins2, rem - 1) \f$,
    * where:
    * - \f$ ins1 \f$ is the index of the last column inserted by
-   * @ref insert_column(const Container_type& column) "insert_column(column)",
+   * @ref insert_column(const Container& column) "insert_column(column)",
    * - \f$ ins2 \f$ is largest index used with
-   * @ref insert_column(const Container_type& column, index columnIndex) "insert_column(column, columnIndex)",
+   * @ref insert_column(const Container& column, Index columnIndex) "insert_column(column, columnIndex)",
    * - \f$ rem \f$ is the last index just before the last call of @ref remove_column or @ref remove_last.
    *
    * If \f$ max(ins1, ins2, rem - 1) = rem - 1 \f$ but no column was explicitly inserted at that index (possible
    * by the use of
-   * @ref insert_column(const Container_type& column, index columnIndex) "insert_column(column, columnIndex)"),
+   * @ref insert_column(const Container& column, Index columnIndex) "insert_column(column, columnIndex)"),
    * the column is assumed to be an empty column.
    *
    * See also @ref remove_column.
@@ -203,14 +203,14 @@ class Base_matrix : public Master_matrix::template Base_swap_option<Base_matrix<
    * 
    * @param rowIndex @ref rowindex "Row index" of the empty row.
    */
-  void erase_empty_row(index rowIndex);
+  void erase_empty_row(Index rowIndex);
 
   /**
    * @brief Returns the current number of columns in the matrix.
    * 
    * @return The number of columns.
    */
-  index get_number_of_columns() const;
+  Index get_number_of_columns() const;
 
   /**
    * @brief Adds column represented by @p sourceColumn onto the column at @p targetColumnIndex in the matrix.
@@ -221,7 +221,7 @@ class Base_matrix : public Master_matrix::template Base_swap_option<Base_matrix<
    * @param targetColumnIndex @ref MatIdx index of the target column.
    */
   template <class Cell_range_or_column_index>
-  void add_to(const Cell_range_or_column_index& sourceColumn, index targetColumnIndex);
+  void add_to(const Cell_range_or_column_index& sourceColumn, Index targetColumnIndex);
   /**
    * @brief Multiplies the target column with the coefficient and then adds the source column to it.
    * That is: `targetColumn = (targetColumn * coefficient) + sourceColumn`.
@@ -234,8 +234,8 @@ class Base_matrix : public Master_matrix::template Base_swap_option<Base_matrix<
    */
   template <class Cell_range_or_column_index>
   void multiply_target_and_add_to(const Cell_range_or_column_index& sourceColumn, 
-                                  const Field_element_type& coefficient,
-                                  index targetColumnIndex);
+                                  const Field_element& coefficient,
+                                  Index targetColumnIndex);
   /**
    * @brief Multiplies the source column with the coefficient before adding it to the target column.
    * That is: `targetColumn += (coefficient * sourceColumn)`. The source column will **not** be modified.
@@ -247,9 +247,9 @@ class Base_matrix : public Master_matrix::template Base_swap_option<Base_matrix<
    * @param targetColumnIndex @ref MatIdx index of the target column.
    */
   template <class Cell_range_or_column_index>
-  void multiply_source_and_add_to(const Field_element_type& coefficient, 
+  void multiply_source_and_add_to(const Field_element& coefficient, 
                                   const Cell_range_or_column_index& sourceColumn,
-                                  index targetColumnIndex);
+                                  Index targetColumnIndex);
 
   /**
    * @brief Zeroes the cell at the given coordinates.
@@ -257,13 +257,13 @@ class Base_matrix : public Master_matrix::template Base_swap_option<Base_matrix<
    * @param columnIndex @ref MatIdx index of the column of the cell.
    * @param rowIndex @ref rowindex "Row index" of the row of the cell.
    */
-  void zero_cell(index columnIndex, index rowIndex);
+  void zero_cell(Index columnIndex, Index rowIndex);
   /**
    * @brief Zeroes the column at the given index.
    * 
    * @param columnIndex @ref MatIdx index of the column to zero.
    */
-  void zero_column(index columnIndex);
+  void zero_column(Index columnIndex);
   /**
    * @brief Indicates if the cell at given coordinates has value zero.
    * 
@@ -272,7 +272,7 @@ class Base_matrix : public Master_matrix::template Base_swap_option<Base_matrix<
    * @return true If the cell has value zero.
    * @return false Otherwise.
    */
-  bool is_zero_cell(index columnIndex, index rowIndex) const;
+  bool is_zero_cell(Index columnIndex, Index rowIndex) const;
   /**
    * @brief Indicates if the column at given index has value zero.
    * 
@@ -280,7 +280,7 @@ class Base_matrix : public Master_matrix::template Base_swap_option<Base_matrix<
    * @return true If the column has value zero.
    * @return false Otherwise.
    */
-  bool is_zero_column(index columnIndex);
+  bool is_zero_column(Index columnIndex);
 
   /**
    * @brief Resets the matrix to an empty matrix.
@@ -317,44 +317,44 @@ class Base_matrix : public Master_matrix::template Base_swap_option<Base_matrix<
   void print();  // for debug
 
  private:
-  using swap_opt = typename Master_matrix::template Base_swap_option<Base_matrix<Master_matrix> >;
-  using ra_opt = typename Master_matrix::Matrix_row_access_option;
-  using matrix_type = typename Master_matrix::column_container_type;
-  using cell_rep_type =
+  using Swap_opt = typename Master_matrix::template Base_swap_option<Base_matrix<Master_matrix> >;
+  using RA_opt = typename Master_matrix::Matrix_row_access_option;
+  using Column_container = typename Master_matrix::Column_container;
+  using Cell_representative =
       typename std::conditional<Master_matrix::Option_list::is_z2, 
-                                index, 
-                                std::pair<index, Field_element_type>
+                                Index, 
+                                std::pair<Index, Field_element>
                                >::type;
 
-  friend swap_opt;  // direct access to matrix_ to avoid row reorder.
+  friend Swap_opt;  // direct access to matrix_ to avoid row reorder.
 
-  matrix_type matrix_;            /**< Column container. */
-  index nextInsertIndex_;         /**< Next unused column index. */
+  Column_container matrix_;       /**< Column container. */
+  Index nextInsertIndex_;         /**< Next unused column index. */
   Column_settings* colSettings_;  /**< Cell factory. */
 
-  template <class Container_type = container_type>
-  void _insert(const Container_type& column, index columnIndex, dimension_type dim);
+  template <class Container = Boundary>
+  void _insert(const Container& column, Index columnIndex, Dimension dim);
   void _orderRowsIfNecessary();
-  const Column_type& _get_column(index columnIndex) const;
-  Column_type& _get_column(index columnIndex);
-  index _get_real_row_index(index rowIndex) const;
-  template <class Container_type>
-  void _container_insert(const Container_type& column, index pos, dimension_type dim);
-  void _container_insert(const Column_type& column, [[maybe_unused]] index pos = 0);
+  const Column& _get_column(Index columnIndex) const;
+  Column& _get_column(Index columnIndex);
+  Index _get_real_row_index(Index rowIndex) const;
+  template <class Container>
+  void _container_insert(const Container& column, Index pos, Dimension dim);
+  void _container_insert(const Column& column, [[maybe_unused]] Index pos = 0);
 };
 
 template <class Master_matrix>
 inline Base_matrix<Master_matrix>::Base_matrix(Column_settings* colSettings)
-    : swap_opt(), ra_opt(), nextInsertIndex_(0), colSettings_(colSettings)
+    : Swap_opt(), RA_opt(), nextInsertIndex_(0), colSettings_(colSettings)
 {}
 
 template <class Master_matrix>
-template <class Container_type>
-inline Base_matrix<Master_matrix>::Base_matrix(const std::vector<Container_type>& columns, 
+template <class Container>
+inline Base_matrix<Master_matrix>::Base_matrix(const std::vector<Container>& columns, 
                                                Column_settings* colSettings)
-    : swap_opt(columns.size()),
+    : Swap_opt(columns.size()),
       // not ideal if max row index is much smaller than max column index, does that happen often?
-      ra_opt(columns.size()),
+      RA_opt(columns.size()),
       matrix_(!Master_matrix::Option_list::has_map_column_container && Master_matrix::Option_list::has_row_access
                   ? 0
                   : columns.size()),
@@ -364,7 +364,7 @@ inline Base_matrix<Master_matrix>::Base_matrix(const std::vector<Container_type>
   if constexpr (!Master_matrix::Option_list::has_map_column_container && Master_matrix::Option_list::has_row_access)
     matrix_.reserve(columns.size());
 
-  for (index i = 0; i < columns.size(); i++) {
+  for (Index i = 0; i < columns.size(); i++) {
     _container_insert(columns[i], i, columns[i].size() == 0 ? 0 : columns[i].size() - 1);
   }
 }
@@ -372,8 +372,8 @@ inline Base_matrix<Master_matrix>::Base_matrix(const std::vector<Container_type>
 template <class Master_matrix>
 inline Base_matrix<Master_matrix>::Base_matrix(unsigned int numberOfColumns, 
                                                Column_settings* colSettings)
-    : swap_opt(numberOfColumns),
-      ra_opt(numberOfColumns),
+    : Swap_opt(numberOfColumns),
+      RA_opt(numberOfColumns),
       matrix_(!Master_matrix::Option_list::has_map_column_container && Master_matrix::Option_list::has_row_access
                   ? 0
                   : numberOfColumns),
@@ -387,8 +387,8 @@ inline Base_matrix<Master_matrix>::Base_matrix(unsigned int numberOfColumns,
 template <class Master_matrix>
 inline Base_matrix<Master_matrix>::Base_matrix(const Base_matrix& matrixToCopy, 
                                                Column_settings* colSettings)
-    : swap_opt(static_cast<const swap_opt&>(matrixToCopy)),
-      ra_opt(static_cast<const ra_opt&>(matrixToCopy)),
+    : Swap_opt(static_cast<const Swap_opt&>(matrixToCopy)),
+      RA_opt(static_cast<const RA_opt&>(matrixToCopy)),
       nextInsertIndex_(matrixToCopy.nextInsertIndex_),
       colSettings_(colSettings == nullptr ? matrixToCopy.colSettings_ : colSettings)
 {
@@ -404,16 +404,16 @@ inline Base_matrix<Master_matrix>::Base_matrix(const Base_matrix& matrixToCopy,
 
 template <class Master_matrix>
 inline Base_matrix<Master_matrix>::Base_matrix(Base_matrix&& other) noexcept
-    : swap_opt(std::move(static_cast<swap_opt&>(other))),
-      ra_opt(std::move(static_cast<ra_opt&>(other))),
+    : Swap_opt(std::move(static_cast<Swap_opt&>(other))),
+      RA_opt(std::move(static_cast<RA_opt&>(other))),
       matrix_(std::move(other.matrix_)),
       nextInsertIndex_(std::exchange(other.nextInsertIndex_, 0)),
       colSettings_(std::exchange(other.colSettings_, nullptr)) 
 {}
 
 template <class Master_matrix>
-template <class Container_type>
-inline void Base_matrix<Master_matrix>::insert_column(const Container_type& column) 
+template <class Container>
+inline void Base_matrix<Master_matrix>::insert_column(const Container& column) 
 {
   //TODO: dim not actually stored right now, so either get rid of it or store it again
   _insert(column, nextInsertIndex_, column.size() == 0 ? 0 : column.size() - 1);
@@ -421,8 +421,8 @@ inline void Base_matrix<Master_matrix>::insert_column(const Container_type& colu
 }
 
 template <class Master_matrix>
-template <class Container_type>
-inline void Base_matrix<Master_matrix>::insert_column(const Container_type& column, index columnIndex) 
+template <class Container>
+inline void Base_matrix<Master_matrix>::insert_column(const Container& column, Index columnIndex) 
 {
   static_assert(!Master_matrix::Option_list::has_row_access,
                 "Columns have to be inserted at the end of the matrix when row access is enabled.");
@@ -433,8 +433,8 @@ inline void Base_matrix<Master_matrix>::insert_column(const Container_type& colu
 }
 
 template <class Master_matrix>
-template <class Boundary_type>
-inline void Base_matrix<Master_matrix>::insert_boundary(const Boundary_type& boundary, dimension_type dim) 
+template <class Boundary_container>
+inline void Base_matrix<Master_matrix>::insert_boundary(const Boundary_container& boundary, Dimension dim) 
 {
   if (dim == -1) dim = boundary.size() == 0 ? 0 : boundary.size() - 1;
   //TODO: dim not actually stored right now, so either get rid of it or store it again
@@ -442,23 +442,23 @@ inline void Base_matrix<Master_matrix>::insert_boundary(const Boundary_type& bou
 }
 
 template <class Master_matrix>
-inline typename Base_matrix<Master_matrix>::Column_type& Base_matrix<Master_matrix>::get_column(index columnIndex) 
+inline typename Base_matrix<Master_matrix>::Column& Base_matrix<Master_matrix>::get_column(Index columnIndex) 
 {
   _orderRowsIfNecessary();
   return _get_column(columnIndex);
 }
 
 template <class Master_matrix>
-inline typename Base_matrix<Master_matrix>::Row_type& Base_matrix<Master_matrix>::get_row(index rowIndex) 
+inline typename Base_matrix<Master_matrix>::Row& Base_matrix<Master_matrix>::get_row(Index rowIndex) 
 {
   static_assert(Master_matrix::Option_list::has_row_access, "Row access has to be enabled for this method.");
 
   _orderRowsIfNecessary();
-  return ra_opt::get_row(rowIndex);
+  return RA_opt::get_row(rowIndex);
 }
 
 template <class Master_matrix>
-inline void Base_matrix<Master_matrix>::remove_column(index columnIndex) 
+inline void Base_matrix<Master_matrix>::remove_column(Index columnIndex) 
 {
   static_assert(Master_matrix::Option_list::has_map_column_container,
                 "'remove_column' is not implemented for the chosen options.");
@@ -489,21 +489,21 @@ inline void Base_matrix<Master_matrix>::remove_last()
 }
 
 template <class Master_matrix>
-inline void Base_matrix<Master_matrix>::erase_empty_row(index rowIndex) 
+inline void Base_matrix<Master_matrix>::erase_empty_row(Index rowIndex) 
 {
   if constexpr (Master_matrix::Option_list::has_row_access && Master_matrix::Option_list::has_removable_rows) {
-    ra_opt::erase_empty_row(_get_real_row_index(rowIndex));
+    RA_opt::erase_empty_row(_get_real_row_index(rowIndex));
   }
   if constexpr ((Master_matrix::Option_list::has_column_and_row_swaps || Master_matrix::Option_list::has_vine_update) &&
                 Master_matrix::Option_list::has_map_column_container) {
-    auto it = swap_opt::indexToRow_.find(rowIndex);
-    swap_opt::rowToIndex_.erase(it->second);
-    swap_opt::indexToRow_.erase(it);
+    auto it = Swap_opt::indexToRow_.find(rowIndex);
+    Swap_opt::rowToIndex_.erase(it->second);
+    Swap_opt::indexToRow_.erase(it);
   }
 }
 
 template <class Master_matrix>
-inline typename Base_matrix<Master_matrix>::index Base_matrix<Master_matrix>::get_number_of_columns() const 
+inline typename Base_matrix<Master_matrix>::Index Base_matrix<Master_matrix>::get_number_of_columns() const 
 {
   if constexpr (Master_matrix::Option_list::has_map_column_container) {
     return matrix_.size();
@@ -515,7 +515,7 @@ inline typename Base_matrix<Master_matrix>::index Base_matrix<Master_matrix>::ge
 template <class Master_matrix>
 template <class Cell_range_or_column_index>
 inline void Base_matrix<Master_matrix>::add_to(const Cell_range_or_column_index& sourceColumn,
-                                               index targetColumnIndex) 
+                                               Index targetColumnIndex) 
 {
   if constexpr (std::is_integral_v<Cell_range_or_column_index>) {
     _get_column(targetColumnIndex) += _get_column(sourceColumn);
@@ -527,8 +527,8 @@ inline void Base_matrix<Master_matrix>::add_to(const Cell_range_or_column_index&
 template <class Master_matrix>
 template <class Cell_range_or_column_index>
 inline void Base_matrix<Master_matrix>::multiply_target_and_add_to(const Cell_range_or_column_index& sourceColumn,
-                                                                   const Field_element_type& coefficient,
-                                                                   index targetColumnIndex) 
+                                                                   const Field_element& coefficient,
+                                                                   Index targetColumnIndex) 
 {
   if constexpr (std::is_integral_v<Cell_range_or_column_index>) {
     _get_column(targetColumnIndex).multiply_target_and_add(coefficient, _get_column(sourceColumn));
@@ -539,9 +539,9 @@ inline void Base_matrix<Master_matrix>::multiply_target_and_add_to(const Cell_ra
 
 template <class Master_matrix>
 template <class Cell_range_or_column_index>
-inline void Base_matrix<Master_matrix>::multiply_source_and_add_to(const Field_element_type& coefficient,
+inline void Base_matrix<Master_matrix>::multiply_source_and_add_to(const Field_element& coefficient,
                                                                    const Cell_range_or_column_index& sourceColumn,
-                                                                   index targetColumnIndex) 
+                                                                   Index targetColumnIndex) 
 {
   if constexpr (std::is_integral_v<Cell_range_or_column_index>) {
     _get_column(targetColumnIndex).multiply_source_and_add(_get_column(sourceColumn), coefficient);
@@ -551,24 +551,24 @@ inline void Base_matrix<Master_matrix>::multiply_source_and_add_to(const Field_e
 }
 
 template <class Master_matrix>
-inline void Base_matrix<Master_matrix>::zero_cell(index columnIndex, index rowIndex) 
+inline void Base_matrix<Master_matrix>::zero_cell(Index columnIndex, Index rowIndex) 
 {
   _get_column(columnIndex).clear(_get_real_row_index(rowIndex));
 }
 
 template <class Master_matrix>
-inline void Base_matrix<Master_matrix>::zero_column(index columnIndex) {
+inline void Base_matrix<Master_matrix>::zero_column(Index columnIndex) {
   _get_column(columnIndex).clear();
 }
 
 template <class Master_matrix>
-inline bool Base_matrix<Master_matrix>::is_zero_cell(index columnIndex, index rowIndex) const 
+inline bool Base_matrix<Master_matrix>::is_zero_cell(Index columnIndex, Index rowIndex) const 
 {
   return !(_get_column(columnIndex).is_non_zero(_get_real_row_index(rowIndex)));
 }
 
 template <class Master_matrix>
-inline bool Base_matrix<Master_matrix>::is_zero_column(index columnIndex) 
+inline bool Base_matrix<Master_matrix>::is_zero_column(Index columnIndex) 
 {
   return _get_column(columnIndex).is_empty();
 }
@@ -576,8 +576,8 @@ inline bool Base_matrix<Master_matrix>::is_zero_column(index columnIndex)
 template <class Master_matrix>
 inline Base_matrix<Master_matrix>& Base_matrix<Master_matrix>::operator=(const Base_matrix& other) 
 {
-  swap_opt::operator=(other);
-  ra_opt::operator=(other);
+  Swap_opt::operator=(other);
+  RA_opt::operator=(other);
   matrix_.clear();
   nextInsertIndex_ = other.nextInsertIndex_;
   colSettings_ = other.colSettings_;
@@ -599,8 +599,8 @@ inline void Base_matrix<Master_matrix>::print()
 {
   _orderRowsIfNecessary();
   std::cout << "Base_matrix:\n";
-  for (index i = 0; i < nextInsertIndex_; ++i) {
-    const Column_type& col = matrix_[i];
+  for (Index i = 0; i < nextInsertIndex_; ++i) {
+    const Column& col = matrix_[i];
     for (const auto& e : col.get_content(nextInsertIndex_)) {
       if (e == 0u)
         std::cout << "- ";
@@ -612,8 +612,8 @@ inline void Base_matrix<Master_matrix>::print()
   std::cout << "\n";
   if constexpr (Master_matrix::Option_list::has_row_access) {
     std::cout << "Row Matrix:\n";
-    for (index i = 0; i < nextInsertIndex_; ++i) {
-      const auto& row = ra_opt::rows_[i];
+    for (Index i = 0; i < nextInsertIndex_; ++i) {
+      const auto& row = RA_opt::rows_[i];
       for (const auto& cell : row) {
         std::cout << cell.get_column_index() << " ";
       }
@@ -624,13 +624,13 @@ inline void Base_matrix<Master_matrix>::print()
 }
 
 template <class Master_matrix>
-template <class Container_type>
-inline void Base_matrix<Master_matrix>::_insert(const Container_type& column, index columnIndex, dimension_type dim) 
+template <class Container>
+inline void Base_matrix<Master_matrix>::_insert(const Container& column, Index columnIndex, Dimension dim) 
 {
   _orderRowsIfNecessary();
 
   //resize of containers when necessary:
-  index pivot = 0;
+  Index pivot = 0;
   if (column.begin() != column.end()) {
     //first, compute pivot of `column`
     if constexpr (Master_matrix::Option_list::is_z2) {
@@ -640,30 +640,30 @@ inline void Base_matrix<Master_matrix>::_insert(const Container_type& column, in
     }
     //row container
     if constexpr (Master_matrix::Option_list::has_row_access && !Master_matrix::Option_list::has_removable_rows)
-      if (ra_opt::rows_->size() <= pivot) ra_opt::rows_->resize(pivot + 1);
+      if (RA_opt::rows_->size() <= pivot) RA_opt::rows_->resize(pivot + 1);
   }
 
   //row swap map containers
   if constexpr (Master_matrix::Option_list::has_map_column_container) {
     if constexpr (Master_matrix::Option_list::has_column_and_row_swaps || Master_matrix::Option_list::has_vine_update) {
       for (auto id : column) {
-        index idx;
+        Index idx;
         if constexpr (Master_matrix::Option_list::is_z2) {
           idx = id;
         } else {
           idx = id.first;
         }
-        swap_opt::indexToRow_[idx] = idx;
-        swap_opt::rowToIndex_[idx] = idx;
+        Swap_opt::indexToRow_[idx] = idx;
+        Swap_opt::rowToIndex_[idx] = idx;
       }
     }
   } else {
     if constexpr (Master_matrix::Option_list::has_column_and_row_swaps || Master_matrix::Option_list::has_vine_update) {
-      index size = swap_opt::indexToRow_.size();
+      Index size = Swap_opt::indexToRow_.size();
       if (size <= pivot) {
-        for (index i = size; i <= pivot; i++) {
-          swap_opt::indexToRow_.push_back(i);
-          swap_opt::rowToIndex_.push_back(i);
+        for (Index i = size; i <= pivot; i++) {
+          Swap_opt::indexToRow_.push_back(i);
+          Swap_opt::rowToIndex_.push_back(i);
         }
       }
     }
@@ -682,13 +682,13 @@ template <class Master_matrix>
 inline void Base_matrix<Master_matrix>::_orderRowsIfNecessary() 
 {
   if constexpr (Master_matrix::Option_list::has_column_and_row_swaps || Master_matrix::Option_list::has_vine_update) {
-    if (swap_opt::rowSwapped_) swap_opt::_orderRows();
+    if (Swap_opt::rowSwapped_) Swap_opt::_orderRows();
   }
 }
 
 template <class Master_matrix>
-inline const typename Base_matrix<Master_matrix>::Column_type& Base_matrix<Master_matrix>::_get_column(
-    index columnIndex) const
+inline const typename Base_matrix<Master_matrix>::Column& Base_matrix<Master_matrix>::_get_column(
+    Index columnIndex) const
 {
   if constexpr (Master_matrix::Option_list::has_map_column_container) {
     return matrix_.at(columnIndex);
@@ -698,7 +698,7 @@ inline const typename Base_matrix<Master_matrix>::Column_type& Base_matrix<Maste
 }
 
 template <class Master_matrix>
-inline typename Base_matrix<Master_matrix>::Column_type& Base_matrix<Master_matrix>::_get_column(index columnIndex)
+inline typename Base_matrix<Master_matrix>::Column& Base_matrix<Master_matrix>::_get_column(Index columnIndex)
 {
   if constexpr (Master_matrix::Option_list::has_map_column_container) {
     return matrix_.at(columnIndex);
@@ -708,13 +708,13 @@ inline typename Base_matrix<Master_matrix>::Column_type& Base_matrix<Master_matr
 }
 
 template <class Master_matrix>
-inline typename Base_matrix<Master_matrix>::index Base_matrix<Master_matrix>::_get_real_row_index(index rowIndex) const
+inline typename Base_matrix<Master_matrix>::Index Base_matrix<Master_matrix>::_get_real_row_index(Index rowIndex) const
 {
   if constexpr (Master_matrix::Option_list::has_column_and_row_swaps || Master_matrix::Option_list::has_vine_update) {
     if constexpr (Master_matrix::Option_list::has_map_column_container) {
-      return swap_opt::indexToRow_.at(rowIndex);
+      return Swap_opt::indexToRow_.at(rowIndex);
     } else {
-      return swap_opt::indexToRow_[rowIndex];
+      return Swap_opt::indexToRow_[rowIndex];
     }
   } else {
     return rowIndex;
@@ -722,34 +722,34 @@ inline typename Base_matrix<Master_matrix>::index Base_matrix<Master_matrix>::_g
 }
 
 template <class Master_matrix>
-template <class Container_type>
-inline void Base_matrix<Master_matrix>::_container_insert(const Container_type& column, index pos, dimension_type dim){
+template <class Container>
+inline void Base_matrix<Master_matrix>::_container_insert(const Container& column, Index pos, Dimension dim){
   if constexpr (Master_matrix::Option_list::has_map_column_container) {
     if constexpr (Master_matrix::Option_list::has_row_access) {
-      matrix_.try_emplace(pos, Column_type(pos, column, dim, ra_opt::rows_, colSettings_));
+      matrix_.try_emplace(pos, Column(pos, column, dim, RA_opt::rows_, colSettings_));
     } else {
-      matrix_.try_emplace(pos, Column_type(column, dim, colSettings_));
+      matrix_.try_emplace(pos, Column(column, dim, colSettings_));
     }
   } else {
     if constexpr (Master_matrix::Option_list::has_row_access) {
-      matrix_.emplace_back(pos, column, dim, ra_opt::rows_, colSettings_);
+      matrix_.emplace_back(pos, column, dim, RA_opt::rows_, colSettings_);
     } else {
-      matrix_[pos] = Column_type(column, dim, colSettings_);
+      matrix_[pos] = Column(column, dim, colSettings_);
     }
   }
 }
 
 template <class Master_matrix>
-inline void Base_matrix<Master_matrix>::_container_insert(const Column_type& column, [[maybe_unused]] index pos){
+inline void Base_matrix<Master_matrix>::_container_insert(const Column& column, [[maybe_unused]] Index pos){
   if constexpr (Master_matrix::Option_list::has_map_column_container) {
     if constexpr (Master_matrix::Option_list::has_row_access) {
-      matrix_.try_emplace(pos, Column_type(column, column.get_column_index(), ra_opt::rows_, colSettings_));
+      matrix_.try_emplace(pos, Column(column, column.get_column_index(), RA_opt::rows_, colSettings_));
     } else {
-      matrix_.try_emplace(pos, Column_type(column, colSettings_));
+      matrix_.try_emplace(pos, Column(column, colSettings_));
     }
   } else {
     if constexpr (Master_matrix::Option_list::has_row_access) {
-      matrix_.emplace_back(column, column.get_column_index(), ra_opt::rows_, colSettings_);
+      matrix_.emplace_back(column, column.get_column_index(), RA_opt::rows_, colSettings_);
     } else {
       matrix_.emplace_back(column, colSettings_);
     }

--- a/src/Persistence_matrix/include/gudhi/Persistence_matrix/base_matrix_with_column_compression.h
+++ b/src/Persistence_matrix/include/gudhi/Persistence_matrix/base_matrix_with_column_compression.h
@@ -45,14 +45,14 @@ template <class Master_matrix>
 class Base_matrix_with_column_compression : protected Master_matrix::Matrix_row_access_option 
 {
  public:
-  using index = typename Master_matrix::index;                        /**< Container index type. */
-  using dimension_type = typename Master_matrix::dimension_type;      /**< Dimension value type. */
+  using Index = typename Master_matrix::Index;                        /**< Container index type. */
+  using Dimension = typename Master_matrix::Dimension;                /**< Dimension value type. */
   /**
    * @brief Field operators class. Necessary only if @ref PersistenceMatrixOptions::is_z2 is false.
    */
   using Field_operators = typename Master_matrix::Field_operators;
-  using Field_element_type = typename Master_matrix::element_type;    /**< Field element value type. */
-  using Row_type = typename Master_matrix::Row_type;                  /**< Row type,
+  using Field_element = typename Master_matrix::Element;              /**< Field element value type. */
+  using Row = typename Master_matrix::Row;                            /**< Row type,
                                                                            only necessary with row access option. */
   using Cell_constructor = typename Master_matrix::Cell_constructor;  /**< Factory of @ref Cell classes. */
   using Column_settings = typename Master_matrix::Column_settings;    /**< Structure giving access to the columns to
@@ -61,50 +61,50 @@ class Base_matrix_with_column_compression : protected Master_matrix::Matrix_row_
   /**
    * @brief Type for columns. Only one for each "column class" is explicitly constructed.
    */
-  class Column_type
-      : public Master_matrix::Column_type,
+  class Column
+      : public Master_matrix::Column,
         public boost::intrusive::set_base_hook<boost::intrusive::link_mode<boost::intrusive::normal_link> > 
   {
    public:
-    using Base = typename Master_matrix::Column_type;
+    using Base = typename Master_matrix::Column;
 
-    Column_type(Column_settings* colSettings = nullptr)
+    Column(Column_settings* colSettings = nullptr)
         : Base(colSettings) {}
-    template <class Container_type>
-    Column_type(const Container_type& nonZeroRowIndices, Column_settings* colSettings)
+    template <class Container>
+    Column(const Container& nonZeroRowIndices, Column_settings* colSettings)
         : Base(nonZeroRowIndices, colSettings) {}
-    template <class Container_type, class Row_container_type>
-    Column_type(index columnIndex, const Container_type& nonZeroRowIndices, Row_container_type& rowContainer,
+    template <class Container, class Row_container>
+    Column(Index columnIndex, const Container& nonZeroRowIndices, Row_container& rowContainer,
                 Column_settings* colSettings)
         : Base(columnIndex, nonZeroRowIndices, rowContainer, colSettings) {}
-    template <class Container_type>
-    Column_type(const Container_type& nonZeroRowIndices, dimension_type dimension, Column_settings* colSettings)
+    template <class Container>
+    Column(const Container& nonZeroRowIndices, Dimension dimension, Column_settings* colSettings)
         : Base(nonZeroRowIndices, dimension, colSettings) {}
-    template <class Container_type, class Row_container_type>
-    Column_type(index columnIndex, const Container_type& nonZeroRowIndices, dimension_type dimension,
-                Row_container_type& rowContainer, Column_settings* colSettings)
+    template <class Container, class Row_container>
+    Column(Index columnIndex, const Container& nonZeroRowIndices, Dimension dimension,
+                Row_container& rowContainer, Column_settings* colSettings)
         : Base(columnIndex, nonZeroRowIndices, dimension, rowContainer, colSettings) {}
-    Column_type(const Column_type& column, Column_settings* colSettings = nullptr)
+    Column(const Column& column, Column_settings* colSettings = nullptr)
         : Base(static_cast<const Base&>(column), colSettings) {}
-    template <class Row_container_type>
-    Column_type(const Column_type& column, index columnIndex, Row_container_type& rowContainer,
+    template <class Row_container>
+    Column(const Column& column, Index columnIndex, Row_container& rowContainer,
                 Column_settings* colSettings = nullptr)
         : Base(static_cast<const Base&>(column), columnIndex, rowContainer, colSettings) {}
-    Column_type(Column_type&& column) noexcept : Base(std::move(static_cast<Base&>(column))) {}
+    Column(Column&& column) noexcept : Base(std::move(static_cast<Base&>(column))) {}
 
     //TODO: is it possible to make this work?
     // template <class... U>
-    // Column_type(U&&... u) : Base(std::forward<U>(u)...) {}
+    // Column(U&&... u) : Base(std::forward<U>(u)...) {}
 
-    index get_rep() const { return rep_; }
-    void set_rep(const index& rep) { rep_ = rep; }
+    Index get_rep() const { return rep_; }
+    void set_rep(const Index& rep) { rep_ = rep; }
 
     struct Hasher {
-      size_t operator()(const Column_type& c) const { return std::hash<Base>()(static_cast<Base>(c)); }
+      size_t operator()(const Column& c) const { return std::hash<Base>()(static_cast<Base>(c)); }
     };
 
    private:
-    index rep_; /**< Index in the union-find of the root of the set representing this column class. */
+    Index rep_; /**< Index in the union-find of the root of the set representing this column class. */
   };
 
   /**
@@ -119,15 +119,15 @@ class Base_matrix_with_column_compression : protected Master_matrix::Matrix_row_
    * If no identical column already existed, a copy of the column is stored. If an identical one existed, no new
    * column is constructed and the relationship between the two is registered in an union-find structure.
    * 
-   * @tparam Container_type Range type for @ref Matrix::cell_rep_type ranges.
+   * @tparam Container Range type for @ref Matrix::Cell_representative ranges.
    * Assumed to have a begin(), end() and size() method.
-   * @param columns A vector of @ref Matrix::cell_rep_type ranges to construct the columns from.
+   * @param columns A vector of @ref Matrix::Cell_representative ranges to construct the columns from.
    * The content of the ranges are assumed to be sorted by increasing ID value.
    * @param colSettings Pointer to an existing setting structure for the columns. The structure should contain all
    * the necessary external classes specifically necessary for the choosen column type, such as custom allocators.
    */
-  template <class Container_type>
-  Base_matrix_with_column_compression(const std::vector<Container_type>& columns, 
+  template <class Container>
+  Base_matrix_with_column_compression(const std::vector<Container>& columns, 
                                       Column_settings* colSettings);
   /**
    * @brief Constructs a new empty matrix and reserves space for the given number of columns.
@@ -162,24 +162,24 @@ class Base_matrix_with_column_compression : protected Master_matrix::Matrix_row_
 
   /**
    * @brief Inserts a new ordered column at the end of the matrix by copying the given range of
-   * @ref Matrix::cell_rep_type. The content of the range is assumed to be sorted by increasing ID value. 
+   * @ref Matrix::Cell_representative. The content of the range is assumed to be sorted by increasing ID value. 
    * 
-   * @tparam Container_type Range of @ref Matrix::cell_rep_type. Assumed to have a begin(), end() and size() method.
-   * @param column Range of @ref Matrix::cell_rep_type from which the column has to be constructed. Assumed to be
+   * @tparam Container Range of @ref Matrix::Cell_representative. Assumed to have a begin(), end() and size() method.
+   * @param column Range of @ref Matrix::Cell_representative from which the column has to be constructed. Assumed to be
    * ordered by increasing ID value. 
    */
-  template <class Container_type>
-  void insert_column(const Container_type& column);
+  template <class Container>
+  void insert_column(const Container& column);
   /**
    * @brief Same as @ref insert_column, only for interface purposes. The given dimension is ignored and not stored.
    * 
-   * @tparam Boundary_type Range of @ref Matrix::cell_rep_type. Assumed to have a begin(), end() and size() method.
-   * @param boundary Range of @ref Matrix::cell_rep_type from which the column has to be constructed. Assumed to be
+   * @tparam Boundary_container Range of @ref Matrix::Cell_representative. Assumed to have a begin(), end() and size() method.
+   * @param boundary Range of @ref Matrix::Cell_representative from which the column has to be constructed. Assumed to be
    * ordered by increasing ID value. 
    * @param dim Ignored.
    */
-  template <class Boundary_type>
-  void insert_boundary(const Boundary_type& boundary, dimension_type dim = -1);
+  template <class Boundary_container>
+  void insert_boundary(const Boundary_container& boundary, Dimension dim = -1);
   /**
    * @brief Returns the column at the given @ref MatIdx index.
    * The type of the column depends on the choosen options, see @ref PersistenceMatrixOptions::column_type.
@@ -190,7 +190,7 @@ class Base_matrix_with_column_compression : protected Master_matrix::Matrix_row_
    * @param columnIndex @ref MatIdx index of the column to return.
    * @return Const reference to the column.
    */
-  const Column_type& get_column(index columnIndex);
+  const Column& get_column(Index columnIndex);
   /**
    * @brief Only available if @ref PersistenceMatrixOptions::has_row_access is true.
    * Returns the row at the given @ref rowindex "row index" of the compressed matrix.
@@ -200,7 +200,7 @@ class Base_matrix_with_column_compression : protected Master_matrix::Matrix_row_
    * @param rowIndex @ref rowindex "Row index" of the row to return.
    * @return Const reference to the row.
    */
-  const Row_type& get_row(index rowIndex) const;
+  const Row& get_row(Index rowIndex) const;
   /**
    * @brief If @ref PersistenceMatrixOptions::has_row_access and @ref PersistenceMatrixOptions::has_removable_rows
    * are true: assumes that the row is empty and removes it. Otherwise, does nothing.
@@ -214,14 +214,14 @@ class Base_matrix_with_column_compression : protected Master_matrix::Matrix_row_
    * 
    * @param rowIndex @ref rowindex "Row index" of the empty row.
    */
-  void erase_empty_row(index rowIndex);
+  void erase_empty_row(Index rowIndex);
 
   /**
    * @brief Returns the current number of columns in the matrix, counting also the redundant columns.
    * 
    * @return The number of columns.
    */
-  index get_number_of_columns() const;
+  Index get_number_of_columns() const;
 
   /**
    * @brief Adds column represented by @p sourceColumn onto the column at @p targetColumnIndex in the matrix.
@@ -235,7 +235,7 @@ class Base_matrix_with_column_compression : protected Master_matrix::Matrix_row_
    * @param targetColumnIndex @ref MatIdx index of the target column.
    */
   template <class Cell_range_or_column_index>
-  void add_to(const Cell_range_or_column_index& sourceColumn, index targetColumnIndex);
+  void add_to(const Cell_range_or_column_index& sourceColumn, Index targetColumnIndex);
   /**
    * @brief Multiplies the target column with the coefficient and then adds the source column to it.
    * That is: `targetColumn = (targetColumn * coefficient) + sourceColumn`.
@@ -251,8 +251,8 @@ class Base_matrix_with_column_compression : protected Master_matrix::Matrix_row_
    */
   template <class Cell_range_or_column_index>
   void multiply_target_and_add_to(const Cell_range_or_column_index& sourceColumn, 
-                                  const Field_element_type& coefficient,
-                                  index targetColumnIndex);
+                                  const Field_element& coefficient,
+                                  Index targetColumnIndex);
   /**
    * @brief Multiplies the source column with the coefficient before adding it to the target column.
    * That is: `targetColumn += (coefficient * sourceColumn)`. The source column will **not** be modified.
@@ -267,9 +267,9 @@ class Base_matrix_with_column_compression : protected Master_matrix::Matrix_row_
    * @param targetColumnIndex @ref MatIdx index of the target column.
    */
   template <class Cell_range_or_column_index>
-  void multiply_source_and_add_to(const Field_element_type& coefficient, 
+  void multiply_source_and_add_to(const Field_element& coefficient, 
                                   const Cell_range_or_column_index& sourceColumn,
-                                  index targetColumnIndex);
+                                  Index targetColumnIndex);
 
   /**
    * @brief Indicates if the cell at given coordinates has value zero.
@@ -279,7 +279,7 @@ class Base_matrix_with_column_compression : protected Master_matrix::Matrix_row_
    * @return true If the cell has value zero.
    * @return false Otherwise.
    */
-  bool is_zero_cell(index columnIndex, index rowIndex);
+  bool is_zero_cell(Index columnIndex, Index rowIndex);
   /**
    * @brief Indicates if the column at given index has value zero.
    * 
@@ -287,7 +287,7 @@ class Base_matrix_with_column_compression : protected Master_matrix::Matrix_row_
    * @return true If the column has value zero.
    * @return false Otherwise.
    */
-  bool is_zero_column(index columnIndex);
+  bool is_zero_column(Index columnIndex);
 
   /**
    * @brief Resets the matrix to an empty matrix.
@@ -295,7 +295,7 @@ class Base_matrix_with_column_compression : protected Master_matrix::Matrix_row_
    * @param colSettings Pointer to the cell factory.
    */
   void reset(Column_settings* colSettings) {
-    columnToRep_.clear_and_dispose(delete_disposer(this));
+    columnToRep_.clear_and_dispose(Delete_disposer(this));
     columnClasses_ = boost::disjoint_sets_with_storage<>();
     repToColumn_.clear();
     nextColumnIndex_ = 0;
@@ -329,53 +329,53 @@ class Base_matrix_with_column_compression : protected Master_matrix::Matrix_row_
   /**
    * @brief The disposer object function for boost intrusive container
    */
-  struct delete_disposer {
-    delete_disposer(Base_matrix_with_column_compression* matrix) : matrix_(matrix) {}
+  struct Delete_disposer {
+    Delete_disposer(Base_matrix_with_column_compression* matrix) : matrix_(matrix) {}
 
-    void operator()(Column_type* delete_this) { matrix_->columnPool_->destroy(delete_this); }
+    void operator()(Column* delete_this) { matrix_->columnPool_->destroy(delete_this); }
 
     Base_matrix_with_column_compression* matrix_;
   };
 
-  using ra_opt = typename Master_matrix::Matrix_row_access_option;
-  using col_dict_type = boost::intrusive::set<Column_type, boost::intrusive::constant_time_size<false> >;
+  using RA_opt = typename Master_matrix::Matrix_row_access_option;
+  using Col_dict = boost::intrusive::set<Column, boost::intrusive::constant_time_size<false> >;
 
-  col_dict_type columnToRep_;                         /**< Map from a column to the index of its representative. */
+  Col_dict columnToRep_;                              /**< Map from a column to the index of its representative. */
   boost::disjoint_sets_with_storage<> columnClasses_; /**< Union-find structure,
                                                            where two columns in the same set are identical. */
-  std::vector<Column_type*> repToColumn_;             /**< Map from the representative index to
+  std::vector<Column*> repToColumn_;                  /**< Map from the representative index to
                                                            the representative Column. */
-  index nextColumnIndex_;                             /**< Next unused column index. */
+  Index nextColumnIndex_;                             /**< Next unused column index. */
   Column_settings* colSettings_;                      /**< Cell factory. */
   /**
    * @brief Column factory. Has to be a pointer as Simple_object_pool is not swappable, so their addresses have to be
    * exchanged instead.
    */
-  std::unique_ptr<Simple_object_pool<Column_type> > columnPool_;
-  inline static const Column_type empty_column_;      /**< Representative for empty columns. */
+  std::unique_ptr<Simple_object_pool<Column> > columnPool_;
+  inline static const Column empty_column_;           /**< Representative for empty columns. */
 
-  void _insert_column(index columnIndex);
-  void _insert_double_column(index columnIndex, typename col_dict_type::iterator& doubleIt);
+  void _insert_column(Index columnIndex);
+  void _insert_double_column(Index columnIndex, typename Col_dict::iterator& doubleIt);
 };
 
 template <class Master_matrix>
 inline Base_matrix_with_column_compression<Master_matrix>::Base_matrix_with_column_compression(
     Column_settings* colSettings)
-    : ra_opt(), nextColumnIndex_(0), colSettings_(colSettings), columnPool_(new Simple_object_pool<Column_type>)
+    : RA_opt(), nextColumnIndex_(0), colSettings_(colSettings), columnPool_(new Simple_object_pool<Column>)
 {}
 
 template <class Master_matrix>
-template <class Container_type>
+template <class Container>
 inline Base_matrix_with_column_compression<Master_matrix>::Base_matrix_with_column_compression(
-    const std::vector<Container_type>& columns, Column_settings* colSettings)
-    : ra_opt(columns.size()),
+    const std::vector<Container>& columns, Column_settings* colSettings)
+    : RA_opt(columns.size()),
       columnClasses_(columns.size()),
       repToColumn_(columns.size(), nullptr),
       nextColumnIndex_(0),
       colSettings_(colSettings),
-      columnPool_(new Simple_object_pool<Column_type>)
+      columnPool_(new Simple_object_pool<Column>)
 {
-  for (const Container_type& c : columns) {
+  for (const Container& c : columns) {
     insert_column(c);
   }
 }
@@ -383,29 +383,29 @@ inline Base_matrix_with_column_compression<Master_matrix>::Base_matrix_with_colu
 template <class Master_matrix>
 inline Base_matrix_with_column_compression<Master_matrix>::Base_matrix_with_column_compression(
     unsigned int numberOfColumns, Column_settings* colSettings)
-    : ra_opt(numberOfColumns),
+    : RA_opt(numberOfColumns),
       columnClasses_(numberOfColumns),
       repToColumn_(numberOfColumns, nullptr),
       nextColumnIndex_(0),
       colSettings_(colSettings),
-      columnPool_(new Simple_object_pool<Column_type>)
+      columnPool_(new Simple_object_pool<Column>)
 {}
 
 template <class Master_matrix>
 inline Base_matrix_with_column_compression<Master_matrix>::Base_matrix_with_column_compression(
     const Base_matrix_with_column_compression& matrixToCopy, Column_settings* colSettings)
-    : ra_opt(static_cast<const ra_opt&>(matrixToCopy)),
+    : RA_opt(static_cast<const RA_opt&>(matrixToCopy)),
       columnClasses_(matrixToCopy.columnClasses_),
       repToColumn_(matrixToCopy.repToColumn_.size(), nullptr),
       nextColumnIndex_(0),
       colSettings_(colSettings == nullptr ? matrixToCopy.colSettings_ : colSettings),
-      columnPool_(new Simple_object_pool<Column_type>)
+      columnPool_(new Simple_object_pool<Column>)
 {
-  for (const Column_type* col : matrixToCopy.repToColumn_) {
+  for (const Column* col : matrixToCopy.repToColumn_) {
     if (col != nullptr) {
       if constexpr (Master_matrix::Option_list::has_row_access) {
         repToColumn_[nextColumnIndex_] =
-            columnPool_->construct(*col, col->get_column_index(), ra_opt::rows_, colSettings_);
+            columnPool_->construct(*col, col->get_column_index(), RA_opt::rows_, colSettings_);
       } else {
         repToColumn_[nextColumnIndex_] = columnPool_->construct(*col, colSettings_);
       }
@@ -419,7 +419,7 @@ inline Base_matrix_with_column_compression<Master_matrix>::Base_matrix_with_colu
 template <class Master_matrix>
 inline Base_matrix_with_column_compression<Master_matrix>::Base_matrix_with_column_compression(
     Base_matrix_with_column_compression&& other) noexcept
-    : ra_opt(std::move(static_cast<ra_opt&>(other))),
+    : RA_opt(std::move(static_cast<RA_opt&>(other))),
       columnToRep_(std::move(other.columnToRep_)),
       columnClasses_(std::move(other.columnClasses_)),
       repToColumn_(std::move(other.repToColumn_)),
@@ -431,20 +431,20 @@ inline Base_matrix_with_column_compression<Master_matrix>::Base_matrix_with_colu
 template <class Master_matrix>
 inline Base_matrix_with_column_compression<Master_matrix>::~Base_matrix_with_column_compression() 
 {
-  columnToRep_.clear_and_dispose(delete_disposer(this));
+  columnToRep_.clear_and_dispose(Delete_disposer(this));
 }
 
 template <class Master_matrix>
-template <class Container_type>
-inline void Base_matrix_with_column_compression<Master_matrix>::insert_column(const Container_type& column) 
+template <class Container>
+inline void Base_matrix_with_column_compression<Master_matrix>::insert_column(const Container& column) 
 {
   insert_boundary(column);
 }
 
 template <class Master_matrix>
-template <class Boundary_type>
-inline void Base_matrix_with_column_compression<Master_matrix>::insert_boundary(const Boundary_type& boundary,
-                                                                                dimension_type dim) 
+template <class Boundary_container>
+inline void Base_matrix_with_column_compression<Master_matrix>::insert_boundary(const Boundary_container& boundary,
+                                                                                Dimension dim) 
 {
   // handles a dimension which is not actually stored.
   // TODO: verify if this is not a problem for the cohomology algorithm and if yes,
@@ -453,13 +453,13 @@ inline void Base_matrix_with_column_compression<Master_matrix>::insert_boundary(
 
   if constexpr (Master_matrix::Option_list::has_row_access && !Master_matrix::Option_list::has_removable_rows) {
     if (boundary.begin() != boundary.end()) {
-      index pivot;
+      Index pivot;
       if constexpr (Master_matrix::Option_list::is_z2) {
         pivot = *std::prev(boundary.end());
       } else {
         pivot = std::prev(boundary.end())->first;
       }
-      if (ra_opt::rows_->size() <= pivot) ra_opt::rows_->resize(pivot + 1);
+      if (RA_opt::rows_->size() <= pivot) RA_opt::rows_->resize(pivot + 1);
     }
   }
 
@@ -468,14 +468,14 @@ inline void Base_matrix_with_column_compression<Master_matrix>::insert_boundary(
     columnClasses_.link(nextColumnIndex_, nextColumnIndex_);
     if constexpr (Master_matrix::Option_list::has_row_access) {
       repToColumn_.push_back(
-          columnPool_->construct(nextColumnIndex_, boundary, dim, ra_opt::rows_, colSettings_));
+          columnPool_->construct(nextColumnIndex_, boundary, dim, RA_opt::rows_, colSettings_));
     } else {
       repToColumn_.push_back(columnPool_->construct(boundary, dim, colSettings_));
     }
   } else {
     if constexpr (Master_matrix::Option_list::has_row_access) {
       repToColumn_[nextColumnIndex_] =
-          columnPool_->construct(nextColumnIndex_, boundary, dim, ra_opt::rows_, colSettings_);
+          columnPool_->construct(nextColumnIndex_, boundary, dim, RA_opt::rows_, colSettings_);
     } else {
       repToColumn_[nextColumnIndex_] = columnPool_->construct(boundary, dim, colSettings_);
     }
@@ -486,8 +486,8 @@ inline void Base_matrix_with_column_compression<Master_matrix>::insert_boundary(
 }
 
 template <class Master_matrix>
-inline const typename Base_matrix_with_column_compression<Master_matrix>::Column_type&
-Base_matrix_with_column_compression<Master_matrix>::get_column(index columnIndex) 
+inline const typename Base_matrix_with_column_compression<Master_matrix>::Column&
+Base_matrix_with_column_compression<Master_matrix>::get_column(Index columnIndex) 
 {
   auto col = repToColumn_[columnClasses_.find_set(columnIndex)];
   if (col == nullptr) return empty_column_;
@@ -495,24 +495,24 @@ Base_matrix_with_column_compression<Master_matrix>::get_column(index columnIndex
 }
 
 template <class Master_matrix>
-inline const typename Base_matrix_with_column_compression<Master_matrix>::Row_type&
-Base_matrix_with_column_compression<Master_matrix>::get_row(index rowIndex) const 
+inline const typename Base_matrix_with_column_compression<Master_matrix>::Row&
+Base_matrix_with_column_compression<Master_matrix>::get_row(Index rowIndex) const 
 {
   static_assert(Master_matrix::Option_list::has_row_access, "Row access has to be enabled for this method.");
 
-  return ra_opt::get_row(rowIndex);
+  return RA_opt::get_row(rowIndex);
 }
 
 template <class Master_matrix>
-inline void Base_matrix_with_column_compression<Master_matrix>::erase_empty_row(index rowIndex) 
+inline void Base_matrix_with_column_compression<Master_matrix>::erase_empty_row(Index rowIndex) 
 {
   if constexpr (Master_matrix::Option_list::has_row_access && Master_matrix::Option_list::has_removable_rows) {
-    ra_opt::erase_empty_row(rowIndex);
+    RA_opt::erase_empty_row(rowIndex);
   }
 }
 
 template <class Master_matrix>
-inline typename Base_matrix_with_column_compression<Master_matrix>::index
+inline typename Base_matrix_with_column_compression<Master_matrix>::Index
 Base_matrix_with_column_compression<Master_matrix>::get_number_of_columns() const 
 {
   return nextColumnIndex_;
@@ -521,11 +521,11 @@ Base_matrix_with_column_compression<Master_matrix>::get_number_of_columns() cons
 template <class Master_matrix>
 template <class Cell_range_or_column_index>
 inline void Base_matrix_with_column_compression<Master_matrix>::add_to(const Cell_range_or_column_index& sourceColumn,
-                                                                       index targetColumnIndex) 
+                                                                       Index targetColumnIndex) 
 {
   // handle case where targetRep == sourceRep?
-  index targetRep = columnClasses_.find_set(targetColumnIndex);
-  Column_type& target = *repToColumn_[targetRep];
+  Index targetRep = columnClasses_.find_set(targetColumnIndex);
+  Column& target = *repToColumn_[targetRep];
   columnToRep_.erase(target);
   if constexpr (std::is_integral_v<Cell_range_or_column_index>) {
     target += get_column(sourceColumn);
@@ -538,11 +538,11 @@ inline void Base_matrix_with_column_compression<Master_matrix>::add_to(const Cel
 template <class Master_matrix>
 template <class Cell_range_or_column_index>
 inline void Base_matrix_with_column_compression<Master_matrix>::multiply_target_and_add_to(
-    const Cell_range_or_column_index& sourceColumn, const Field_element_type& coefficient, index targetColumnIndex) 
+    const Cell_range_or_column_index& sourceColumn, const Field_element& coefficient, Index targetColumnIndex) 
 {
   // handle case where targetRep == sourceRep?
-  index targetRep = columnClasses_.find_set(targetColumnIndex);
-  Column_type& target = *repToColumn_[targetRep];
+  Index targetRep = columnClasses_.find_set(targetColumnIndex);
+  Column& target = *repToColumn_[targetRep];
   columnToRep_.erase(target);
   if constexpr (std::is_integral_v<Cell_range_or_column_index>) {
     target.multiply_target_and_add(coefficient, get_column(sourceColumn));
@@ -555,11 +555,11 @@ inline void Base_matrix_with_column_compression<Master_matrix>::multiply_target_
 template <class Master_matrix>
 template <class Cell_range_or_column_index>
 inline void Base_matrix_with_column_compression<Master_matrix>::multiply_source_and_add_to(
-    const Field_element_type& coefficient, const Cell_range_or_column_index& sourceColumn, index targetColumnIndex) 
+    const Field_element& coefficient, const Cell_range_or_column_index& sourceColumn, Index targetColumnIndex) 
 {
   // handle case where targetRep == sourceRep?
-  index targetRep = columnClasses_.find_set(targetColumnIndex);
-  Column_type& target = *repToColumn_[targetRep];
+  Index targetRep = columnClasses_.find_set(targetColumnIndex);
+  Column& target = *repToColumn_[targetRep];
   columnToRep_.erase(target);
   if constexpr (std::is_integral_v<Cell_range_or_column_index>) {
     target.multiply_source_and_add(get_column(sourceColumn), coefficient);
@@ -570,7 +570,7 @@ inline void Base_matrix_with_column_compression<Master_matrix>::multiply_source_
 }
 
 template <class Master_matrix>
-inline bool Base_matrix_with_column_compression<Master_matrix>::is_zero_cell(index columnIndex, index rowIndex) 
+inline bool Base_matrix_with_column_compression<Master_matrix>::is_zero_cell(Index columnIndex, Index rowIndex) 
 {
   auto col = repToColumn_[columnClasses_.find_set(columnIndex)];
   if (col == nullptr) return true;
@@ -578,7 +578,7 @@ inline bool Base_matrix_with_column_compression<Master_matrix>::is_zero_cell(ind
 }
 
 template <class Master_matrix>
-inline bool Base_matrix_with_column_compression<Master_matrix>::is_zero_column(index columnIndex) 
+inline bool Base_matrix_with_column_compression<Master_matrix>::is_zero_column(Index columnIndex) 
 {
   auto col = repToColumn_[columnClasses_.find_set(columnIndex)];
   if (col == nullptr) return true;
@@ -595,16 +595,16 @@ Base_matrix_with_column_compression<Master_matrix>::operator=(const Base_matrix_
       col = nullptr;
     }
   }
-  ra_opt::operator=(other);
+  RA_opt::operator=(other);
   columnClasses_ = other.columnClasses_;
   columnToRep_.reserve(other.columnToRep_.size());
   repToColumn_.resize(other.repToColumn_.size(), nullptr);
   nextColumnIndex_ = 0;
   colSettings_ = other.colSettings_;
-  for (const Column_type* col : other.repToColumn_) {
+  for (const Column* col : other.repToColumn_) {
     if constexpr (Master_matrix::Option_list::has_row_access) {
       repToColumn_[nextColumnIndex_] =
-          columnPool_->construct(*col, col->get_column_index(), ra_opt::rows_, colSettings_);
+          columnPool_->construct(*col, col->get_column_index(), RA_opt::rows_, colSettings_);
     } else {
       repToColumn_[nextColumnIndex_] = columnPool_->construct(*col, colSettings_);
     }
@@ -619,7 +619,7 @@ template <class Master_matrix>
 inline void Base_matrix_with_column_compression<Master_matrix>::print() 
 {
   std::cout << "Compressed_matrix:\n";
-  for (Column_type& col : columnToRep_) {
+  for (Column& col : columnToRep_) {
     for (auto e : col->get_content(nextColumnIndex_)) {
       if (e == 0u)
         std::cout << "- ";
@@ -627,15 +627,15 @@ inline void Base_matrix_with_column_compression<Master_matrix>::print()
         std::cout << e << " ";
     }
     std::cout << "(";
-    for (index i = 0; i < nextColumnIndex_; ++i) {
+    for (Index i = 0; i < nextColumnIndex_; ++i) {
       if (columnClasses_.find_set(i) == col.get_rep()) std::cout << i << " ";
     }
     std::cout << ")\n";
   }
   std::cout << "\n";
   std::cout << "Row Matrix:\n";
-  for (index i = 0; i < ra_opt::rows_->size(); ++i) {
-    const Row_type& row = ra_opt::rows_[i];
+  for (Index i = 0; i < RA_opt::rows_->size(); ++i) {
+    const Row& row = RA_opt::rows_[i];
     for (const auto& cell : row) {
       std::cout << cell.get_column_index() << " ";
     }
@@ -645,9 +645,9 @@ inline void Base_matrix_with_column_compression<Master_matrix>::print()
 }
 
 template <class Master_matrix>
-inline void Base_matrix_with_column_compression<Master_matrix>::_insert_column(index columnIndex) 
+inline void Base_matrix_with_column_compression<Master_matrix>::_insert_column(Index columnIndex) 
 {
-  Column_type& col = *repToColumn_[columnIndex];
+  Column& col = *repToColumn_[columnIndex];
 
   if (col.is_empty()) {
     columnPool_->destroy(&col);  // delete curr_col;
@@ -664,11 +664,11 @@ inline void Base_matrix_with_column_compression<Master_matrix>::_insert_column(i
 
 template <class Master_matrix>
 inline void Base_matrix_with_column_compression<Master_matrix>::_insert_double_column(
-    index columnIndex, typename col_dict_type::iterator& doubleIt) 
+    Index columnIndex, typename Col_dict::iterator& doubleIt) 
 {
-  index doubleRep = doubleIt->get_rep();
+  Index doubleRep = doubleIt->get_rep();
   columnClasses_.link(columnIndex, doubleRep);  // both should be representatives
-  index newRep = columnClasses_.find_set(columnIndex);
+  Index newRep = columnClasses_.find_set(columnIndex);
 
   columnPool_->destroy(repToColumn_[columnIndex]);
   repToColumn_[columnIndex] = nullptr;

--- a/src/Persistence_matrix/include/gudhi/Persistence_matrix/base_pairing.h
+++ b/src/Persistence_matrix/include/gudhi/Persistence_matrix/base_pairing.h
@@ -50,16 +50,16 @@ struct Dummy_base_pairing {
 template <class Master_matrix>
 class Base_pairing : public std::conditional<
                        Master_matrix::Option_list::has_removable_columns,
-                       Face_position_to_ID_mapper<typename Master_matrix::id_index, typename Master_matrix::pos_index>,
+                       Face_position_to_ID_mapper<typename Master_matrix::ID_index, typename Master_matrix::Pos_index>,
                        Dummy_pos_mapper
                     >::type
 {
  public:
   using Bar = typename Master_matrix::Bar;                            /**< Bar type. */
-  using barcode_type = typename Master_matrix::barcode_type;          /**< Barcode type. */
-  using matrix_type = typename Master_matrix::column_container_type;  /**< Column container type. */
-  using index = typename Master_matrix::index;                        /**< Container index type. */
-  using dimension_type = typename Master_matrix::dimension_type;      /**< Dimension value type. */
+  using Barcode = typename Master_matrix::Barcode;                    /**< Barcode type. */
+  using Column_container = typename Master_matrix::Column_container;  /**< Column container type. */
+  using Index = typename Master_matrix::Index;                        /**< Container index type. */
+  using Dimension = typename Master_matrix::Dimension;                /**< Dimension value type. */
 
   /**
    * @brief Default constructor.
@@ -75,15 +75,15 @@ class Base_pairing : public std::conditional<
    * 
    * @return Const reference to the barcode.
    */
-  const barcode_type& get_current_barcode();
+  const Barcode& get_current_barcode();
 
   /**
    * @brief Swap operator.
    */
   friend void swap(Base_pairing& pairing1, Base_pairing& pairing2) {
     if constexpr (Master_matrix::Option_list::has_removable_columns) {
-      swap(static_cast<Face_position_to_ID_mapper<id_index, pos_index>&>(pairing1),
-           static_cast<Face_position_to_ID_mapper<id_index, pos_index>&>(pairing2));
+      swap(static_cast<Face_position_to_ID_mapper<ID_index, Pos_index>&>(pairing1),
+           static_cast<Face_position_to_ID_mapper<ID_index, Pos_index>&>(pairing2));
     }
     pairing1.barcode_.swap(pairing2.barcode_);
     pairing1.deathToBar_.swap(pairing2.deathToBar_);
@@ -92,30 +92,30 @@ class Base_pairing : public std::conditional<
   }
 
  protected:
-  using pos_index = typename Master_matrix::pos_index;
-  using id_index = typename Master_matrix::id_index;
-  using dictionary_type = typename Master_matrix::bar_dictionary_type;
-  using base_matrix = typename Master_matrix::Boundary_matrix_type;
+  using Pos_index = typename Master_matrix::Pos_index;
+  using ID_index = typename Master_matrix::ID_index;
+  using Dictionary = typename Master_matrix::Bar_dictionary;
+  using Base_matrix = typename Master_matrix::Master_boundary_matrix;
   //PIDM = Position to ID Map
   using PIDM = typename std::conditional<Master_matrix::Option_list::has_removable_columns,
-                                        Face_position_to_ID_mapper<id_index, pos_index>,
-                                        Dummy_pos_mapper
-                                       >::type;
+                                         Face_position_to_ID_mapper<ID_index, Pos_index>,
+                                         Dummy_pos_mapper
+                                        >::type;
 
-  barcode_type barcode_;        /**< Bar container. */
-  dictionary_type deathToBar_; /**< Map from death index to bar index. */
+  Barcode barcode_;       /**< Bar container. */
+  Dictionary deathToBar_; /**< Map from death index to bar index. */
   /**
    * @brief Map from face ID to face position. Only stores a pair if ID != position.
    */
-  std::unordered_map<id_index, pos_index> idToPosition_;  //TODO: test other map types
-  bool isReduced_;              /**< True if `_reduce()` was called. */
+  std::unordered_map<ID_index,Pos_index> idToPosition_;  //TODO: test other map types
+  bool isReduced_;        /**< True if `_reduce()` was called. */
 
   void _reduce();
-  void _remove_last(pos_index columnIndex);
+  void _remove_last(Pos_index columnIndex);
 
   //access to inheriting Boundary_matrix class
-  constexpr base_matrix* _matrix() { return static_cast<base_matrix*>(this); }
-  constexpr const base_matrix* _matrix() const { return static_cast<const base_matrix*>(this); }
+  constexpr Base_matrix* _matrix() { return static_cast<Base_matrix*>(this); }
+  constexpr const Base_matrix* _matrix() const { return static_cast<const Base_matrix*>(this); }
 };
 
 template <class Master_matrix>
@@ -123,7 +123,7 @@ inline Base_pairing<Master_matrix>::Base_pairing() : PIDM(), isReduced_(false)
 {}
 
 template <class Master_matrix>
-inline const typename Base_pairing<Master_matrix>::barcode_type& Base_pairing<Master_matrix>::get_current_barcode() 
+inline const typename Base_pairing<Master_matrix>::Barcode& Base_pairing<Master_matrix>::get_current_barcode() 
 {
   if (!isReduced_) _reduce();
   return barcode_;
@@ -132,30 +132,30 @@ inline const typename Base_pairing<Master_matrix>::barcode_type& Base_pairing<Ma
 template <class Master_matrix>
 inline void Base_pairing<Master_matrix>::_reduce() 
 {
-  std::unordered_map<id_index, index> pivotsToColumn(_matrix()->get_number_of_columns());
+  std::unordered_map<ID_index, Index> pivotsToColumn(_matrix()->get_number_of_columns());
 
   auto dim = _matrix()->get_max_dimension();
-  std::vector<std::vector<index> > columnsByDim(dim + 1);
+  std::vector<std::vector<Index> > columnsByDim(dim + 1);
   for (unsigned int i = 0; i < _matrix()->get_number_of_columns(); i++) {
     columnsByDim[dim - _matrix()->get_column_dimension(i)].push_back(i);
   }
 
   for (const auto& cols : columnsByDim) {
-    for (index i : cols) {
+    for (Index i : cols) {
       auto& curr = _matrix()->get_column(i);
       if (curr.is_empty()) {
         if (pivotsToColumn.find(i) == pivotsToColumn.end()) {
           barcode_.emplace_back(i, -1, dim);
         }
       } else {
-        id_index pivot = curr.get_pivot();
+        ID_index pivot = curr.get_pivot();
 
-        while (pivot != static_cast<id_index>(-1) && pivotsToColumn.find(pivot) != pivotsToColumn.end()) {
+        while (pivot != static_cast<ID_index>(-1) && pivotsToColumn.find(pivot) != pivotsToColumn.end()) {
           if constexpr (Master_matrix::Option_list::is_z2) {
             curr += _matrix()->get_column(pivotsToColumn.at(pivot));
           } else {
             auto& toadd = _matrix()->get_column(pivotsToColumn.at(pivot));
-            typename Master_matrix::element_type coef = toadd.get_pivot_value();
+            typename Master_matrix::Element coef = toadd.get_pivot_value();
             auto& operators = _matrix()->colSettings_->operators;
             coef = operators.get_inverse(coef);
             operators.multiply_inplace(coef, operators.get_characteristic() - curr.get_pivot_value());
@@ -165,7 +165,7 @@ inline void Base_pairing<Master_matrix>::_reduce()
           pivot = curr.get_pivot();
         }
 
-        if (pivot != static_cast<id_index>(-1)) {
+        if (pivot != static_cast<ID_index>(-1)) {
           pivotsToColumn.emplace(pivot, i);
           auto it = idToPosition_.find(pivot);
           auto pivotColumnNumber = it == idToPosition_.end() ? pivot : it->second;
@@ -184,9 +184,9 @@ inline void Base_pairing<Master_matrix>::_reduce()
     // sort barcode by birth such that a removal is trivial
     std::sort(barcode_.begin(), barcode_.end(), [](const Bar& b1, const Bar& b2) { return b1.birth < b2.birth; });
     // map can only be constructed once barcode is sorted
-    for (index i = 0; i < barcode_.size(); ++i) {
+    for (Index i = 0; i < barcode_.size(); ++i) {
       auto d = barcode_[i].death;
-      if (d != static_cast<pos_index>(-1)) {
+      if (d != static_cast<Pos_index>(-1)) {
         deathToBar_.emplace(d, i);
       }
     }
@@ -196,7 +196,7 @@ inline void Base_pairing<Master_matrix>::_reduce()
 }
 
 template <class Master_matrix>
-inline void Base_pairing<Master_matrix>::_remove_last(pos_index columnIndex) 
+inline void Base_pairing<Master_matrix>::_remove_last(Pos_index columnIndex) 
 {
   static_assert(Master_matrix::Option_list::has_removable_columns, "remove_last not available.");
 

--- a/src/Persistence_matrix/include/gudhi/Persistence_matrix/boundary_face_position_to_id_mapper.h
+++ b/src/Persistence_matrix/include/gudhi/Persistence_matrix/boundary_face_position_to_id_mapper.h
@@ -40,14 +40,14 @@ struct Dummy_pos_mapper {
  *
  * @brief Map from face position to face ID. Only stores a pair if ID != position and has_removable_column is true.
  * 
- * @tparam id_index @ref IDIdx index type
- * @tparam pos_index @ref PosIdx index type
+ * @tparam ID_index @ref IDIdx index type
+ * @tparam Pos_index @ref PosIdx index type
  */
-template<typename id_index, typename pos_index>
+template<typename ID_index, typename Pos_index>
 struct Face_position_to_ID_mapper {
-  using map_type = std::unordered_map<pos_index,id_index>; //TODO: test other map types
+  using Index_map = std::unordered_map<Pos_index,ID_index>; //TODO: test other map types
 
-  map_type map_;
+  Index_map map_;
 
   friend void swap(Face_position_to_ID_mapper& mapper1, Face_position_to_ID_mapper& mapper2) {
     mapper1.map_.swap(mapper2.map_);

--- a/src/Persistence_matrix/include/gudhi/Persistence_matrix/boundary_matrix.h
+++ b/src/Persistence_matrix/include/gudhi/Persistence_matrix/boundary_matrix.h
@@ -43,17 +43,17 @@ class Boundary_matrix : public Master_matrix::Matrix_dimension_option,
                         public Master_matrix::Matrix_row_access_option 
 {
  public:
-  using index = typename Master_matrix::index;                        /**< Container index type. */
-  using id_index = typename Master_matrix::id_index;                  /**< @ref IDIdx index type. */
-  using dimension_type = typename Master_matrix::dimension_type;      /**< Dimension value type. */
+  using Index = typename Master_matrix::Index;                        /**< Container index type. */
+  using ID_index = typename Master_matrix::ID_index;                  /**< @ref IDIdx index type. */
+  using Dimension = typename Master_matrix::Dimension;                /**< Dimension value type. */
   /**
    * @brief Field operators class. Necessary only if @ref PersistenceMatrixOptions::is_z2 is false.
    */
   using Field_operators = typename Master_matrix::Field_operators;
-  using Field_element_type = typename Master_matrix::element_type;    /**< Type of an field element. */
-  using Column_type = typename Master_matrix::Column_type;            /**< Column type. */
-  using boundary_type = typename Master_matrix::boundary_type;        /**< Type of an input column. */
-  using Row_type = typename Master_matrix::Row_type;                  /**< Row type,
+  using Field_element = typename Master_matrix::Element;              /**< Type of an field element. */
+  using Column = typename Master_matrix::Column;                      /**< Column type. */
+  using Boundary = typename Master_matrix::Boundary;                  /**< Type of an input column. */
+  using Row = typename Master_matrix::Row;                            /**< Row type,
                                                                            only necessary with row access option. */
   using Cell_constructor = typename Master_matrix::Cell_constructor;  /**< Factory of @ref Cell classes. */
   using Column_settings = typename Master_matrix::Column_settings;    /**< Structure giving access to the columns to
@@ -67,11 +67,11 @@ class Boundary_matrix : public Master_matrix::Matrix_dimension_option,
    */
   Boundary_matrix(Column_settings* colSettings);
   /**
-   * @brief Constructs a new matrix from the given ranges of @ref Matrix::cell_rep_type. Each range corresponds to
+   * @brief Constructs a new matrix from the given ranges of @ref Matrix::Cell_representative. Each range corresponds to
    * a column  (the order of the ranges are preserved). The content of the ranges is assumed to be sorted by increasing
    * IDs. The IDs of the simplices are also assumed to be consecutive, ordered by filtration value, starting with 0. 
    * 
-   * @tparam Boundary_type Range type for @ref Matrix::cell_rep_type ranges.
+   * @tparam Boundary_container Range type for @ref Matrix::Cell_representative ranges.
    * Assumed to have a begin(), end() and size() method.
    * @param orderedBoundaries Range of boundaries: @p orderedBoundaries is interpreted as a boundary matrix of a 
    * filtered **simplicial** complex, whose boundaries are ordered by filtration order. 
@@ -87,8 +87,8 @@ class Boundary_matrix : public Master_matrix::Matrix_dimension_option,
    * @param colSettings Pointer to an existing setting structure for the columns. The structure should contain all
    * the necessary external classes specifically necessary for the choosen column type, such as custom allocators.
    */
-  template <class Boundary_type = boundary_type>
-  Boundary_matrix(const std::vector<Boundary_type>& orderedBoundaries, 
+  template <class Boundary_container = Boundary>
+  Boundary_matrix(const std::vector<Boundary_container>& orderedBoundaries, 
                   Column_settings* colSettings);
   /**
    * @brief Constructs a new empty matrix and reserves space for the given number of columns.
@@ -121,7 +121,7 @@ class Boundary_matrix : public Master_matrix::Matrix_dimension_option,
    * This means that it is assumed that this method is called on boundaries in the order of the filtration. 
    * It also assumes that the faces in the given boundary are identified by their relative position in the filtration, 
    * starting at 0. If it is not the case, use the other
-   * @ref insert_boundary(id_index faceIndex, const Boundary_type& boundary, dimension_type dim) "insert_boundary"
+   * @ref insert_boundary(ID_index faceIndex, const Boundary_container& boundary, Dimension dim) "insert_boundary"
    * instead by indicating the face ID used in the boundaries when the face is inserted.
    *
    * Different to the constructor, the boundaries do not have to come from a simplicial complex, but also from
@@ -132,14 +132,14 @@ class Boundary_matrix : public Master_matrix::Matrix_dimension_option,
    * not be updated, so call @ref Base_pairing::get_current_barcode "get_current_barcode" only when the matrix is
    * complete.
    * 
-   * @tparam Boundary_type Range of @ref Matrix::cell_rep_type. Assumed to have a begin(), end() and size() method.
+   * @tparam Boundary_container Range of @ref Matrix::Cell_representative. Assumed to have a begin(), end() and size() method.
    * @param boundary Boundary generating the new column. The content should be ordered by ID.
    * @param dim Dimension of the face whose boundary is given. If the complex is simplicial, 
    * this parameter can be omitted as it can be deduced from the size of the boundary.
    * @return The @ref MatIdx index of the inserted boundary.
    */
-  template <class Boundary_type = boundary_type>
-  index insert_boundary(const Boundary_type& boundary, dimension_type dim = -1);
+  template <class Boundary_container = Boundary>
+  Index insert_boundary(const Boundary_container& boundary, Dimension dim = -1);
   /**
    * @brief It does the same as the other version, but allows the boundary faces to be identified without restrictions
    * except that all IDs have to be strictly increasing in the order of filtration. Note that you should avoid then
@@ -148,7 +148,7 @@ class Boundary_matrix : public Master_matrix::Matrix_dimension_option,
    * As a face has to be inserted before one of its cofaces in a valid filtration (recall that it is assumed that
    * the faces are inserted by order of filtration), it is sufficient to indicate the ID of the face being inserted.
    * 
-   * @tparam Boundary_type Range of @ref Matrix::cell_rep_type. Assumed to have a begin(), end() and size() method.
+   * @tparam Boundary_container Range of @ref Matrix::Cell_representative. Assumed to have a begin(), end() and size() method.
    * @param faceIndex @ref IDIdx index to use to identify the new face.
    * @param boundary Boundary generating the new column. The indices of the boundary have to correspond to the 
    * @p faceIndex values of precedent calls of the method for the corresponding faces and should be ordered in 
@@ -157,8 +157,8 @@ class Boundary_matrix : public Master_matrix::Matrix_dimension_option,
    * this parameter can be omitted as it can be deduced from the size of the boundary.
    * @return The @ref MatIdx index of the inserted boundary.
    */
-  template <class Boundary_type = boundary_type>
-  index insert_boundary(id_index faceIndex, const Boundary_type& boundary, dimension_type dim = -1);
+  template <class Boundary_container = Boundary>
+  Index insert_boundary(ID_index faceIndex, const Boundary_container& boundary, Dimension dim = -1);
   /**
    * @brief Returns the column at the given @ref MatIdx index.
    * The type of the column depends on the choosen options, see @ref PersistenceMatrixOptions::column_type.
@@ -170,7 +170,7 @@ class Boundary_matrix : public Master_matrix::Matrix_dimension_option,
    * @param columnIndex @ref MatIdx index of the column to return.
    * @return Reference to the column.
    */
-  Column_type& get_column(index columnIndex);
+  Column& get_column(Index columnIndex);
   /**
    * @brief Only available if @ref PersistenceMatrixOptions::has_row_access is true.
    * Returns the row at the given @ref rowindex "row index" of the matrix.
@@ -183,14 +183,14 @@ class Boundary_matrix : public Master_matrix::Matrix_dimension_option,
    * @param rowIndex @ref rowindex "Row index" of the row to return.
    * @return Reference to the row.
    */
-  Row_type& get_row(index rowIndex);
+  Row& get_row(Index rowIndex);
   /**
    * @brief Only available if @ref PersistenceMatrixOptions::has_removable_columns is true.
    * Removes the last face in the filtration from the matrix and updates the barcode if this one was already computed.
    * 
    * @return The pivot of the removed face.
    */
-  index remove_last();
+  Index remove_last();
   /**
    * @brief If @ref PersistenceMatrixOptions::has_row_access and @ref PersistenceMatrixOptions::has_removable_rows
    * are true: assumes that the row is empty and removes it. If @ref PersistenceMatrixOptions::has_map_column_container
@@ -206,14 +206,14 @@ class Boundary_matrix : public Master_matrix::Matrix_dimension_option,
    * 
    * @param rowIndex @ref rowindex "Row index" of the empty row.
    */
-  void erase_empty_row(index rowIndex);
+  void erase_empty_row(Index rowIndex);
 
   /**
    * @brief Returns the current number of columns in the matrix.
    * 
    * @return The number of columns.
    */
-  index get_number_of_columns() const;
+  Index get_number_of_columns() const;
 
   /**
    * @brief Returns the dimension of the given column.
@@ -221,7 +221,7 @@ class Boundary_matrix : public Master_matrix::Matrix_dimension_option,
    * @param columnIndex @ref MatIdx index of the column representing the face.
    * @return Dimension of the face.
    */
-  dimension_type get_column_dimension(index columnIndex) const;
+  Dimension get_column_dimension(Index columnIndex) const;
 
   /**
    * @brief Adds column at @p sourceColumnIndex onto the column at @p targetColumnIndex in the matrix.
@@ -233,7 +233,7 @@ class Boundary_matrix : public Master_matrix::Matrix_dimension_option,
    * @param sourceColumnIndex @ref MatIdx index of the source column.
    * @param targetColumnIndex @ref MatIdx index of the target column.
    */
-  void add_to(index sourceColumnIndex, index targetColumnIndex);
+  void add_to(Index sourceColumnIndex, Index targetColumnIndex);
   /**
    * @brief Multiplies the target column with the coefficient and then adds the source column to it.
    * That is: `targetColumn = (targetColumn * coefficient) + sourceColumn`.
@@ -246,9 +246,9 @@ class Boundary_matrix : public Master_matrix::Matrix_dimension_option,
    * @param coefficient Value to multiply.
    * @param targetColumnIndex @ref MatIdx index of the target column.
    */
-  void multiply_target_and_add_to(index sourceColumnIndex, 
-                                  const Field_element_type& coefficient,
-                                  index targetColumnIndex);
+  void multiply_target_and_add_to(Index sourceColumnIndex, 
+                                  const Field_element& coefficient,
+                                  Index targetColumnIndex);
   /**
    * @brief Multiplies the source column with the coefficient before adding it to the target column.
    * That is: `targetColumn += (coefficient * sourceColumn)`. The source column will **not** be modified.
@@ -261,9 +261,9 @@ class Boundary_matrix : public Master_matrix::Matrix_dimension_option,
    * @param sourceColumnIndex @ref MatIdx index of the source column.
    * @param targetColumnIndex @ref MatIdx index of the target column.
    */
-  void multiply_source_and_add_to(const Field_element_type& coefficient, 
-                                  index sourceColumnIndex,
-                                  index targetColumnIndex);
+  void multiply_source_and_add_to(const Field_element& coefficient, 
+                                  Index sourceColumnIndex,
+                                  Index targetColumnIndex);
 
   /**
    * @brief Zeroes the cell at the given coordinates.
@@ -274,7 +274,7 @@ class Boundary_matrix : public Master_matrix::Matrix_dimension_option,
    * @param columnIndex @ref MatIdx index of the column of the cell.
    * @param rowIndex @ref rowindex "Row index" of the row of the cell.
    */
-  void zero_cell(index columnIndex, index rowIndex);
+  void zero_cell(Index columnIndex, Index rowIndex);
   /**
    * @brief Zeroes the column at the given index.
    *
@@ -283,7 +283,7 @@ class Boundary_matrix : public Master_matrix::Matrix_dimension_option,
    * 
    * @param columnIndex @ref MatIdx index of the column to zero.
    */
-  void zero_column(index columnIndex);
+  void zero_column(Index columnIndex);
   /**
    * @brief Indicates if the cell at given coordinates has value zero.
    * 
@@ -292,7 +292,7 @@ class Boundary_matrix : public Master_matrix::Matrix_dimension_option,
    * @return true If the cell has value zero.
    * @return false Otherwise.
    */
-  bool is_zero_cell(index columnIndex, index rowIndex) const;
+  bool is_zero_cell(Index columnIndex, Index rowIndex) const;
   /**
    * @brief Indicates if the column at given index has value zero.
    * 
@@ -300,7 +300,7 @@ class Boundary_matrix : public Master_matrix::Matrix_dimension_option,
    * @return true If the column has value zero.
    * @return false Otherwise.
    */
-  bool is_zero_column(index columnIndex);
+  bool is_zero_column(Index columnIndex);
 
   /**
    * @brief Returns the pivot of the given column.
@@ -308,7 +308,7 @@ class Boundary_matrix : public Master_matrix::Matrix_dimension_option,
    * @param columnIndex @ref MatIdx index of the column.
    * @return Pivot of the column at @p columnIndex.
    */
-  index get_pivot(index columnIndex);
+  Index get_pivot(Index columnIndex);
 
   /**
    * @brief Resets the matrix to an empty matrix.
@@ -349,17 +349,17 @@ class Boundary_matrix : public Master_matrix::Matrix_dimension_option,
   void print();  // for debug
 
  private:
-  using dim_opt = typename Master_matrix::Matrix_dimension_option;
-  using swap_opt = typename Master_matrix::template Base_swap_option<Boundary_matrix<Master_matrix> >;
-  using pair_opt = typename Master_matrix::Base_pairing_option;
-  using ra_opt = typename Master_matrix::Matrix_row_access_option;
-  using matrix_type = typename Master_matrix::column_container_type;
+  using Dim_opt = typename Master_matrix::Matrix_dimension_option;
+  using Swap_opt = typename Master_matrix::template Base_swap_option<Boundary_matrix<Master_matrix> >;
+  using Pair_opt = typename Master_matrix::Base_pairing_option;
+  using RA_opt = typename Master_matrix::Matrix_row_access_option;
+  using Column_container = typename Master_matrix::Column_container;
 
-  friend swap_opt;
-  friend pair_opt;
+  friend Swap_opt;
+  friend Pair_opt;
 
-  matrix_type matrix_;          /**< Column container. */
-  index nextInsertIndex_;       /**< Next unused column index. */
+  Column_container matrix_;          /**< Column container. */
+  Index nextInsertIndex_;       /**< Next unused column index. */
   Column_settings* colSettings_;  /**< Cell factory. */
 
   static constexpr bool activeDimOption =
@@ -371,38 +371,38 @@ class Boundary_matrix : public Master_matrix::Matrix_dimension_option,
                                               !Master_matrix::Option_list::can_retrieve_representative_cycles;
 
   void _orderRowsIfNecessary();
-  const Column_type& _get_column(index columnIndex) const;
-  Column_type& _get_column(index columnIndex);
-  index _get_real_row_index(index rowIndex) const;
-  template <class Container_type>
-  void _container_insert(const Container_type& column, index pos, dimension_type dim);
-  void _container_insert(const Column_type& column, [[maybe_unused]] index pos = 0);
+  const Column& _get_column(Index columnIndex) const;
+  Column& _get_column(Index columnIndex);
+  Index _get_real_row_index(Index rowIndex) const;
+  template <class Container>
+  void _container_insert(const Container& column, Index pos, Dimension dim);
+  void _container_insert(const Column& column, [[maybe_unused]] Index pos = 0);
 };
 
 template <class Master_matrix>
 inline Boundary_matrix<Master_matrix>::Boundary_matrix(Column_settings* colSettings)
-    : dim_opt(-1),
-      swap_opt(),
-      pair_opt(),
-      ra_opt(),
+    : Dim_opt(-1),
+      Swap_opt(),
+      Pair_opt(),
+      RA_opt(),
       nextInsertIndex_(0),
       colSettings_(colSettings)
 {}
 
 template <class Master_matrix>
-template <class Boundary_type>
-inline Boundary_matrix<Master_matrix>::Boundary_matrix(const std::vector<Boundary_type>& orderedBoundaries,
+template <class Boundary_container>
+inline Boundary_matrix<Master_matrix>::Boundary_matrix(const std::vector<Boundary_container>& orderedBoundaries,
                                                        Column_settings* colSettings)
-    : dim_opt(-1),
-      swap_opt(orderedBoundaries.size()),
-      pair_opt(),
-      ra_opt(orderedBoundaries.size()),
+    : Dim_opt(-1),
+      Swap_opt(orderedBoundaries.size()),
+      Pair_opt(),
+      RA_opt(orderedBoundaries.size()),
       nextInsertIndex_(orderedBoundaries.size()),
       colSettings_(colSettings)
 {
   matrix_.reserve(orderedBoundaries.size());
 
-  for (index i = 0; i < orderedBoundaries.size(); i++) {
+  for (Index i = 0; i < orderedBoundaries.size(); i++) {
     _container_insert(orderedBoundaries[i], i, orderedBoundaries[i].size() == 0 ? 0 : orderedBoundaries[i].size() - 1);
   }
 }
@@ -410,10 +410,10 @@ inline Boundary_matrix<Master_matrix>::Boundary_matrix(const std::vector<Boundar
 template <class Master_matrix>
 inline Boundary_matrix<Master_matrix>::Boundary_matrix(unsigned int numberOfColumns, 
                                                        Column_settings* colSettings)
-    : dim_opt(-1),
-      swap_opt(numberOfColumns),
-      pair_opt(),
-      ra_opt(numberOfColumns),
+    : Dim_opt(-1),
+      Swap_opt(numberOfColumns),
+      Pair_opt(),
+      RA_opt(numberOfColumns),
       matrix_(!Master_matrix::Option_list::has_map_column_container && Master_matrix::Option_list::has_row_access
                   ? 0
                   : numberOfColumns),
@@ -427,10 +427,10 @@ inline Boundary_matrix<Master_matrix>::Boundary_matrix(unsigned int numberOfColu
 template <class Master_matrix>
 inline Boundary_matrix<Master_matrix>::Boundary_matrix(const Boundary_matrix& matrixToCopy, 
                                                        Column_settings* colSettings)
-    : dim_opt(static_cast<const dim_opt&>(matrixToCopy)),
-      swap_opt(static_cast<const swap_opt&>(matrixToCopy)),
-      pair_opt(static_cast<const pair_opt&>(matrixToCopy)),
-      ra_opt(static_cast<const ra_opt&>(matrixToCopy)),
+    : Dim_opt(static_cast<const Dim_opt&>(matrixToCopy)),
+      Swap_opt(static_cast<const Swap_opt&>(matrixToCopy)),
+      Pair_opt(static_cast<const Pair_opt&>(matrixToCopy)),
+      RA_opt(static_cast<const RA_opt&>(matrixToCopy)),
       nextInsertIndex_(matrixToCopy.nextInsertIndex_),
       colSettings_(colSettings == nullptr ? matrixToCopy.colSettings_ : colSettings) 
 {
@@ -446,27 +446,27 @@ inline Boundary_matrix<Master_matrix>::Boundary_matrix(const Boundary_matrix& ma
 
 template <class Master_matrix>
 inline Boundary_matrix<Master_matrix>::Boundary_matrix(Boundary_matrix&& other) noexcept
-    : dim_opt(std::move(static_cast<dim_opt&>(other))),
-      swap_opt(std::move(static_cast<swap_opt&>(other))),
-      pair_opt(std::move(static_cast<pair_opt&>(other))),
-      ra_opt(std::move(static_cast<ra_opt&>(other))),
+    : Dim_opt(std::move(static_cast<Dim_opt&>(other))),
+      Swap_opt(std::move(static_cast<Swap_opt&>(other))),
+      Pair_opt(std::move(static_cast<Pair_opt&>(other))),
+      RA_opt(std::move(static_cast<RA_opt&>(other))),
       matrix_(std::move(other.matrix_)),
       nextInsertIndex_(std::exchange(other.nextInsertIndex_, 0)),
       colSettings_(std::exchange(other.colSettings_, nullptr)) 
 {}
 
 template <class Master_matrix>
-template <class Boundary_type>
-inline typename Boundary_matrix<Master_matrix>::index Boundary_matrix<Master_matrix>::insert_boundary(
-    const Boundary_type& boundary, dimension_type dim) 
+template <class Boundary_container>
+inline typename Boundary_matrix<Master_matrix>::Index Boundary_matrix<Master_matrix>::insert_boundary(
+    const Boundary_container& boundary, Dimension dim) 
 {
   return insert_boundary(nextInsertIndex_, boundary, dim);
 }
 
 template <class Master_matrix>
-template <class Boundary_type>
-inline typename Boundary_matrix<Master_matrix>::index Boundary_matrix<Master_matrix>::insert_boundary(
-    id_index faceIndex, const Boundary_type& boundary, dimension_type dim) 
+template <class Boundary_container>
+inline typename Boundary_matrix<Master_matrix>::Index Boundary_matrix<Master_matrix>::insert_boundary(
+    ID_index faceIndex, const Boundary_container& boundary, Dimension dim) 
 {
   if (dim == -1) dim = boundary.size() == 0 ? 0 : boundary.size() - 1;
 
@@ -475,28 +475,28 @@ inline typename Boundary_matrix<Master_matrix>::index Boundary_matrix<Master_mat
   //updates container sizes
   if constexpr (Master_matrix::Option_list::has_row_access && !Master_matrix::Option_list::has_removable_rows) {
     if (boundary.size() != 0){
-      id_index pivot;
+      ID_index pivot;
       if constexpr (Master_matrix::Option_list::is_z2) {
         pivot = *std::prev(boundary.end());
       } else {
         pivot = std::prev(boundary.end())->first;
       }
       //row container
-      if (ra_opt::rows_->size() <= pivot) ra_opt::rows_->resize(pivot + 1);
+      if (RA_opt::rows_->size() <= pivot) RA_opt::rows_->resize(pivot + 1);
     }
   }
 
   //row swap map containers
   if constexpr (Master_matrix::Option_list::has_map_column_container) {
     if constexpr (activeSwapOption) {
-      swap_opt::indexToRow_.emplace(faceIndex, faceIndex);
-      swap_opt::rowToIndex_.emplace(faceIndex, faceIndex);
+      Swap_opt::indexToRow_.emplace(faceIndex, faceIndex);
+      Swap_opt::rowToIndex_.emplace(faceIndex, faceIndex);
     }
   } else {
     if constexpr (activeSwapOption) {
-      for (index i = swap_opt::indexToRow_.size(); i <= faceIndex; ++i) {
-        swap_opt::indexToRow_.push_back(i);
-        swap_opt::rowToIndex_.push_back(i);
+      for (Index i = Swap_opt::indexToRow_.size(); i <= faceIndex; ++i) {
+        Swap_opt::indexToRow_.push_back(i);
+        Swap_opt::rowToIndex_.push_back(i);
       }
     }
   }
@@ -504,9 +504,9 @@ inline typename Boundary_matrix<Master_matrix>::index Boundary_matrix<Master_mat
   //maps for possible shifting between column content and position indices used for birth events
   if constexpr (activePairingOption){
     if (faceIndex != nextInsertIndex_){
-      pair_opt::idToPosition_.emplace(faceIndex, nextInsertIndex_);
+      Pair_opt::idToPosition_.emplace(faceIndex, nextInsertIndex_);
       if constexpr (Master_matrix::Option_list::has_removable_columns){
-        pair_opt::PIDM::map_.emplace(nextInsertIndex_, faceIndex);
+        Pair_opt::PIDM::map_.emplace(nextInsertIndex_, faceIndex);
       }
     }
   }
@@ -517,8 +517,7 @@ inline typename Boundary_matrix<Master_matrix>::index Boundary_matrix<Master_mat
 }
 
 template <class Master_matrix>
-inline typename Boundary_matrix<Master_matrix>::Column_type& Boundary_matrix<Master_matrix>::get_column(
-    index columnIndex) 
+inline typename Boundary_matrix<Master_matrix>::Column& Boundary_matrix<Master_matrix>::get_column(Index columnIndex) 
 {
   _orderRowsIfNecessary();
 
@@ -526,17 +525,17 @@ inline typename Boundary_matrix<Master_matrix>::Column_type& Boundary_matrix<Mas
 }
 
 template <class Master_matrix>
-inline typename Boundary_matrix<Master_matrix>::Row_type& Boundary_matrix<Master_matrix>::get_row(index rowIndex) 
+inline typename Boundary_matrix<Master_matrix>::Row& Boundary_matrix<Master_matrix>::get_row(Index rowIndex) 
 {
   static_assert(Master_matrix::Option_list::has_row_access, "'get_row' is not implemented for the chosen options.");
 
   _orderRowsIfNecessary();
 
-  return ra_opt::get_row(rowIndex);
+  return RA_opt::get_row(rowIndex);
 }
 
 template <class Master_matrix>
-inline typename Boundary_matrix<Master_matrix>::index Boundary_matrix<Master_matrix>::remove_last() 
+inline typename Boundary_matrix<Master_matrix>::Index Boundary_matrix<Master_matrix>::remove_last() 
 {
   static_assert(Master_matrix::Option_list::has_removable_columns,
                 "'remove_last' is not implemented for the chosen options.");
@@ -546,18 +545,18 @@ inline typename Boundary_matrix<Master_matrix>::index Boundary_matrix<Master_mat
 
   //updates dimension max
   if constexpr (activeDimOption) {
-    dim_opt::update_down(matrix_.at(nextInsertIndex_).get_dimension());
+    Dim_opt::update_down(matrix_.at(nextInsertIndex_).get_dimension());
   }
 
   //computes pivot and removes column from matrix_
-  id_index pivot;
+  ID_index pivot;
   if constexpr (Master_matrix::Option_list::has_map_column_container) {
     auto it = matrix_.find(nextInsertIndex_);
     pivot = it->second.get_pivot();
     if constexpr (activeSwapOption) {
       // if the removed column is positive, the pivot won't change value
-      if (swap_opt::rowSwapped_ && pivot != static_cast<id_index>(-1)) {
-        swap_opt::_orderRows();
+      if (Swap_opt::rowSwapped_ && pivot != static_cast<ID_index>(-1)) {
+        Swap_opt::_orderRows();
         pivot = it->second.get_pivot();
       }
     }
@@ -566,8 +565,8 @@ inline typename Boundary_matrix<Master_matrix>::index Boundary_matrix<Master_mat
     pivot = matrix_[nextInsertIndex_].get_pivot();
     if constexpr (activeSwapOption) {
       // if the removed column is positive, the pivot won't change value
-      if (swap_opt::rowSwapped_ && pivot != static_cast<id_index>(-1)) {
-        swap_opt::_orderRows();
+      if (Swap_opt::rowSwapped_ && pivot != static_cast<ID_index>(-1)) {
+        Swap_opt::_orderRows();
         pivot = matrix_[nextInsertIndex_].get_pivot();
       }
     }
@@ -584,35 +583,35 @@ inline typename Boundary_matrix<Master_matrix>::index Boundary_matrix<Master_mat
 
   //updates barcode
   if constexpr (activePairingOption) {
-    pair_opt::_remove_last(nextInsertIndex_);
+    Pair_opt::_remove_last(nextInsertIndex_);
   }
 
   return pivot;
 }
 
 template <class Master_matrix>
-inline void Boundary_matrix<Master_matrix>::erase_empty_row(index rowIndex) 
+inline void Boundary_matrix<Master_matrix>::erase_empty_row(Index rowIndex) 
 {
   //computes real row index and erases it if necessary from the row swap map containers
-  id_index rowID = rowIndex;
+  ID_index rowID = rowIndex;
   if constexpr (activeSwapOption) {
     if constexpr (Master_matrix::Option_list::has_map_column_container) {
-      auto it = swap_opt::indexToRow_.find(rowIndex);
+      auto it = Swap_opt::indexToRow_.find(rowIndex);
       rowID = it->second;
-      swap_opt::rowToIndex_.erase(rowID);
-      swap_opt::indexToRow_.erase(it);
+      Swap_opt::rowToIndex_.erase(rowID);
+      Swap_opt::indexToRow_.erase(it);
     } else {
-      rowID = swap_opt::indexToRow_[rowIndex];
+      rowID = Swap_opt::indexToRow_[rowIndex];
     }
   }
 
   if constexpr (Master_matrix::Option_list::has_row_access && Master_matrix::Option_list::has_removable_rows) {
-    ra_opt::erase_empty_row(rowID);
+    RA_opt::erase_empty_row(rowID);
   }
 }
 
 template <class Master_matrix>
-inline typename Boundary_matrix<Master_matrix>::index Boundary_matrix<Master_matrix>::get_number_of_columns() const 
+inline typename Boundary_matrix<Master_matrix>::Index Boundary_matrix<Master_matrix>::get_number_of_columns() const 
 {
   if constexpr (Master_matrix::Option_list::has_map_column_container) {
     return matrix_.size();
@@ -622,60 +621,60 @@ inline typename Boundary_matrix<Master_matrix>::index Boundary_matrix<Master_mat
 }
 
 template <class Master_matrix>
-inline typename Boundary_matrix<Master_matrix>::dimension_type Boundary_matrix<Master_matrix>::get_column_dimension(
-    index columnIndex) const 
+inline typename Boundary_matrix<Master_matrix>::Dimension Boundary_matrix<Master_matrix>::get_column_dimension(
+    Index columnIndex) const 
 {
   return _get_column(columnIndex).get_dimension();
 }
 
 template <class Master_matrix>
-inline void Boundary_matrix<Master_matrix>::add_to(index sourceColumnIndex, index targetColumnIndex) 
+inline void Boundary_matrix<Master_matrix>::add_to(Index sourceColumnIndex, Index targetColumnIndex) 
 {
   _get_column(targetColumnIndex) += _get_column(sourceColumnIndex);
 }
 
 template <class Master_matrix>
-inline void Boundary_matrix<Master_matrix>::multiply_target_and_add_to(index sourceColumnIndex,
-                                                                       const Field_element_type& coefficient,
-                                                                       index targetColumnIndex) 
+inline void Boundary_matrix<Master_matrix>::multiply_target_and_add_to(Index sourceColumnIndex,
+                                                                       const Field_element& coefficient,
+                                                                       Index targetColumnIndex) 
 {
   _get_column(targetColumnIndex).multiply_target_and_add(coefficient, _get_column(sourceColumnIndex));
 }
 
 template <class Master_matrix>
-inline void Boundary_matrix<Master_matrix>::multiply_source_and_add_to(const Field_element_type& coefficient,
-                                                                       index sourceColumnIndex,
-                                                                       index targetColumnIndex) 
+inline void Boundary_matrix<Master_matrix>::multiply_source_and_add_to(const Field_element& coefficient,
+                                                                       Index sourceColumnIndex,
+                                                                       Index targetColumnIndex) 
 {
   _get_column(targetColumnIndex).multiply_source_and_add(_get_column(sourceColumnIndex), coefficient);
 }
 
 template <class Master_matrix>
-inline void Boundary_matrix<Master_matrix>::zero_cell(index columnIndex, index rowIndex) 
+inline void Boundary_matrix<Master_matrix>::zero_cell(Index columnIndex, Index rowIndex) 
 {
   _get_column(columnIndex).clear(_get_real_row_index(rowIndex));
 }
 
 template <class Master_matrix>
-inline void Boundary_matrix<Master_matrix>::zero_column(index columnIndex) 
+inline void Boundary_matrix<Master_matrix>::zero_column(Index columnIndex) 
 {
   _get_column(columnIndex).clear();
 }
 
 template <class Master_matrix>
-inline bool Boundary_matrix<Master_matrix>::is_zero_cell(index columnIndex, index rowIndex) const 
+inline bool Boundary_matrix<Master_matrix>::is_zero_cell(Index columnIndex, Index rowIndex) const 
 {
   return !(_get_column(columnIndex).is_non_zero(_get_real_row_index(rowIndex)));
 }
 
 template <class Master_matrix>
-inline bool Boundary_matrix<Master_matrix>::is_zero_column(index columnIndex) 
+inline bool Boundary_matrix<Master_matrix>::is_zero_column(Index columnIndex) 
 {
   return _get_column(columnIndex).is_empty();
 }
 
 template <class Master_matrix>
-inline typename Boundary_matrix<Master_matrix>::index Boundary_matrix<Master_matrix>::get_pivot(index columnIndex) 
+inline typename Boundary_matrix<Master_matrix>::Index Boundary_matrix<Master_matrix>::get_pivot(Index columnIndex) 
 {
   _orderRowsIfNecessary();
 
@@ -685,10 +684,10 @@ inline typename Boundary_matrix<Master_matrix>::index Boundary_matrix<Master_mat
 template <class Master_matrix>
 inline Boundary_matrix<Master_matrix>& Boundary_matrix<Master_matrix>::operator=(const Boundary_matrix& other) 
 {
-  dim_opt::operator=(other);
-  swap_opt::operator=(other);
-  pair_opt::operator=(other);
-  ra_opt::operator=(other);
+  Dim_opt::operator=(other);
+  Swap_opt::operator=(other);
+  Pair_opt::operator=(other);
+  RA_opt::operator=(other);
 
   matrix_.clear();
   nextInsertIndex_ = other.nextInsertIndex_;
@@ -710,11 +709,11 @@ template <class Master_matrix>
 inline void Boundary_matrix<Master_matrix>::print() 
 {
   if constexpr (activeSwapOption) {
-    if (swap_opt::rowSwapped_) swap_opt::_orderRows();
+    if (Swap_opt::rowSwapped_) Swap_opt::_orderRows();
   }
   std::cout << "Boundary_matrix:\n";
-  for (index i = 0; i < nextInsertIndex_; ++i) {
-    Column_type& col = matrix_[i];
+  for (Index i = 0; i < nextInsertIndex_; ++i) {
+    Column& col = matrix_[i];
     for (auto e : col.get_content(nextInsertIndex_)) {
       if (e == 0u)
         std::cout << "- ";
@@ -726,8 +725,8 @@ inline void Boundary_matrix<Master_matrix>::print()
   std::cout << "\n";
   if constexpr (Master_matrix::Option_list::has_row_access) {
     std::cout << "Row Matrix:\n";
-    for (id_index i = 0; i < nextInsertIndex_; ++i) {
-      const auto& row = ra_opt::rows_[i];
+    for (ID_index i = 0; i < nextInsertIndex_; ++i) {
+      const auto& row = RA_opt::rows_[i];
       for (const auto& cell : row) {
         std::cout << cell.get_column_index() << " ";
       }
@@ -741,13 +740,13 @@ template <class Master_matrix>
 inline void Boundary_matrix<Master_matrix>::_orderRowsIfNecessary() 
 {
   if constexpr (activeSwapOption) {
-    if (swap_opt::rowSwapped_) swap_opt::_orderRows();
+    if (Swap_opt::rowSwapped_) Swap_opt::_orderRows();
   }
 }
 
 template <class Master_matrix>
-inline const typename Boundary_matrix<Master_matrix>::Column_type& Boundary_matrix<Master_matrix>::_get_column(
-    index columnIndex) const
+inline const typename Boundary_matrix<Master_matrix>::Column& Boundary_matrix<Master_matrix>::_get_column(
+    Index columnIndex) const
 {
   if constexpr (Master_matrix::Option_list::has_map_column_container) {
     return matrix_.at(columnIndex);
@@ -757,8 +756,8 @@ inline const typename Boundary_matrix<Master_matrix>::Column_type& Boundary_matr
 }
 
 template <class Master_matrix>
-inline typename Boundary_matrix<Master_matrix>::Column_type& Boundary_matrix<Master_matrix>::_get_column(
-    index columnIndex)
+inline typename Boundary_matrix<Master_matrix>::Column& Boundary_matrix<Master_matrix>::_get_column(
+    Index columnIndex)
 {
   if constexpr (Master_matrix::Option_list::has_map_column_container) {
     return matrix_.at(columnIndex);
@@ -768,14 +767,14 @@ inline typename Boundary_matrix<Master_matrix>::Column_type& Boundary_matrix<Mas
 }
 
 template <class Master_matrix>
-inline typename Boundary_matrix<Master_matrix>::index Boundary_matrix<Master_matrix>::_get_real_row_index(
-    index rowIndex) const
+inline typename Boundary_matrix<Master_matrix>::Index Boundary_matrix<Master_matrix>::_get_real_row_index(
+    Index rowIndex) const
 {
   if constexpr (Master_matrix::Option_list::has_column_and_row_swaps || Master_matrix::Option_list::has_vine_update) {
     if constexpr (Master_matrix::Option_list::has_map_column_container) {
-      return swap_opt::indexToRow_.at(rowIndex);
+      return Swap_opt::indexToRow_.at(rowIndex);
     } else {
-      return swap_opt::indexToRow_[rowIndex];
+      return Swap_opt::indexToRow_[rowIndex];
     }
   } else {
     return rowIndex;
@@ -783,45 +782,45 @@ inline typename Boundary_matrix<Master_matrix>::index Boundary_matrix<Master_mat
 }
 
 template <class Master_matrix>
-template <class Container_type>
-inline void Boundary_matrix<Master_matrix>::_container_insert(const Container_type& column,
-                                                              index pos,
-                                                              dimension_type dim)
+template <class Container>
+inline void Boundary_matrix<Master_matrix>::_container_insert(const Container& column,
+                                                              Index pos,
+                                                              Dimension dim)
 {
   if constexpr (Master_matrix::Option_list::has_map_column_container) {
     if constexpr (Master_matrix::Option_list::has_row_access) {
-      matrix_.try_emplace(pos, Column_type(pos, column, dim, ra_opt::rows_, colSettings_));
+      matrix_.try_emplace(pos, Column(pos, column, dim, RA_opt::rows_, colSettings_));
     } else {
-      matrix_.try_emplace(pos, Column_type(column, dim, colSettings_));
+      matrix_.try_emplace(pos, Column(column, dim, colSettings_));
     }
   } else {
     if constexpr (Master_matrix::Option_list::has_row_access) {
-      matrix_.emplace_back(pos, column, dim, ra_opt::rows_, colSettings_);
+      matrix_.emplace_back(pos, column, dim, RA_opt::rows_, colSettings_);
     } else {
       if (matrix_.size() <= pos) {
         matrix_.emplace_back(column, dim, colSettings_);
       } else {
-        matrix_[pos] = Column_type(column, dim, colSettings_);
+        matrix_[pos] = Column(column, dim, colSettings_);
       }
     }
   }
   if constexpr (activeDimOption) {
-    dim_opt::update_up(dim);
+    Dim_opt::update_up(dim);
   }
 }
 
 template <class Master_matrix>
-inline void Boundary_matrix<Master_matrix>::_container_insert(const Column_type& column, [[maybe_unused]] index pos)
+inline void Boundary_matrix<Master_matrix>::_container_insert(const Column& column, [[maybe_unused]] Index pos)
 {
   if constexpr (Master_matrix::Option_list::has_map_column_container) {
     if constexpr (Master_matrix::Option_list::has_row_access) {
-      matrix_.try_emplace(pos, Column_type(column, column.get_column_index(), ra_opt::rows_, colSettings_));
+      matrix_.try_emplace(pos, Column(column, column.get_column_index(), RA_opt::rows_, colSettings_));
     } else {
-      matrix_.try_emplace(pos, Column_type(column, colSettings_));
+      matrix_.try_emplace(pos, Column(column, colSettings_));
     }
   } else {
     if constexpr (Master_matrix::Option_list::has_row_access) {
-      matrix_.emplace_back(column, column.get_column_index(), ra_opt::rows_, colSettings_);
+      matrix_.emplace_back(column, column.get_column_index(), RA_opt::rows_, colSettings_);
     } else {
       matrix_.emplace_back(column, colSettings_);
     }

--- a/src/Persistence_matrix/include/gudhi/Persistence_matrix/chain_matrix.h
+++ b/src/Persistence_matrix/include/gudhi/Persistence_matrix/chain_matrix.h
@@ -53,20 +53,20 @@ class Chain_matrix : public Master_matrix::Matrix_dimension_option,
    * @brief Field operators class. Necessary only if @ref PersistenceMatrixOptions::is_z2 is false.
    */
   using Field_operators = typename Master_matrix::Field_operators;
-  using Field_element_type = typename Master_matrix::element_type;    /**< Type of an field element. */
-  using Column_type = typename Master_matrix::Column_type;            /**< Column type. */
-  using Row_type = typename Master_matrix::Row_type;                  /**< Row type,
-                                                                           only necessary with row access option. */
-  using Cell = typename Master_matrix::Cell_type;                     /**< @ref Cell "Matrix cell" type. */
-  using Cell_constructor = typename Master_matrix::Cell_constructor;  /**< Factory of @ref Cell classes. */
-  using Column_settings = typename Master_matrix::Column_settings;    /**< Structure giving access to the columns to
-                                                                           necessary external classes. */
-  using boundary_type = typename Master_matrix::boundary_type;        /**< Type of an input column. */
-  using cell_rep_type = typename Master_matrix::cell_rep_type;        /**< %Cell content representative. */
-  using index = typename Master_matrix::index;                        /**< @ref MatIdx index type. */
-  using id_index = typename Master_matrix::id_index;                  /**< @ref IDIdx index type. */
-  using pos_index = typename Master_matrix::pos_index;                /**< @ref PosIdx index type. */
-  using dimension_type = typename Master_matrix::dimension_type;      /**< Dimension value type. */
+  using Field_element = typename Master_matrix::Element;                    /**< Type of an field element. */
+  using Column = typename Master_matrix::Column;                            /**< Column type. */
+  using Row = typename Master_matrix::Row;                                  /**< Row type, only necessary with row
+                                                                                 access option. */
+  using Cell = typename Master_matrix::Matrix_cell;                         /**< @ref Cell "Matrix cell" type. */
+  using Cell_constructor = typename Master_matrix::Cell_constructor;        /**< Factory of @ref Cell classes. */
+  using Column_settings = typename Master_matrix::Column_settings;          /**< Structure giving access to the columns
+                                                                                 to necessary external classes. */
+  using Boundary = typename Master_matrix::Boundary;                        /**< Type of an input column. */
+  using Cell_representative = typename Master_matrix::Cell_representative;  /**< %Cell content representative. */
+  using Index = typename Master_matrix::Index;                              /**< @ref MatIdx index type. */
+  using ID_index = typename Master_matrix::ID_index;                        /**< @ref IDIdx index type. */
+  using Pos_index = typename Master_matrix::Pos_index;                      /**< @ref PosIdx index type. */
+  using Dimension = typename Master_matrix::Dimension;                      /**< Dimension value type. */
 
   /**
    * @brief Constructs an empty matrix. Only available if @ref PersistenceMatrixOptions::has_column_pairings is
@@ -78,14 +78,14 @@ class Chain_matrix : public Master_matrix::Matrix_dimension_option,
    */
   Chain_matrix(Column_settings* colSettings);
   /**
-   * @brief Constructs a new matrix from the given ranges of @ref Matrix::cell_rep_type. Each range corresponds to a
+   * @brief Constructs a new matrix from the given ranges of @ref Matrix::Cell_representative. Each range corresponds to a
    * column  (the order of the ranges are preserved). The content of the ranges is assumed to be sorted by increasing
    * IDs. The IDs of the simplices are also assumed to be consecutive, ordered by filtration value, starting with 0. 
    * Only available if @ref PersistenceMatrixOptions::has_column_pairings is true or
    * @ref PersistenceMatrixOptions::has_vine_update is false. Otherwise, birth and death
    * comparators have to be provided.
    * 
-   * @tparam Boundary_type Range type for @ref Matrix::cell_rep_type ranges.
+   * @tparam Boundary_container Range type for @ref Matrix::Cell_representative ranges.
    * Assumed to have a begin(), end() and size() method.
    * @param orderedBoundaries Range of boundaries: @p orderedBoundaries is interpreted as a boundary matrix of a 
    * filtered **simplicial** complex, whose boundaries are ordered by filtration order. 
@@ -101,8 +101,8 @@ class Chain_matrix : public Master_matrix::Matrix_dimension_option,
    * @param colSettings Pointer to an existing setting structure for the columns. The structure should contain all
    * the necessary external classes specifically necessary for the choosen column type, such as custom allocators.
    */
-  template <class Boundary_type = boundary_type>
-  Chain_matrix(const std::vector<Boundary_type>& orderedBoundaries, 
+  template <class Boundary_container = Boundary>
+  Chain_matrix(const std::vector<Boundary_container>& orderedBoundaries, 
                Column_settings* colSettings);
   /**
    * @brief Constructs a new empty matrix and reserves space for the given number of columns. Only available
@@ -122,8 +122,8 @@ class Chain_matrix : public Master_matrix::Matrix_dimension_option,
    * @ref PersistenceMatrixOptions::has_column_pairings is also true, the comparators are ignored and
    * the current barcode is used to compare birth and deaths. Therefore it is useless to provide them in those cases.
    * 
-   * @tparam BirthComparatorFunction Type of the birth comparator: (@ref pos_index, @ref pos_index) -> bool
-   * @tparam DeathComparatorFunction Type of the death comparator: (@ref pos_index, @ref pos_index) -> bool
+   * @tparam BirthComparatorFunction Type of the birth comparator: (@ref Pos_index, @ref Pos_index) -> bool
+   * @tparam DeathComparatorFunction Type of the death comparator: (@ref Pos_index, @ref Pos_index) -> bool
    * @param colSettings Pointer to an existing setting structure for the columns. The structure should contain all
    * the necessary external classes specifically necessary for the choosen column type, such as custom allocators.
    * @param birthComparator Method taking two @ref PosIdx indices as input and returning true if and only if
@@ -140,7 +140,7 @@ class Chain_matrix : public Master_matrix::Matrix_dimension_option,
                const BirthComparatorFunction& birthComparator,
                const DeathComparatorFunction& deathComparator);
   /**
-   * @brief Constructs a new matrix from the given ranges of @ref Matrix::cell_rep_type. Each range corresponds to a
+   * @brief Constructs a new matrix from the given ranges of @ref Matrix::Cell_representative. Each range corresponds to a
    * column (the order of the ranges are preserved). The content of the ranges is assumed to be sorted by increasing
    * IDs. The IDs of the simplices are also assumed to be consecutive, ordered by filtration value, starting with 0.
    *
@@ -149,9 +149,9 @@ class Chain_matrix : public Master_matrix::Matrix_dimension_option,
    * @ref PersistenceMatrixOptions::has_column_pairings is also true, the comparators are ignored and
    * the current barcode is used to compare birth and deaths. Therefore it is useless to provide them in those cases.
    * 
-   * @tparam BirthComparatorFunction Type of the birth comparator: (@ref pos_index, @ref pos_index) -> bool
-   * @tparam DeathComparatorFunction Type of the death comparator: (@ref pos_index, @ref pos_index) -> bool
-   * @tparam Boundary_type  Range type for @ref Matrix::cell_rep_type ranges.
+   * @tparam BirthComparatorFunction Type of the birth comparator: (@ref Pos_index, @ref Pos_index) -> bool
+   * @tparam DeathComparatorFunction Type of the death comparator: (@ref Pos_index, @ref Pos_index) -> bool
+   * @tparam Boundary_container  Range type for @ref Matrix::Cell_representative ranges.
    * Assumed to have a begin(), end() and size() method.
    * @param orderedBoundaries Range of boundaries: @p orderedBoundaries is interpreted as a boundary matrix of a 
    * filtered **simplicial** complex, whose boundaries are ordered by filtration order. 
@@ -174,8 +174,8 @@ class Chain_matrix : public Master_matrix::Matrix_dimension_option,
    * the second one with respect to some self defined order. It is used while swapping two positive but paired
    * columns.
    */
-  template <typename BirthComparatorFunction, typename DeathComparatorFunction, class Boundary_type = boundary_type>
-  Chain_matrix(const std::vector<Boundary_type>& orderedBoundaries, 
+  template <typename BirthComparatorFunction, typename DeathComparatorFunction, class Boundary_container = Boundary>
+  Chain_matrix(const std::vector<Boundary_container>& orderedBoundaries, 
                Column_settings* colSettings, 
                const BirthComparatorFunction& birthComparator,
                const DeathComparatorFunction& deathComparator);
@@ -187,8 +187,8 @@ class Chain_matrix : public Master_matrix::Matrix_dimension_option,
    * @ref PersistenceMatrixOptions::has_column_pairings is also true, the comparators are ignored and
    * the current barcode is used to compare birth and deaths. Therefore it is useless to provide them in those cases.
    * 
-   * @tparam BirthComparatorFunction Type of the birth comparator: (@ref pos_index, @ref pos_index) -> bool
-   * @tparam DeathComparatorFunction Type of the death comparator: (@ref pos_index, @ref pos_index) -> bool
+   * @tparam BirthComparatorFunction Type of the birth comparator: (@ref Pos_index, @ref Pos_index) -> bool
+   * @tparam DeathComparatorFunction Type of the death comparator: (@ref Pos_index, @ref Pos_index) -> bool
    * @param numberOfColumns Number of columns to reserve space for.
    * @param colSettings Pointer to an existing setting structure for the columns. The structure should contain all
    * the necessary external classes specifically necessary for the choosen column type, such as custom allocators.
@@ -229,7 +229,7 @@ class Chain_matrix : public Master_matrix::Matrix_dimension_option,
    * This means that it is assumed that this method is called on boundaries in the order of the filtration.
    * It also assumes that the faces in the given boundary are identified by their relative position in the filtration,
    * starting at 0. If it is not the case, use the other
-   * @ref insert_boundary(id_index faceIndex, const Boundary_type& boundary, dimension_type dim) "insert_boundary"
+   * @ref insert_boundary(ID_index faceIndex, const Boundary_container& boundary, Dimension dim) "insert_boundary"
    * instead by indicating the face ID used in the boundaries when the face is inserted.
    *
    * Different to the constructor, the boundaries do not have to come from a simplicial complex, but also from
@@ -238,14 +238,14 @@ class Chain_matrix : public Master_matrix::Matrix_dimension_option,
    * When inserted, the given boundary is reduced and from the reduction process, the column is deduced in the form of:
    * `IDIdx + linear combination of older column IDIdxs`. If the barcode is stored, it will be updated.
    * 
-   * @tparam Boundary_type Range of @ref Matrix::cell_rep_type. Assumed to have a begin(), end() and size() method.
+   * @tparam Boundary_container Range of @ref Matrix::Cell_representative. Assumed to have a begin(), end() and size() method.
    * @param boundary Boundary generating the new column. The content should be ordered by ID.
    * @param dim Dimension of the face whose boundary is given. If the complex is simplicial, 
    * this parameter can be omitted as it can be deduced from the size of the boundary.
    * @return The @ref MatIdx indices of the unpaired chains used to reduce the boundary.
    */
-  template <class Boundary_type = boundary_type>
-  std::vector<cell_rep_type> insert_boundary(const Boundary_type& boundary, dimension_type dim = -1);
+  template <class Boundary_container = Boundary>
+  std::vector<Cell_representative> insert_boundary(const Boundary_container& boundary, Dimension dim = -1);
   /**
    * @brief It does the same as the other version, but allows the boundary faces to be identified without restrictions
    * except that all IDs have to be strictly increasing in the order of filtration. Note that you should avoid then
@@ -254,7 +254,7 @@ class Chain_matrix : public Master_matrix::Matrix_dimension_option,
    * As a face has to be inserted before one of its cofaces in a valid filtration (recall that it is assumed that
    * the faces are inserted by order of filtration), it is sufficient to indicate the ID of the face being inserted.
    * 
-   * @tparam Boundary_type Range of @ref Matrix::cell_rep_type. Assumed to have a begin(), end() and size() method.
+   * @tparam Boundary_container Range of @ref Matrix::Cell_representative. Assumed to have a begin(), end() and size() method.
    * @param faceID @ref IDIdx index to use to identify the new face.
    * @param boundary Boundary generating the new column. The indices of the boundary have to correspond to the 
    * @p faceID values of precedent calls of the method for the corresponding faces and should be ordered in 
@@ -263,8 +263,8 @@ class Chain_matrix : public Master_matrix::Matrix_dimension_option,
    * this parameter can be omitted as it can be deduced from the size of the boundary.
    * @return The @ref MatIdx index of the inserted boundary.
    */
-  template <class Boundary_type = boundary_type>
-  std::vector<cell_rep_type> insert_boundary(id_index faceID, const Boundary_type& boundary, dimension_type dim = -1);
+  template <class Boundary_container = Boundary>
+  std::vector<Cell_representative> insert_boundary(ID_index faceID, const Boundary_container& boundary, Dimension dim = -1);
   /**
    * @brief Returns the column at the given @ref MatIdx index.
    * The type of the column depends on the choosen options, see @ref PersistenceMatrixOptions::column_type.
@@ -272,7 +272,7 @@ class Chain_matrix : public Master_matrix::Matrix_dimension_option,
    * @param columnIndex @ref MatIdx index of the column to return.
    * @return Reference to the column.
    */
-  Column_type& get_column(index columnIndex);
+  Column& get_column(Index columnIndex);
   /**
    * @brief Returns the column at the given @ref MatIdx index.
    * The type of the column depends on the choosen options, see @ref PersistenceMatrixOptions::column_type.
@@ -280,7 +280,7 @@ class Chain_matrix : public Master_matrix::Matrix_dimension_option,
    * @param columnIndex @ref MatIdx index of the column to return.
    * @return Const reference to the column.
    */
-  const Column_type& get_column(index columnIndex) const;
+  const Column& get_column(Index columnIndex) const;
   /**
    * @brief Only available if @ref PersistenceMatrixOptions::has_removable_columns and
    * @ref PersistenceMatrixOptions::has_vine_update are true, as well as,
@@ -297,7 +297,7 @@ class Chain_matrix : public Master_matrix::Matrix_dimension_option,
    * 
    * @param faceID @ref IDIdx index of the face to remove
    */
-  void remove_maximal_face(id_index faceID);
+  void remove_maximal_face(ID_index faceID);
   /**
    * @brief Only available if @ref PersistenceMatrixOptions::has_removable_columns,
    * @ref PersistenceMatrixOptions::has_vine_update and @ref PersistenceMatrixOptions::has_map_column_container
@@ -313,7 +313,7 @@ class Chain_matrix : public Master_matrix::Matrix_dimension_option,
    * the matrix. If the user has an easy access to the @ref IDIdx of the faces in the order of filtration, passing them
    * by argument with @p columnsToSwap allows to skip a linear search process. Typically, if the user knows that the
    * face he wants to remove is already the last face of the filtration, calling
-   * @ref remove_maximal_face(id_index faceIndex, const std::vector<id_index>& columnsToSwap)
+   * @ref remove_maximal_face(ID_index faceIndex, const std::vector<ID_index>& columnsToSwap)
    * "remove_maximal_face(faceID, {})" will be faster than @ref remove_last().
    *
    * See also @ref remove_last.
@@ -321,7 +321,7 @@ class Chain_matrix : public Master_matrix::Matrix_dimension_option,
    * @param faceID @ref IDIdx index of the face to remove
    * @param columnsToSwap Vector of @ref IDIdx indices of the faces coming after @p faceID in the filtration.
    */
-  void remove_maximal_face(id_index faceID, const std::vector<id_index>& columnsToSwap);
+  void remove_maximal_face(ID_index faceID, const std::vector<ID_index>& columnsToSwap);
   /**
    * @brief Only available if @ref PersistenceMatrixOptions::has_removable_columns is true and,
    * if @ref PersistenceMatrixOptions::has_map_column_container is true or
@@ -333,7 +333,7 @@ class Chain_matrix : public Master_matrix::Matrix_dimension_option,
    * @warning If @ref PersistenceMatrixOptions::has_vine_update is true, the last face does not have to
    * be at the end of the matrix container and therefore has to be searched first. In this case, if the user
    * already knows the @ref IDIdx of the last face, calling
-   * @ref remove_maximal_face(id_index faceIndex, const std::vector<id_index>& columnsToSwap)
+   * @ref remove_maximal_face(ID_index faceIndex, const std::vector<ID_index>& columnsToSwap)
    * "remove_maximal_face(faceID, {})" instead allows to skip the search.
    */
   void remove_last();
@@ -343,7 +343,7 @@ class Chain_matrix : public Master_matrix::Matrix_dimension_option,
    * 
    * @return The number of columns.
    */
-  index get_number_of_columns() const;
+  Index get_number_of_columns() const;
 
   /**
    * @brief Returns the dimension of the given column.
@@ -351,7 +351,7 @@ class Chain_matrix : public Master_matrix::Matrix_dimension_option,
    * @param columnIndex @ref MatIdx index of the column representing the face.
    * @return Dimension of the face.
    */
-  dimension_type get_column_dimension(index columnIndex) const;
+  Dimension get_column_dimension(Index columnIndex) const;
 
   /**
    * @brief Adds column at @p sourceColumnIndex onto the column at @p targetColumnIndex in the matrix.
@@ -363,7 +363,7 @@ class Chain_matrix : public Master_matrix::Matrix_dimension_option,
    * @param sourceColumnIndex @ref MatIdx index of the source column.
    * @param targetColumnIndex @ref MatIdx index of the target column.
    */
-  void add_to(index sourceColumnIndex, index targetColumnIndex);
+  void add_to(Index sourceColumnIndex, Index targetColumnIndex);
   /**
    * @brief Multiplies the target column with the coefficient and then adds the source column to it.
    * That is: `targetColumn = (targetColumn * coefficient) + sourceColumn`.
@@ -376,9 +376,9 @@ class Chain_matrix : public Master_matrix::Matrix_dimension_option,
    * @param coefficient Value to multiply.
    * @param targetColumnIndex @ref MatIdx index of the target column.
    */
-  void multiply_target_and_add_to(index sourceColumnIndex, 
-                                  const Field_element_type& coefficient,
-                                  index targetColumnIndex);
+  void multiply_target_and_add_to(Index sourceColumnIndex, 
+                                  const Field_element& coefficient,
+                                  Index targetColumnIndex);
   /**
    * @brief Multiplies the source column with the coefficient before adding it to the target column.
    * That is: `targetColumn += (coefficient * sourceColumn)`. The source column will **not** be modified.
@@ -391,9 +391,9 @@ class Chain_matrix : public Master_matrix::Matrix_dimension_option,
    * @param sourceColumnIndex @ref MatIdx index of the source column.
    * @param targetColumnIndex @ref MatIdx index of the target column.
    */
-  void multiply_source_and_add_to(const Field_element_type& coefficient, 
-                                  index sourceColumnIndex,
-                                  index targetColumnIndex);
+  void multiply_source_and_add_to(const Field_element& coefficient, 
+                                  Index sourceColumnIndex,
+                                  Index targetColumnIndex);
 
   /**
    * @brief Indicates if the cell at given coordinates has value zero.
@@ -403,7 +403,7 @@ class Chain_matrix : public Master_matrix::Matrix_dimension_option,
    * @return true If the cell has value zero.
    * @return false Otherwise.
    */
-  bool is_zero_cell(index columnIndex, id_index rowIndex) const;
+  bool is_zero_cell(Index columnIndex, ID_index rowIndex) const;
   /**
    * @brief Indicates if the column at given index has value zero. Note that if the matrix is valid, this method
    * should always return false.
@@ -412,7 +412,7 @@ class Chain_matrix : public Master_matrix::Matrix_dimension_option,
    * @return true If the column has value zero.
    * @return false Otherwise.
    */
-  bool is_zero_column(index columnIndex);
+  bool is_zero_column(Index columnIndex);
 
   /**
    * @brief Returns the column with given @ref rowindex "row index" as pivot. Assumes that the pivot exists.
@@ -420,14 +420,14 @@ class Chain_matrix : public Master_matrix::Matrix_dimension_option,
    * @param faceID @ref rowindex "Row index" of the pivot.
    * @return @ref MatIdx index of the column with the given pivot.
    */
-  index get_column_with_pivot(id_index faceID) const;
+  Index get_column_with_pivot(ID_index faceID) const;
   /**
    * @brief Returns the @ref rowindex "row index" of the pivot of the given column.
    * 
    * @param columnIndex @ref MatIdx index of the column
    * @return The @ref rowindex "row index" of the pivot.
    */
-  id_index get_pivot(index columnIndex);
+  ID_index get_pivot(Index columnIndex);
 
   /**
    * @brief Resets the matrix to an empty matrix.
@@ -474,69 +474,68 @@ class Chain_matrix : public Master_matrix::Matrix_dimension_option,
   friend class Id_to_index_overlay<Chain_matrix<Master_matrix>, Master_matrix>;
 
  private:
-  using dim_opt = typename Master_matrix::Matrix_dimension_option;
-  using swap_opt = typename Master_matrix::Chain_vine_swap_option;
-  using pair_opt = typename Master_matrix::Chain_pairing_option;
-  using rep_opt = typename Master_matrix::Chain_representative_cycles_option;
-  using ra_opt = typename Master_matrix::Matrix_row_access_option;
-  using matrix_type = typename Master_matrix::column_container_type;
-  using dictionary_type = typename Master_matrix::template dictionary_type<index>;
-  using barcode_type = typename Master_matrix::barcode_type;
-  using bar_dictionary_type = typename Master_matrix::bar_dictionary_type;
-  using tmp_column_type = typename std::conditional<
-      Master_matrix::Option_list::is_z2, 
-      std::set<id_index>,
-      std::map<id_index, Field_element_type>
-    >::type;
+  using Dim_opt = typename Master_matrix::Matrix_dimension_option;
+  using Swap_opt = typename Master_matrix::Chain_vine_swap_option;
+  using Pair_opt = typename Master_matrix::Chain_pairing_option;
+  using Rep_opt = typename Master_matrix::Chain_representative_cycles_option;
+  using RA_opt = typename Master_matrix::Matrix_row_access_option;
+  using Column_container = typename Master_matrix::Column_container;
+  using Dictionary = typename Master_matrix::template Dictionary<Index>;
+  using Barcode = typename Master_matrix::Barcode;
+  using Bar_dictionary = typename Master_matrix::Bar_dictionary;
+  using Tmp_column = typename std::conditional<Master_matrix::Option_list::is_z2,
+                                               std::set<ID_index>,
+                                               std::map<ID_index, Field_element>
+                                              >::type;
 
-  matrix_type matrix_;                  /**< Column container. */
-  dictionary_type pivotToColumnIndex_; /**< Map from @ref IDIdx to @ref MatIdx index. */
-  index nextIndex_;                     /**< Next unused column index. */
-  Column_settings* colSettings_;          /**< Cell factory. */
+  Column_container matrix_;       /**< Column container. */
+  Dictionary pivotToColumnIndex_; /**< Map from @ref IDIdx to @ref MatIdx index. */
+  Index nextIndex_;               /**< Next unused column index. */
+  Column_settings* colSettings_;  /**< Cell factory. */
 
-  template <class Boundary_type>
-  std::vector<cell_rep_type> _reduce_boundary(id_index faceID, const Boundary_type& boundary, dimension_type dim);
-  void _reduce_by_G(tmp_column_type& column, std::vector<cell_rep_type>& chainsInH, index currentPivot);
-  void _reduce_by_F(tmp_column_type& column, std::vector<cell_rep_type>& chainsInF, index currentPivot);
-  void _build_from_H(id_index faceID, tmp_column_type& column, std::vector<cell_rep_type>& chainsInH);
-  void _update_largest_death_in_F(const std::vector<cell_rep_type>& chainsInF);
-  void _insert_chain(const tmp_column_type& column, dimension_type dimension);
-  void _insert_chain(const tmp_column_type& column, dimension_type dimension, index pair);
-  void _add_to(const Column_type& column, tmp_column_type& set, unsigned int coef);
+  template <class Boundary_container>
+  std::vector<Cell_representative> _reduce_boundary(ID_index faceID, const Boundary_container& boundary, Dimension dim);
+  void _reduce_by_G(Tmp_column& column, std::vector<Cell_representative>& chainsInH, Index currentPivot);
+  void _reduce_by_F(Tmp_column& column, std::vector<Cell_representative>& chainsInF, Index currentPivot);
+  void _build_from_H(ID_index faceID, Tmp_column& column, std::vector<Cell_representative>& chainsInH);
+  void _update_largest_death_in_F(const std::vector<Cell_representative>& chainsInF);
+  void _insert_chain(const Tmp_column& column, Dimension dimension);
+  void _insert_chain(const Tmp_column& column, Dimension dimension, Index pair);
+  void _add_to(const Column& column, Tmp_column& set, unsigned int coef);
   template <typename F>
-  void _add_to(Column_type& target, F&& addition);
-  void _remove_last(index lastIndex);
-  void _update_barcode(pos_index birth);
-  void _add_bar(dimension_type dim);
-  template <class Container_type>
-  void _container_insert(const Container_type& column, index pos, dimension_type dim);
-  void _container_insert(const Column_type& column, [[maybe_unused]] index pos = 0);
+  void _add_to(Column& target, F&& addition);
+  void _remove_last(Index lastIndex);
+  void _update_barcode(Pos_index birth);
+  void _add_bar(Dimension dim);
+  template <class Container>
+  void _container_insert(const Container& column, Index pos, Dimension dim);
+  void _container_insert(const Column& column, [[maybe_unused]] Index pos = 0);
 
-  constexpr barcode_type& _barcode();
-  constexpr bar_dictionary_type& _indexToBar();
-  constexpr pos_index& _nextPosition();
+  constexpr Barcode& _barcode();
+  constexpr Bar_dictionary& _indexToBar();
+  constexpr Pos_index& _nextPosition();
 };
 
 template <class Master_matrix>
 inline Chain_matrix<Master_matrix>::Chain_matrix(Column_settings* colSettings)
-    : dim_opt(-1),
-      pair_opt(),
-      swap_opt(),
-      rep_opt(),
-      ra_opt(),
+    : Dim_opt(-1),
+      Pair_opt(),
+      Swap_opt(),
+      Rep_opt(),
+      RA_opt(),
       nextIndex_(0),
       colSettings_(colSettings)
 {}
 
 template <class Master_matrix>
-template <class Boundary_type>
-inline Chain_matrix<Master_matrix>::Chain_matrix(const std::vector<Boundary_type>& orderedBoundaries,
+template <class Boundary_container>
+inline Chain_matrix<Master_matrix>::Chain_matrix(const std::vector<Boundary_container>& orderedBoundaries,
                                                  Column_settings* colSettings)
-    : dim_opt(-1),
-      pair_opt(),
-      swap_opt(),
-      rep_opt(),
-      ra_opt(orderedBoundaries.size()),
+    : Dim_opt(-1),
+      Pair_opt(),
+      Swap_opt(),
+      Rep_opt(),
+      RA_opt(orderedBoundaries.size()),
       nextIndex_(0),
       colSettings_(colSettings)
 {
@@ -547,7 +546,7 @@ inline Chain_matrix<Master_matrix>::Chain_matrix(const std::vector<Boundary_type
     pivotToColumnIndex_.resize(orderedBoundaries.size(), -1);
   }
 
-  for (const Boundary_type& b : orderedBoundaries) {
+  for (const Boundary_container& b : orderedBoundaries) {
     insert_boundary(b);
   }
 }
@@ -555,11 +554,11 @@ inline Chain_matrix<Master_matrix>::Chain_matrix(const std::vector<Boundary_type
 template <class Master_matrix>
 inline Chain_matrix<Master_matrix>::Chain_matrix(unsigned int numberOfColumns, 
                                                  Column_settings* colSettings)
-    : dim_opt(-1),
-      pair_opt(),
-      swap_opt(),
-      rep_opt(),
-      ra_opt(numberOfColumns),
+    : Dim_opt(-1),
+      Pair_opt(),
+      Swap_opt(),
+      Rep_opt(),
+      RA_opt(numberOfColumns),
       nextIndex_(0),
       colSettings_(colSettings)
 {
@@ -576,26 +575,26 @@ template <typename BirthComparatorFunction, typename DeathComparatorFunction>
 inline Chain_matrix<Master_matrix>::Chain_matrix(Column_settings* colSettings,
                                                  const BirthComparatorFunction& birthComparator,
                                                  const DeathComparatorFunction& deathComparator)
-    : dim_opt(-1),
-      pair_opt(),
-      swap_opt(birthComparator, deathComparator),
-      rep_opt(),
-      ra_opt(),
+    : Dim_opt(-1),
+      Pair_opt(),
+      Swap_opt(birthComparator, deathComparator),
+      Rep_opt(),
+      RA_opt(),
       nextIndex_(0),
       colSettings_(colSettings)
 {}
 
 template <class Master_matrix>
-template <typename BirthComparatorFunction, typename DeathComparatorFunction, class Boundary_type>
-inline Chain_matrix<Master_matrix>::Chain_matrix(const std::vector<Boundary_type>& orderedBoundaries,
+template <typename BirthComparatorFunction, typename DeathComparatorFunction, class Boundary_container>
+inline Chain_matrix<Master_matrix>::Chain_matrix(const std::vector<Boundary_container>& orderedBoundaries,
                                                  Column_settings* colSettings,
                                                  const BirthComparatorFunction& birthComparator,
                                                  const DeathComparatorFunction& deathComparator)
-    : dim_opt(-1),
-      pair_opt(),
-      swap_opt(birthComparator, deathComparator),
-      rep_opt(),
-      ra_opt(orderedBoundaries.size()),
+    : Dim_opt(-1),
+      Pair_opt(),
+      Swap_opt(birthComparator, deathComparator),
+      Rep_opt(),
+      RA_opt(orderedBoundaries.size()),
       nextIndex_(0),
       colSettings_(colSettings)
 {
@@ -605,7 +604,7 @@ inline Chain_matrix<Master_matrix>::Chain_matrix(const std::vector<Boundary_type
   } else {
     pivotToColumnIndex_.resize(orderedBoundaries.size(), -1);
   }
-  for (const Boundary_type& b : orderedBoundaries) {
+  for (const Boundary_container& b : orderedBoundaries) {
     insert_boundary(b);
   }
 }
@@ -616,11 +615,11 @@ inline Chain_matrix<Master_matrix>::Chain_matrix(unsigned int numberOfColumns,
                                                  Column_settings* colSettings,
                                                  const BirthComparatorFunction& birthComparator,
                                                  const DeathComparatorFunction& deathComparator)
-    : dim_opt(-1),
-      pair_opt(),
-      swap_opt(birthComparator, deathComparator),
-      rep_opt(),
-      ra_opt(numberOfColumns),
+    : Dim_opt(-1),
+      Pair_opt(),
+      Swap_opt(birthComparator, deathComparator),
+      Rep_opt(),
+      RA_opt(numberOfColumns),
       nextIndex_(0),
       colSettings_(colSettings)
 {
@@ -633,13 +632,12 @@ inline Chain_matrix<Master_matrix>::Chain_matrix(unsigned int numberOfColumns,
 }
 
 template <class Master_matrix>
-inline Chain_matrix<Master_matrix>::Chain_matrix(const Chain_matrix& matrixToCopy, 
-                                                 Column_settings* colSettings)
-    : dim_opt(static_cast<const dim_opt&>(matrixToCopy)),
-      pair_opt(static_cast<const pair_opt&>(matrixToCopy)),
-      swap_opt(static_cast<const swap_opt&>(matrixToCopy)),
-      rep_opt(static_cast<const rep_opt&>(matrixToCopy)),
-      ra_opt(static_cast<const ra_opt&>(matrixToCopy)),
+inline Chain_matrix<Master_matrix>::Chain_matrix(const Chain_matrix& matrixToCopy, Column_settings* colSettings)
+    : Dim_opt(static_cast<const Dim_opt&>(matrixToCopy)),
+      Pair_opt(static_cast<const Pair_opt&>(matrixToCopy)),
+      Swap_opt(static_cast<const Swap_opt&>(matrixToCopy)),
+      Rep_opt(static_cast<const Rep_opt&>(matrixToCopy)),
+      RA_opt(static_cast<const RA_opt&>(matrixToCopy)),
       pivotToColumnIndex_(matrixToCopy.pivotToColumnIndex_),
       nextIndex_(matrixToCopy.nextIndex_),
       colSettings_(colSettings == nullptr ? matrixToCopy.colSettings_ : colSettings)
@@ -656,11 +654,11 @@ inline Chain_matrix<Master_matrix>::Chain_matrix(const Chain_matrix& matrixToCop
 
 template <class Master_matrix>
 inline Chain_matrix<Master_matrix>::Chain_matrix(Chain_matrix&& other) noexcept
-    : dim_opt(std::move(static_cast<dim_opt&>(other))),
-      pair_opt(std::move(static_cast<pair_opt&>(other))),
-      swap_opt(std::move(static_cast<swap_opt&>(other))),
-      rep_opt(std::move(static_cast<rep_opt&>(other))),
-      ra_opt(std::move(static_cast<ra_opt&>(other))),
+    : Dim_opt(std::move(static_cast<Dim_opt&>(other))),
+      Pair_opt(std::move(static_cast<Pair_opt&>(other))),
+      Swap_opt(std::move(static_cast<Swap_opt&>(other))),
+      Rep_opt(std::move(static_cast<Rep_opt&>(other))),
+      RA_opt(std::move(static_cast<RA_opt&>(other))),
       matrix_(std::move(other.matrix_)),
       pivotToColumnIndex_(std::move(other.pivotToColumnIndex_)),
       nextIndex_(std::exchange(other.nextIndex_, 0)),
@@ -668,17 +666,17 @@ inline Chain_matrix<Master_matrix>::Chain_matrix(Chain_matrix&& other) noexcept
 {}
 
 template <class Master_matrix>
-template <class Boundary_type>
-inline std::vector<typename Master_matrix::cell_rep_type> Chain_matrix<Master_matrix>::insert_boundary(
-    const Boundary_type& boundary, dimension_type dim) 
+template <class Boundary_container>
+inline std::vector<typename Master_matrix::Cell_representative> Chain_matrix<Master_matrix>::insert_boundary(
+    const Boundary_container& boundary, Dimension dim) 
 {
   return insert_boundary(nextIndex_, boundary, dim);
 }
 
 template <class Master_matrix>
-template <class Boundary_type>
-inline std::vector<typename Master_matrix::cell_rep_type> Chain_matrix<Master_matrix>::insert_boundary(
-    id_index faceID, const Boundary_type& boundary, dimension_type dim) 
+template <class Boundary_container>
+inline std::vector<typename Master_matrix::Cell_representative> Chain_matrix<Master_matrix>::insert_boundary(
+    ID_index faceID, const Boundary_container& boundary, Dimension dim) 
 {
   if constexpr (!Master_matrix::Option_list::has_map_column_container) {
     if (pivotToColumnIndex_.size() <= faceID) {
@@ -688,23 +686,23 @@ inline std::vector<typename Master_matrix::cell_rep_type> Chain_matrix<Master_ma
 
   if constexpr (Master_matrix::Option_list::has_vine_update && Master_matrix::Option_list::has_column_pairings) {
     if constexpr (Master_matrix::Option_list::has_map_column_container) {
-      swap_opt::CP::pivotToPosition_.try_emplace(faceID, _nextPosition());
+      Swap_opt::CP::pivotToPosition_.try_emplace(faceID, _nextPosition());
     } else {
-      if (swap_opt::CP::pivotToPosition_.size() <= faceID)
-        swap_opt::CP::pivotToPosition_.resize(pivotToColumnIndex_.size(), -1);
-      swap_opt::CP::pivotToPosition_[faceID] = _nextPosition();
+      if (Swap_opt::CP::pivotToPosition_.size() <= faceID)
+        Swap_opt::CP::pivotToPosition_.resize(pivotToColumnIndex_.size(), -1);
+      Swap_opt::CP::pivotToPosition_[faceID] = _nextPosition();
     }
   }
 
   if constexpr (Master_matrix::Option_list::has_matrix_maximal_dimension_access) {
-    dim_opt::update_up(dim == static_cast<dimension_type>(-1) ? (boundary.size() == 0 ? 0 : boundary.size() - 1) : dim);
+    Dim_opt::update_up(dim == static_cast<Dimension>(-1) ? (boundary.size() == 0 ? 0 : boundary.size() - 1) : dim);
   }
 
   return _reduce_boundary(faceID, boundary, dim);
 }
 
 template <class Master_matrix>
-inline typename Chain_matrix<Master_matrix>::Column_type& Chain_matrix<Master_matrix>::get_column(index columnIndex) 
+inline typename Chain_matrix<Master_matrix>::Column& Chain_matrix<Master_matrix>::get_column(Index columnIndex) 
 {
   if constexpr (Master_matrix::Option_list::has_map_column_container) {
     return matrix_.at(columnIndex);
@@ -714,8 +712,8 @@ inline typename Chain_matrix<Master_matrix>::Column_type& Chain_matrix<Master_ma
 }
 
 template <class Master_matrix>
-inline const typename Chain_matrix<Master_matrix>::Column_type& Chain_matrix<Master_matrix>::get_column(
-    index columnIndex) const 
+inline const typename Chain_matrix<Master_matrix>::Column& Chain_matrix<Master_matrix>::get_column(
+    Index columnIndex) const
 {
   if constexpr (Master_matrix::Option_list::has_map_column_container) {
     return matrix_.at(columnIndex);
@@ -725,7 +723,7 @@ inline const typename Chain_matrix<Master_matrix>::Column_type& Chain_matrix<Mas
 }
 
 template <class Master_matrix>
-inline void Chain_matrix<Master_matrix>::remove_maximal_face(id_index faceID) 
+inline void Chain_matrix<Master_matrix>::remove_maximal_face(ID_index faceID)
 {
   static_assert(Master_matrix::Option_list::has_removable_columns,
                 "'remove_maximal_face' is not implemented for the chosen options.");
@@ -736,25 +734,25 @@ inline void Chain_matrix<Master_matrix>::remove_maximal_face(id_index faceID)
 
   // TODO: find simple test to verify that col at columnIndex is maximal even without row access.
 
-  const auto& pivotToPosition = swap_opt::CP::pivotToPosition_;
+  const auto& pivotToPosition = Swap_opt::CP::pivotToPosition_;
   auto it = pivotToPosition.find(faceID);
   if (it == pivotToPosition.end()) return;  // face does not exists. TODO: put an assert instead?
-  pos_index startPos = it->second;
-  index startIndex = pivotToColumnIndex_.at(faceID);
+  Pos_index startPos = it->second;
+  Index startIndex = pivotToColumnIndex_.at(faceID);
 
   if (startPos != _nextPosition() - 1) {
-    std::vector<index> colToSwap;
+    std::vector<Index> colToSwap;
     colToSwap.reserve(matrix_.size());
 
     for (auto& p : pivotToPosition) {
       if (p.second > startPos) colToSwap.push_back(pivotToColumnIndex_.at(p.first));
     }
-    std::sort(colToSwap.begin(), colToSwap.end(), [&](index c1, index c2) {
+    std::sort(colToSwap.begin(), colToSwap.end(), [&](Index c1, Index c2) {
       return pivotToPosition.at(get_pivot(c1)) < pivotToPosition.at(get_pivot(c2));
     });
 
-    for (index i : colToSwap) {
-      startIndex = swap_opt::vine_swap(startIndex, i);
+    for (Index i : colToSwap) {
+      startIndex = Swap_opt::vine_swap(startIndex, i);
     }
   }
 
@@ -762,8 +760,8 @@ inline void Chain_matrix<Master_matrix>::remove_maximal_face(id_index faceID)
 }
 
 template <class Master_matrix>
-inline void Chain_matrix<Master_matrix>::remove_maximal_face(id_index faceID,
-                                                             const std::vector<id_index>& columnsToSwap) 
+inline void Chain_matrix<Master_matrix>::remove_maximal_face(ID_index faceID,
+                                                             const std::vector<ID_index>& columnsToSwap)
 {
   static_assert(Master_matrix::Option_list::has_removable_columns,
                 "'remove_maximal_face' is not implemented for the chosen options.");
@@ -772,17 +770,17 @@ inline void Chain_matrix<Master_matrix>::remove_maximal_face(id_index faceID,
 
   // TODO: find simple test to verify that col at columnIndex is maximal even without row access.
 
-  index startIndex = pivotToColumnIndex_.at(faceID);
+  Index startIndex = pivotToColumnIndex_.at(faceID);
 
-  for (id_index i : columnsToSwap) {
-    startIndex = swap_opt::vine_swap(startIndex, pivotToColumnIndex_.at(i));
+  for (ID_index i : columnsToSwap) {
+    startIndex = Swap_opt::vine_swap(startIndex, pivotToColumnIndex_.at(i));
   }
 
   _remove_last(startIndex);
 }
 
 template <class Master_matrix>
-inline void Chain_matrix<Master_matrix>::remove_last() 
+inline void Chain_matrix<Master_matrix>::remove_last()
 {
   static_assert(Master_matrix::Option_list::has_removable_columns,
                 "'remove_last' is not implemented for the chosen options.");
@@ -796,8 +794,8 @@ inline void Chain_matrix<Master_matrix>::remove_last()
     // of the last column while performing swaps (or the @ref MatIdx with the return values of `vine_swap` + get_pivot)
     // and then call `remove_maximal_face` with it and an empty `columnsToSwap`.
 
-    id_index pivot = 0;
-    index colIndex = 0;
+    ID_index pivot = 0;
+    Index colIndex = 0;
     for (auto& p : pivotToColumnIndex_) {
       if (p.first > pivot) {  // pivots have to be strictly increasing in order of filtration
         pivot = p.first;
@@ -811,7 +809,7 @@ inline void Chain_matrix<Master_matrix>::remove_last()
 }
 
 template <class Master_matrix>
-inline typename Chain_matrix<Master_matrix>::index Chain_matrix<Master_matrix>::get_number_of_columns() const 
+inline typename Chain_matrix<Master_matrix>::Index Chain_matrix<Master_matrix>::get_number_of_columns() const
 {
   if constexpr (Master_matrix::Option_list::has_map_column_container) {
     return matrix_.size();
@@ -821,52 +819,52 @@ inline typename Chain_matrix<Master_matrix>::index Chain_matrix<Master_matrix>::
 }
 
 template <class Master_matrix>
-inline typename Chain_matrix<Master_matrix>::dimension_type Chain_matrix<Master_matrix>::get_column_dimension(
-    index columnIndex) const 
+inline typename Chain_matrix<Master_matrix>::Dimension Chain_matrix<Master_matrix>::get_column_dimension(
+    Index columnIndex) const 
 {
   return get_column(columnIndex).get_dimension();
 }
 
 template <class Master_matrix>
-inline void Chain_matrix<Master_matrix>::add_to(index sourceColumnIndex, index targetColumnIndex) 
+inline void Chain_matrix<Master_matrix>::add_to(Index sourceColumnIndex, Index targetColumnIndex)
 {
   auto& col = get_column(targetColumnIndex);
   _add_to(col, [&]() { col += get_column(sourceColumnIndex); });
 }
 
 template <class Master_matrix>
-inline void Chain_matrix<Master_matrix>::multiply_target_and_add_to(index sourceColumnIndex,
-                                                                    const Field_element_type& coefficient,
-                                                                    index targetColumnIndex) 
+inline void Chain_matrix<Master_matrix>::multiply_target_and_add_to(Index sourceColumnIndex,
+                                                                    const Field_element& coefficient,
+                                                                    Index targetColumnIndex)
 {
   auto& col = get_column(targetColumnIndex);
   _add_to(col, [&]() { col.multiply_target_and_add(coefficient, get_column(sourceColumnIndex)); });
 }
 
 template <class Master_matrix>
-inline void Chain_matrix<Master_matrix>::multiply_source_and_add_to(const Field_element_type& coefficient,
-                                                                    index sourceColumnIndex, 
-                                                                    index targetColumnIndex) 
+inline void Chain_matrix<Master_matrix>::multiply_source_and_add_to(const Field_element& coefficient,
+                                                                    Index sourceColumnIndex,
+                                                                    Index targetColumnIndex)
 {
   auto& col = get_column(targetColumnIndex);
   _add_to(col, [&]() { col.multiply_source_and_add(get_column(sourceColumnIndex), coefficient); });
 }
 
 template <class Master_matrix>
-inline bool Chain_matrix<Master_matrix>::is_zero_cell(index columnIndex, id_index rowIndex) const 
+inline bool Chain_matrix<Master_matrix>::is_zero_cell(Index columnIndex, ID_index rowIndex) const 
 {
   return !get_column(columnIndex).is_non_zero(rowIndex);
 }
 
 template <class Master_matrix>
-inline bool Chain_matrix<Master_matrix>::is_zero_column(index columnIndex) 
+inline bool Chain_matrix<Master_matrix>::is_zero_column(Index columnIndex) 
 {
   return get_column(columnIndex).is_empty();
 }
 
 template <class Master_matrix>
-inline typename Chain_matrix<Master_matrix>::index Chain_matrix<Master_matrix>::get_column_with_pivot(
-    id_index faceID) const 
+inline typename Chain_matrix<Master_matrix>::Index Chain_matrix<Master_matrix>::get_column_with_pivot(
+    ID_index faceID) const
 {
   if constexpr (Master_matrix::Option_list::has_map_column_container) {
     return pivotToColumnIndex_.at(faceID);
@@ -876,18 +874,18 @@ inline typename Chain_matrix<Master_matrix>::index Chain_matrix<Master_matrix>::
 }
 
 template <class Master_matrix>
-inline typename Chain_matrix<Master_matrix>::id_index Chain_matrix<Master_matrix>::get_pivot(index columnIndex) 
+inline typename Chain_matrix<Master_matrix>::ID_index Chain_matrix<Master_matrix>::get_pivot(Index columnIndex)
 {
   return get_column(columnIndex).get_pivot();
 }
 
 template <class Master_matrix>
-inline Chain_matrix<Master_matrix>& Chain_matrix<Master_matrix>::operator=(const Chain_matrix& other) 
+inline Chain_matrix<Master_matrix>& Chain_matrix<Master_matrix>::operator=(const Chain_matrix& other)
 {
-  dim_opt::operator=(other);
-  swap_opt::operator=(other);
-  pair_opt::operator=(other);
-  rep_opt::operator=(other);
+  Dim_opt::operator=(other);
+  Swap_opt::operator=(other);
+  Pair_opt::operator=(other);
+  Rep_opt::operator=(other);
   matrix_.clear();
   pivotToColumnIndex_ = other.pivotToColumnIndex_;
   nextIndex_ = other.nextIndex_;
@@ -906,13 +904,13 @@ inline Chain_matrix<Master_matrix>& Chain_matrix<Master_matrix>::operator=(const
 }
 
 template <class Master_matrix>
-inline void Chain_matrix<Master_matrix>::print() const 
+inline void Chain_matrix<Master_matrix>::print() const
 {
   std::cout << "Column Matrix:\n";
   if constexpr (!Master_matrix::Option_list::has_map_column_container) {
-    for (id_index i = 0; i < pivotToColumnIndex_.size() && pivotToColumnIndex_[i] != static_cast<index>(-1); ++i) {
-      index pos = pivotToColumnIndex_[i];
-      const Column_type& col = matrix_[pos];
+    for (ID_index i = 0; i < pivotToColumnIndex_.size() && pivotToColumnIndex_[i] != static_cast<Index>(-1); ++i) {
+      Index pos = pivotToColumnIndex_[i];
+      const Column& col = matrix_[pos];
       for (const auto& cell : col) {
         std::cout << cell.get_row_index() << " ";
       }
@@ -921,9 +919,9 @@ inline void Chain_matrix<Master_matrix>::print() const
     if constexpr (Master_matrix::Option_list::has_row_access) {
       std::cout << "\n";
       std::cout << "Row Matrix:\n";
-      for (id_index i = 0; i < pivotToColumnIndex_.size() && pivotToColumnIndex_[i] != static_cast<index>(-1); ++i) {
-        index pos = pivotToColumnIndex_[i];
-        const Row_type& row = ra_opt::get_row(pos);
+      for (ID_index i = 0; i < pivotToColumnIndex_.size() && pivotToColumnIndex_[i] != static_cast<Index>(-1); ++i) {
+        Index pos = pivotToColumnIndex_[i];
+        const Row& row = RA_opt::get_row(pos);
         for (const auto& cell : row) {
           std::cout << cell.get_column_index() << " ";
         }
@@ -932,7 +930,7 @@ inline void Chain_matrix<Master_matrix>::print() const
     }
   } else {
     for (const auto& p : pivotToColumnIndex_) {
-      const Column_type& col = matrix_.at(p.second);
+      const Column& col = matrix_.at(p.second);
       for (const auto& cell : col) {
         std::cout << cell.get_row_index() << " ";
       }
@@ -942,7 +940,7 @@ inline void Chain_matrix<Master_matrix>::print() const
       std::cout << "\n";
       std::cout << "Row Matrix:\n";
       for (const auto& p : pivotToColumnIndex_) {
-        const Row_type& row = ra_opt::get_row(p.first);
+        const Row& row = RA_opt::get_row(p.first);
         for (const auto& cell : row) {
           std::cout << cell.get_column_index() << " ";
         }
@@ -954,14 +952,14 @@ inline void Chain_matrix<Master_matrix>::print() const
 }
 
 template <class Master_matrix>
-template <class Boundary_type>
-inline std::vector<typename Master_matrix::cell_rep_type> Chain_matrix<Master_matrix>::_reduce_boundary(
-    id_index faceID, const Boundary_type& boundary, dimension_type dim) 
+template <class Boundary_container>
+inline std::vector<typename Master_matrix::Cell_representative> Chain_matrix<Master_matrix>::_reduce_boundary(
+    ID_index faceID, const Boundary_container& boundary, Dimension dim)
 {
-  tmp_column_type column(boundary.begin(), boundary.end());
-  if (dim == static_cast<dimension_type>(-1)) dim = boundary.begin() == boundary.end() ? 0 : boundary.size() - 1;
-  std::vector<cell_rep_type> chainsInH;  // for corresponding indices in H (paired columns)
-  std::vector<cell_rep_type> chainsInF;  // for corresponding indices in F (unpaired, essential columns)
+  Tmp_column column(boundary.begin(), boundary.end());
+  if (dim == static_cast<Dimension>(-1)) dim = boundary.begin() == boundary.end() ? 0 : boundary.size() - 1;
+  std::vector<Cell_representative> chainsInH;  // for corresponding indices in H (paired columns)
+  std::vector<Cell_representative> chainsInF;  // for corresponding indices in F (unpaired, essential columns)
 
   auto get_last = [&column]() {
     if constexpr (Master_matrix::Option_list::is_z2)
@@ -979,7 +977,7 @@ inline std::vector<typename Master_matrix::cell_rep_type> Chain_matrix<Master_ma
     return chainsInF;
   }
 
-  index currentIndex = get_column_with_pivot(get_last());
+  Index currentIndex = get_column_with_pivot(get_last());
 
   while (get_column(currentIndex).is_paired()) {
     _reduce_by_G(column, chainsInH, currentIndex);
@@ -1021,16 +1019,16 @@ inline std::vector<typename Master_matrix::cell_rep_type> Chain_matrix<Master_ma
 }
 
 template <class Master_matrix>
-inline void Chain_matrix<Master_matrix>::_reduce_by_G(tmp_column_type& column, 
-                                                      std::vector<cell_rep_type>& chainsInH,
-                                                      index currentIndex) 
+inline void Chain_matrix<Master_matrix>::_reduce_by_G(Tmp_column& column,
+                                                      std::vector<Cell_representative>& chainsInH,
+                                                      Index currentIndex)
 {
-  Column_type& col = get_column(currentIndex);
+  Column& col = get_column(currentIndex);
   if constexpr (Master_matrix::Option_list::is_z2) {
     _add_to(col, column, 1u);                           // Reduce with the column col_g
     chainsInH.push_back(col.get_paired_chain_index());  // keep the col_h with which col_g is paired
   } else {
-    Field_element_type coef = col.get_pivot_value();
+    Field_element coef = col.get_pivot_value();
     auto& operators = colSettings_->operators;
     coef = operators.get_inverse(coef);
     operators.multiply_inplace(coef, operators.get_characteristic() - column.rbegin()->second);
@@ -1041,16 +1039,16 @@ inline void Chain_matrix<Master_matrix>::_reduce_by_G(tmp_column_type& column,
 }
 
 template <class Master_matrix>
-inline void Chain_matrix<Master_matrix>::_reduce_by_F(tmp_column_type& column, 
-                                                      std::vector<cell_rep_type>& chainsInF,
-                                                      index currentIndex) 
+inline void Chain_matrix<Master_matrix>::_reduce_by_F(Tmp_column& column, 
+                                                      std::vector<Cell_representative>& chainsInF,
+                                                      Index currentIndex) 
 {
-  Column_type& col = get_column(currentIndex);
+  Column& col = get_column(currentIndex);
   if constexpr (Master_matrix::Option_list::is_z2) {
     _add_to(col, column, 1u);  // Reduce with the column col_g
     chainsInF.push_back(currentIndex);
   } else {
-    Field_element_type coef = col.get_pivot_value();
+    Field_element coef = col.get_pivot_value();
     auto& operators = colSettings_->operators;
     coef = operators.get_inverse(coef);
     operators.multiply_inplace(coef, operators.get_characteristic() - column.rbegin()->second);
@@ -1061,33 +1059,33 @@ inline void Chain_matrix<Master_matrix>::_reduce_by_F(tmp_column_type& column,
 }
 
 template <class Master_matrix>
-inline void Chain_matrix<Master_matrix>::_build_from_H(id_index faceID, 
-                                                       tmp_column_type& column,
-                                                       std::vector<cell_rep_type>& chainsInH) 
+inline void Chain_matrix<Master_matrix>::_build_from_H(ID_index faceID,
+                                                       Tmp_column& column,
+                                                       std::vector<Cell_representative>& chainsInH)
 {
   if constexpr (Master_matrix::Option_list::is_z2) {
     column.insert(faceID);
-    for (index idx_h : chainsInH) {
+    for (Index idx_h : chainsInH) {
       _add_to(get_column(idx_h), column, 1u);
     }
   } else {
     column.emplace(faceID, 1);
-    for (std::pair<index, Field_element_type>& idx_h : chainsInH) {
+    for (std::pair<Index, Field_element>& idx_h : chainsInH) {
       _add_to(get_column(idx_h.first), column, idx_h.second);
     }
   }
 }
 
 template <class Master_matrix>
-inline void Chain_matrix<Master_matrix>::_update_largest_death_in_F(const std::vector<cell_rep_type>& chainsInF) 
+inline void Chain_matrix<Master_matrix>::_update_largest_death_in_F(const std::vector<Cell_representative>& chainsInF) 
 {
   if constexpr (Master_matrix::Option_list::is_z2) {
-    index toUpdate = chainsInF[0];
+    Index toUpdate = chainsInF[0];
     for (auto other_col_it = chainsInF.begin() + 1; other_col_it != chainsInF.end(); ++other_col_it) {
       add_to(*other_col_it, toUpdate);
     }
   } else {
-    index toUpdate = chainsInF[0].first;
+    Index toUpdate = chainsInF[0].first;
     get_column(toUpdate) *= chainsInF[0].second;
     for (auto other_col_it = chainsInF.begin() + 1; other_col_it != chainsInF.end(); ++other_col_it) {
       multiply_source_and_add_to(other_col_it->second, other_col_it->first, toUpdate);
@@ -1096,7 +1094,7 @@ inline void Chain_matrix<Master_matrix>::_update_largest_death_in_F(const std::v
 }
 
 template <class Master_matrix>
-inline void Chain_matrix<Master_matrix>::_insert_chain(const tmp_column_type& column, dimension_type dimension) 
+inline void Chain_matrix<Master_matrix>::_insert_chain(const Tmp_column& column, Dimension dimension) 
 {
   _container_insert(column, nextIndex_, dimension);
   _add_bar(dimension);
@@ -1105,13 +1103,11 @@ inline void Chain_matrix<Master_matrix>::_insert_chain(const tmp_column_type& co
 }
 
 template <class Master_matrix>
-inline void Chain_matrix<Master_matrix>::_insert_chain(const tmp_column_type& column, 
-                                                       dimension_type dimension,
-                                                       index pair) 
+inline void Chain_matrix<Master_matrix>::_insert_chain(const Tmp_column& column, Dimension dimension, Index pair)
 {
   // true when no vine updates and if nextIndex_ is updated in remove_last for special case of no vines
   // because then @ref PosIdx == @ref MatIdx
-  pos_index pairPos = pair;
+  Pos_index pairPos = pair;
 
   _container_insert(column, nextIndex_, dimension);
 
@@ -1120,7 +1116,7 @@ inline void Chain_matrix<Master_matrix>::_insert_chain(const tmp_column_type& co
   pairCol.assign_paired_chain(nextIndex_);
 
   if constexpr (Master_matrix::Option_list::has_column_pairings && Master_matrix::Option_list::has_vine_update) {
-    pairPos = swap_opt::CP::pivotToPosition_[pairCol.get_pivot()];
+    pairPos = Swap_opt::CP::pivotToPosition_[pairCol.get_pivot()];
   }
 
   _update_barcode(pairPos);
@@ -1129,12 +1125,12 @@ inline void Chain_matrix<Master_matrix>::_insert_chain(const tmp_column_type& co
 }
 
 template <class Master_matrix>
-inline void Chain_matrix<Master_matrix>::_add_to(const Column_type& column, 
-                                                 tmp_column_type& set,
+inline void Chain_matrix<Master_matrix>::_add_to(const Column& column,
+                                                 Tmp_column& set,
                                                  [[maybe_unused]] unsigned int coef) 
 {
   if constexpr (Master_matrix::Option_list::is_z2) {
-    std::pair<typename std::set<index>::iterator, bool> res_insert;
+    std::pair<typename std::set<Index>::iterator, bool> res_insert;
     for (const Cell& cell : column) {
       res_insert = set.insert(cell.get_row_index());
       if (!res_insert.second) {
@@ -1159,7 +1155,7 @@ inline void Chain_matrix<Master_matrix>::_add_to(const Column_type& column,
 
 template <class Master_matrix>
 template <typename F>
-inline void Chain_matrix<Master_matrix>::_add_to(Column_type& target, F&& addition) 
+inline void Chain_matrix<Master_matrix>::_add_to(Column& target, F&& addition)
 {
   auto pivot = target.get_pivot();
   addition();
@@ -1174,22 +1170,22 @@ inline void Chain_matrix<Master_matrix>::_add_to(Column_type& target, F&& additi
 }
 
 template <class Master_matrix>
-inline void Chain_matrix<Master_matrix>::_remove_last(index lastIndex) 
+inline void Chain_matrix<Master_matrix>::_remove_last(Index lastIndex)
 {
   static_assert(Master_matrix::Option_list::has_removable_columns,
                 "'_remove_last' is not implemented for the chosen options.");
   static_assert(Master_matrix::Option_list::has_map_column_container || !Master_matrix::Option_list::has_vine_update,
                 "'_remove_last' is not implemented for the chosen options.");
 
-  id_index pivot;
+  ID_index pivot;
 
   if constexpr (Master_matrix::Option_list::has_map_column_container) {
     auto itToErase = matrix_.find(lastIndex);
-    Column_type& colToErase = itToErase->second;
+    Column& colToErase = itToErase->second;
     pivot = colToErase.get_pivot();
 
     if constexpr (Master_matrix::Option_list::has_matrix_maximal_dimension_access) {
-      dim_opt::update_down(colToErase.get_dimension());
+      Dim_opt::update_down(colToErase.get_dimension());
     }
 
     if (colToErase.is_paired()) matrix_.at(colToErase.get_paired_chain_index()).unassign_paired_chain();
@@ -1199,11 +1195,11 @@ inline void Chain_matrix<Master_matrix>::_remove_last(index lastIndex)
     GUDHI_CHECK(lastIndex == nextIndex_ - 1 && nextIndex_ == matrix_.size(),
                 std::logic_error("Chain_matrix::_remove_last - Indexation problem."));
 
-    Column_type& colToErase = matrix_[lastIndex];
+    Column& colToErase = matrix_[lastIndex];
     pivot = colToErase.get_pivot();
 
     if constexpr (Master_matrix::Option_list::has_matrix_maximal_dimension_access) {
-      dim_opt::update_down(colToErase.get_dimension());
+      Dim_opt::update_down(colToErase.get_dimension());
     }
 
     if (colToErase.is_paired()) matrix_.at(colToErase.get_paired_chain_index()).unassign_paired_chain();
@@ -1218,30 +1214,30 @@ inline void Chain_matrix<Master_matrix>::_remove_last(index lastIndex)
 
   if constexpr (Master_matrix::Option_list::has_column_pairings) {
     auto it = _indexToBar().find(--_nextPosition());
-    typename barcode_type::iterator bar = it->second;
+    typename Barcode::iterator bar = it->second;
 
-    if (bar->death == static_cast<pos_index>(-1))
+    if (bar->death == static_cast<Pos_index>(-1))
       _barcode().erase(bar);
     else
       bar->death = -1;
 
     _indexToBar().erase(it);
-    if constexpr (Master_matrix::Option_list::has_vine_update) swap_opt::CP::pivotToPosition_.erase(pivot);
+    if constexpr (Master_matrix::Option_list::has_vine_update) Swap_opt::CP::pivotToPosition_.erase(pivot);
   }
 
   if constexpr (Master_matrix::Option_list::has_row_access) {
     GUDHI_CHECK(
-        ra_opt::get_row(pivot).size() == 0,
+        RA_opt::get_row(pivot).size() == 0,
         std::invalid_argument(
             "Chain_matrix::_remove_last - Column asked to be removed does not corresponds to a maximal simplex."));
     if constexpr (Master_matrix::Option_list::has_removable_rows) {
-      ra_opt::erase_empty_row(pivot);
+      RA_opt::erase_empty_row(pivot);
     }
   }
 }
 
 template <class Master_matrix>
-inline void Chain_matrix<Master_matrix>::_update_barcode(pos_index birth) 
+inline void Chain_matrix<Master_matrix>::_update_barcode(Pos_index birth)
 {
   if constexpr (Master_matrix::Option_list::has_column_pairings) {
     if constexpr (Master_matrix::Option_list::has_removable_columns) {
@@ -1257,7 +1253,7 @@ inline void Chain_matrix<Master_matrix>::_update_barcode(pos_index birth)
 }
 
 template <class Master_matrix>
-inline void Chain_matrix<Master_matrix>::_add_bar(dimension_type dim) 
+inline void Chain_matrix<Master_matrix>::_add_bar(Dimension dim)
 {
   if constexpr (Master_matrix::Option_list::has_column_pairings) {
     _barcode().emplace_back(_nextPosition(), -1, dim);
@@ -1271,12 +1267,10 @@ inline void Chain_matrix<Master_matrix>::_add_bar(dimension_type dim)
 }
 
 template <class Master_matrix>
-template <class Container_type>
-inline void Chain_matrix<Master_matrix>::_container_insert(const Container_type& column,
-                                                              index pos,
-                                                              dimension_type dim)
+template <class Container>
+inline void Chain_matrix<Master_matrix>::_container_insert(const Container& column, Index pos, Dimension dim)
 {
-  id_index pivot;
+  ID_index pivot;
   if constexpr (Master_matrix::Option_list::is_z2) {
     pivot = *(column.rbegin());
   } else {
@@ -1285,13 +1279,13 @@ inline void Chain_matrix<Master_matrix>::_container_insert(const Container_type&
   if constexpr (Master_matrix::Option_list::has_map_column_container) {
     pivotToColumnIndex_.try_emplace(pivot, pos);
     if constexpr (Master_matrix::Option_list::has_row_access) {
-      matrix_.try_emplace(pos, Column_type(pos, column, dim, ra_opt::rows_, colSettings_));
+      matrix_.try_emplace(pos, Column(pos, column, dim, RA_opt::rows_, colSettings_));
     } else {
-      matrix_.try_emplace(pos, Column_type(column, dim, colSettings_));
+      matrix_.try_emplace(pos, Column(column, dim, colSettings_));
     }
   } else {
     if constexpr (Master_matrix::Option_list::has_row_access) {
-      matrix_.emplace_back(pos, column, dim, ra_opt::rows_, colSettings_);
+      matrix_.emplace_back(pos, column, dim, RA_opt::rows_, colSettings_);
     } else {
       matrix_.emplace_back(column, dim, colSettings_);
     }
@@ -1300,17 +1294,17 @@ inline void Chain_matrix<Master_matrix>::_container_insert(const Container_type&
 }
 
 template <class Master_matrix>
-inline void Chain_matrix<Master_matrix>::_container_insert(const Column_type& column, [[maybe_unused]] index pos)
+inline void Chain_matrix<Master_matrix>::_container_insert(const Column& column, [[maybe_unused]] Index pos)
 {
   if constexpr (Master_matrix::Option_list::has_map_column_container) {
     if constexpr (Master_matrix::Option_list::has_row_access) {
-      matrix_.try_emplace(pos, Column_type(column, column.get_column_index(), ra_opt::rows_, colSettings_));
+      matrix_.try_emplace(pos, Column(column, column.get_column_index(), RA_opt::rows_, colSettings_));
     } else {
-      matrix_.try_emplace(pos, Column_type(column, colSettings_));
+      matrix_.try_emplace(pos, Column(column, colSettings_));
     }
   } else {
     if constexpr (Master_matrix::Option_list::has_row_access) {
-      matrix_.emplace_back(column, column.get_column_index(), ra_opt::rows_, colSettings_);
+      matrix_.emplace_back(column, column.get_column_index(), RA_opt::rows_, colSettings_);
     } else {
       matrix_.emplace_back(column, colSettings_);
     }
@@ -1318,31 +1312,31 @@ inline void Chain_matrix<Master_matrix>::_container_insert(const Column_type& co
 }
 
 template <class Master_matrix>
-inline constexpr typename Chain_matrix<Master_matrix>::barcode_type& Chain_matrix<Master_matrix>::_barcode() 
+inline constexpr typename Chain_matrix<Master_matrix>::Barcode& Chain_matrix<Master_matrix>::_barcode()
 {
   if constexpr (Master_matrix::Option_list::has_vine_update)
-    return swap_opt::template Chain_pairing<Master_matrix>::barcode_;
+    return Swap_opt::template Chain_pairing<Master_matrix>::barcode_;
   else
-    return pair_opt::barcode_;
+    return Pair_opt::barcode_;
 }
 
 template <class Master_matrix>
-inline constexpr typename Chain_matrix<Master_matrix>::bar_dictionary_type&
-Chain_matrix<Master_matrix>::_indexToBar() 
+inline constexpr typename Chain_matrix<Master_matrix>::Bar_dictionary&
+Chain_matrix<Master_matrix>::_indexToBar()
 {
   if constexpr (Master_matrix::Option_list::has_vine_update)
-    return swap_opt::template Chain_pairing<Master_matrix>::indexToBar_;
+    return Swap_opt::template Chain_pairing<Master_matrix>::indexToBar_;
   else
-    return pair_opt::indexToBar_;
+    return Pair_opt::indexToBar_;
 }
 
 template <class Master_matrix>
-inline constexpr typename Chain_matrix<Master_matrix>::pos_index& Chain_matrix<Master_matrix>::_nextPosition() 
+inline constexpr typename Chain_matrix<Master_matrix>::Pos_index& Chain_matrix<Master_matrix>::_nextPosition()
 {
   if constexpr (Master_matrix::Option_list::has_vine_update)
-    return swap_opt::template Chain_pairing<Master_matrix>::nextPosition_;
+    return Swap_opt::template Chain_pairing<Master_matrix>::nextPosition_;
   else
-    return pair_opt::nextPosition_;
+    return Pair_opt::nextPosition_;
 }
 
 }  // namespace persistence_matrix

--- a/src/Persistence_matrix/include/gudhi/Persistence_matrix/chain_pairing.h
+++ b/src/Persistence_matrix/include/gudhi/Persistence_matrix/chain_pairing.h
@@ -30,7 +30,8 @@ namespace persistence_matrix {
  * Inherited instead of @ref Chain_pairing, when the computation of the barcode was not enabled or if the pairing
  * is already managed by the vine update classes.
  */
-struct Dummy_chain_pairing {
+struct Dummy_chain_pairing
+{
   friend void swap([[maybe_unused]] Dummy_chain_pairing& d1, [[maybe_unused]] Dummy_chain_pairing& d2) {}
 };
 
@@ -46,8 +47,8 @@ template <class Master_matrix>
 class Chain_pairing 
 {
  public:
-  using barcode_type = typename Master_matrix::barcode_type;      /**< Barcode type. */
-  using dimension_type = typename Master_matrix::dimension_type;  /**< Dimension value type. */
+  using Barcode = typename Master_matrix::Barcode;      /**< Barcode type. */
+  using Dimension = typename Master_matrix::Dimension;  /**< Dimension value type. */
 
   /**
    * @brief Default constructor.
@@ -71,7 +72,7 @@ class Chain_pairing
    * 
    * @return Const reference to the barcode.
    */
-  const barcode_type& get_current_barcode() const;
+  const Barcode& get_current_barcode() const;
 
   /**
    * @brief Assign operator.
@@ -87,12 +88,12 @@ class Chain_pairing
   }
 
  protected:
-  using dictionary_type = typename Master_matrix::bar_dictionary_type;
-  using pos_index = typename Master_matrix::pos_index;
+  using Dictionary = typename Master_matrix::Bar_dictionary;
+  using Pos_index = typename Master_matrix::Pos_index;
 
-  barcode_type barcode_;        /**< Bar container. */
-  dictionary_type indexToBar_; /**< Map from @ref MatIdx index to bar index. */
-  pos_index nextPosition_;      /**< Next relative position in the filtration. */
+  Barcode barcode_;         /**< Bar container. */
+  Dictionary indexToBar_;   /**< Map from @ref MatIdx index to bar index. */
+  Pos_index nextPosition_;  /**< Next relative position in the filtration. */
 };
 
 template <class Master_matrix>
@@ -114,7 +115,7 @@ inline Chain_pairing<Master_matrix>::Chain_pairing(Chain_pairing<Master_matrix>&
 {}
 
 template <class Master_matrix>
-inline const typename Chain_pairing<Master_matrix>::barcode_type& Chain_pairing<Master_matrix>::get_current_barcode()
+inline const typename Chain_pairing<Master_matrix>::Barcode& Chain_pairing<Master_matrix>::get_current_barcode()
     const 
 {
   return barcode_;

--- a/src/Persistence_matrix/include/gudhi/Persistence_matrix/chain_vine_swap.h
+++ b/src/Persistence_matrix/include/gudhi/Persistence_matrix/chain_vine_swap.h
@@ -52,7 +52,8 @@ constexpr bool _no_G_death_comparator([[maybe_unused]] unsigned int columnIndex1
  * @brief Empty structure.
  * Inherited instead of @ref Chain_vine_swap, when vine swaps are not enabled.
  */
-struct Dummy_chain_vine_swap {
+struct Dummy_chain_vine_swap
+{
   friend void swap([[maybe_unused]] Dummy_chain_vine_swap& d1, [[maybe_unused]] Dummy_chain_vine_swap& d2) {}
 
   Dummy_chain_vine_swap() {}
@@ -67,7 +68,8 @@ struct Dummy_chain_vine_swap {
  * @brief Empty structure.
  * Inherited instead of @ref Chain_barcode_swap, when the barcode is not stored.
  */
-struct Dummy_chain_vine_pairing {
+struct Dummy_chain_vine_pairing
+{
   friend void swap([[maybe_unused]] Dummy_chain_vine_pairing& d1, [[maybe_unused]] Dummy_chain_vine_pairing& d2) {}
 };
 
@@ -82,8 +84,8 @@ template <typename Master_matrix>
 class Chain_barcode_swap : public Chain_pairing<Master_matrix> 
 {
  public:
-  using id_index = typename Master_matrix::id_index;    /**< @ref IDIdx index type. */
-  using pos_index = typename Master_matrix::pos_index;  /**< @ref PosIdx index type. */
+  using ID_index = typename Master_matrix::ID_index;    /**< @ref IDIdx index type. */
+  using Pos_index = typename Master_matrix::Pos_index;  /**< @ref PosIdx index type. */
   //CP = Chain Pairing
   using CP = Chain_pairing<Master_matrix>;
 
@@ -107,11 +109,11 @@ class Chain_barcode_swap : public Chain_pairing<Master_matrix>
       : CP(std::move(static_cast<CP&>(other))), pivotToPosition_(std::move(other.pivotToPosition_)){};
 
  protected:
-  using dictionary_type = typename Master_matrix::template dictionary_type<pos_index>;
+  using Dictionary = typename Master_matrix::template Dictionary<Pos_index>;
 
-  dictionary_type pivotToPosition_;  // necessary to keep track of the barcode changes
+  Dictionary pivotToPosition_;  // necessary to keep track of the barcode changes
 
-  void swap_positions(id_index pivot1, id_index pivot2) {
+  void swap_positions(ID_index pivot1, ID_index pivot2) {
     if constexpr (Master_matrix::Option_list::has_map_column_container) {
       std::swap(pivotToPosition_.at(pivot1), pivotToPosition_.at(pivot2));
     } else {
@@ -119,50 +121,50 @@ class Chain_barcode_swap : public Chain_pairing<Master_matrix>
     }
   }
 
-  bool is_negative_in_pair(id_index pivot) const {
-    pos_index pos = _get_pivot_position(pivot);
+  bool is_negative_in_pair(ID_index pivot) const {
+    Pos_index pos = _get_pivot_position(pivot);
     return death(pivot) == pos;
   }
 
-  void positive_transpose(id_index pivot1, id_index pivot2) {
-    pos_index pos1 = _get_pivot_position(pivot1);
-    pos_index pos2 = _get_pivot_position(pivot2);
+  void positive_transpose(ID_index pivot1, ID_index pivot2) {
+    Pos_index pos1 = _get_pivot_position(pivot1);
+    Pos_index pos2 = _get_pivot_position(pivot2);
 
     _birth(pos1) = pos2;
     _birth(pos2) = pos1;
     std::swap(CP::indexToBar_.at(pos1), CP::indexToBar_.at(pos2));
   }
 
-  void negative_transpose(id_index pivot1, id_index pivot2) {
-    pos_index pos1 = _get_pivot_position(pivot1);
-    pos_index pos2 = _get_pivot_position(pivot2);
+  void negative_transpose(ID_index pivot1, ID_index pivot2) {
+    Pos_index pos1 = _get_pivot_position(pivot1);
+    Pos_index pos2 = _get_pivot_position(pivot2);
 
     _death(pos1) = pos2;
     _death(pos2) = pos1;
     std::swap(CP::indexToBar_.at(pos1), CP::indexToBar_.at(pos2));
   }
 
-  void positive_negative_transpose(id_index pivot1, id_index pivot2) {
-    pos_index pos1 = _get_pivot_position(pivot1);
-    pos_index pos2 = _get_pivot_position(pivot2);
+  void positive_negative_transpose(ID_index pivot1, ID_index pivot2) {
+    Pos_index pos1 = _get_pivot_position(pivot1);
+    Pos_index pos2 = _get_pivot_position(pivot2);
 
     _birth(pos1) = pos2;
     _death(pos2) = pos1;
     std::swap(CP::indexToBar_.at(pos1), CP::indexToBar_.at(pos2));
   }
 
-  void negative_positive_transpose(id_index pivot1, id_index pivot2) {
-    pos_index pos1 = _get_pivot_position(pivot1);
-    pos_index pos2 = _get_pivot_position(pivot2);
+  void negative_positive_transpose(ID_index pivot1, ID_index pivot2) {
+    Pos_index pos1 = _get_pivot_position(pivot1);
+    Pos_index pos2 = _get_pivot_position(pivot2);
 
     _death(pos1) = pos2;
     _birth(pos2) = pos1;
     std::swap(CP::indexToBar_.at(pos1), CP::indexToBar_.at(pos2));
   }
 
-  bool are_adjacent(id_index pivot1, id_index pivot2) const {
-    pos_index pos1 = _get_pivot_position(pivot1);
-    pos_index pos2 = _get_pivot_position(pivot2);
+  bool are_adjacent(ID_index pivot1, ID_index pivot2) const {
+    Pos_index pos1 = _get_pivot_position(pivot1);
+    Pos_index pos2 = _get_pivot_position(pivot2);
     return pos1 < pos2 ? (pos2 - pos1) == 1 : (pos1 - pos2) == 1;
   }
 
@@ -175,8 +177,8 @@ class Chain_barcode_swap : public Chain_pairing<Master_matrix>
     swap1.pivotToPosition_.swap(swap2.pivotToPosition_);
   }
 
-  pos_index death(id_index pivot) const {
-    pos_index simplexIndex = _get_pivot_position(pivot);
+  Pos_index death(ID_index pivot) const {
+    Pos_index simplexIndex = _get_pivot_position(pivot);
 
     if constexpr (Master_matrix::Option_list::has_removable_columns) {
       return CP::indexToBar_.at(simplexIndex)->death;
@@ -185,8 +187,8 @@ class Chain_barcode_swap : public Chain_pairing<Master_matrix>
     }
   }
 
-  pos_index birth(id_index pivot) const {
-    pos_index simplexIndex = _get_pivot_position(pivot);
+  Pos_index birth(ID_index pivot) const {
+    Pos_index simplexIndex = _get_pivot_position(pivot);
 
     if constexpr (Master_matrix::Option_list::has_removable_columns) {
       return CP::indexToBar_.at(simplexIndex)->birth;
@@ -196,7 +198,7 @@ class Chain_barcode_swap : public Chain_pairing<Master_matrix>
   }
 
  private:
-  pos_index _get_pivot_position(id_index pivot) const {
+  Pos_index _get_pivot_position(ID_index pivot) const {
     if constexpr (Master_matrix::Option_list::has_map_column_container) {
       return pivotToPosition_.at(
           pivot);  // quite often called, make public and pass position instead of pivot to avoid find() every time?
@@ -205,7 +207,7 @@ class Chain_barcode_swap : public Chain_pairing<Master_matrix>
     }
   }
 
-  pos_index& _death(pos_index simplexIndex) {
+  Pos_index& _death(Pos_index simplexIndex) {
     if constexpr (Master_matrix::Option_list::has_removable_columns) {
       return CP::indexToBar_.at(simplexIndex)->death;
     } else {
@@ -213,7 +215,7 @@ class Chain_barcode_swap : public Chain_pairing<Master_matrix>
     }
   }
 
-  pos_index& _birth(pos_index simplexIndex) {
+  Pos_index& _birth(Pos_index simplexIndex) {
     if constexpr (Master_matrix::Option_list::has_removable_columns) {
       return CP::indexToBar_.at(simplexIndex)->birth;
     } else {
@@ -237,12 +239,12 @@ class Chain_vine_swap : public std::conditional<Master_matrix::Option_list::has_
                                                >::type 
 {
  public:
-  using index = typename Master_matrix::index;                        /**< @ref MatIdx index type. */
-  using id_index = typename Master_matrix::id_index;                  /**< @ref IDIdx index type. */
-  using pos_index = typename Master_matrix::pos_index;                /**< @ref PosIdx index type. */
-  using matrix_type = typename Master_matrix::column_container_type;  /**< Column container type. */
-  using Column_type = typename Master_matrix::Column_type;            /**< Column type. */
-  typedef bool (*EventCompFuncPointer)(pos_index, pos_index);         /**< Pointer type for birth/death comparators. */
+  using Index = typename Master_matrix::Index;                        /**< @ref MatIdx index type. */
+  using ID_index = typename Master_matrix::ID_index;                  /**< @ref IDIdx index type. */
+  using Pos_index = typename Master_matrix::Pos_index;                /**< @ref PosIdx index type. */
+  using Column_container = typename Master_matrix::Column_container;  /**< Column container type. */
+  using Column = typename Master_matrix::Column;                      /**< Column type. */
+  typedef bool (*EventCompFuncPointer)(Pos_index, Pos_index);         /**< Pointer type for birth/death comparators. */
 
   /**
    * @brief Default constructor. Only available if @ref PersistenceMatrixOptions::has_column_pairings is true.
@@ -260,8 +262,8 @@ class Chain_vine_swap : public std::conditional<Master_matrix::Option_list::has_
    * the second one with respect to some self defined order. It is used while swapping two positive but paired
    * columns. Default value: @ref _no_G_death_comparator.
    */
-  Chain_vine_swap(std::function<bool(pos_index,pos_index)> birthComparator,
-                  std::function<bool(pos_index,pos_index)> deathComparator = _no_G_death_comparator);
+  Chain_vine_swap(std::function<bool(Pos_index,Pos_index)> birthComparator,
+                  std::function<bool(Pos_index,Pos_index)> deathComparator = _no_G_death_comparator);
   /**
    * @brief Copy constructor.
    * 
@@ -285,7 +287,7 @@ class Chain_vine_swap : public std::conditional<Master_matrix::Option_list::has_
    * @p columnIndex2. The method returns the @ref MatIdx of the column which has now, after the swap, the @ref PosIdx
    * \f$ max(pos1, pos2) \f$.
    */
-  index vine_swap_with_z_eq_1_case(index columnIndex1, index columnIndex2);
+  Index vine_swap_with_z_eq_1_case(Index columnIndex1, Index columnIndex2);
   /**
    * @brief Does a vine swap between two faces which are consecutive in the filtration. Roughly, if \f$ F \f$ is
    * the current filtration represented by the matrix, the method modifies the matrix such that the new state
@@ -301,7 +303,7 @@ class Chain_vine_swap : public std::conditional<Master_matrix::Option_list::has_
    * @p columnIndex2. The method returns the @ref MatIdx of the column which has now, after the swap, the @ref PosIdx
    * \f$ max(pos1, pos2) \f$.
    */
-  index vine_swap(index columnIndex1, index columnIndex2);
+  Index vine_swap(Index columnIndex1, Index columnIndex2);
 
   /**
    * @brief Assign operator.
@@ -326,20 +328,20 @@ class Chain_vine_swap : public std::conditional<Master_matrix::Option_list::has_
                                       >::type;
 
  private:
-  using chain_matrix = typename Master_matrix::Chain_matrix_type;
+  using Master_chain_matrix = typename Master_matrix::Master_chain_matrix;
 
-  std::function<bool(pos_index,pos_index)> birthComp_;  /**< for F x F & H x H. */
-  std::function<bool(pos_index,pos_index)> deathComp_;  /**< for G x G. */
+  std::function<bool(Pos_index,Pos_index)> birthComp_;  /**< for F x F & H x H. */
+  std::function<bool(Pos_index,Pos_index)> deathComp_;  /**< for G x G. */
 
-  bool _is_negative_in_pair(index columnIndex);
+  bool _is_negative_in_pair(Index columnIndex);
 
-  index _positive_vine_swap(index columnIndex1, index columnIndex2);
-  index _positive_negative_vine_swap(index columnIndex1, index columnIndex2);
-  index _negative_positive_vine_swap(index columnIndex1, index columnIndex2);
-  index _negative_vine_swap(index columnIndex1, index columnIndex2);
+  Index _positive_vine_swap(Index columnIndex1, Index columnIndex2);
+  Index _positive_negative_vine_swap(Index columnIndex1, Index columnIndex2);
+  Index _negative_positive_vine_swap(Index columnIndex1, Index columnIndex2);
+  Index _negative_vine_swap(Index columnIndex1, Index columnIndex2);
 
-  constexpr chain_matrix* _matrix() { return static_cast<chain_matrix*>(this); }
-  constexpr const chain_matrix* _matrix() const { return static_cast<const chain_matrix*>(this); }
+  constexpr Master_chain_matrix* _matrix() { return static_cast<Master_chain_matrix*>(this); }
+  constexpr const Master_chain_matrix* _matrix() const { return static_cast<const Master_chain_matrix*>(this); }
 };
 
 template <class Master_matrix>
@@ -350,8 +352,8 @@ inline Chain_vine_swap<Master_matrix>::Chain_vine_swap() : CP(), birthComp_(), d
 }
 
 template <class Master_matrix>
-inline Chain_vine_swap<Master_matrix>::Chain_vine_swap(std::function<bool(pos_index,pos_index)> birthComparator,
-                                                       std::function<bool(pos_index,pos_index)> deathComparator)
+inline Chain_vine_swap<Master_matrix>::Chain_vine_swap(std::function<bool(Pos_index,Pos_index)> birthComparator,
+                                                       std::function<bool(Pos_index,Pos_index)> deathComparator)
     : CP(), birthComp_(std::move(birthComparator)), deathComp_(std::move(deathComparator)) 
 {}
 
@@ -370,8 +372,8 @@ inline Chain_vine_swap<Master_matrix>::Chain_vine_swap(Chain_vine_swap<Master_ma
 {}
 
 template <class Master_matrix>
-inline typename Chain_vine_swap<Master_matrix>::index Chain_vine_swap<Master_matrix>::vine_swap_with_z_eq_1_case(
-    index columnIndex1, index columnIndex2) 
+inline typename Chain_vine_swap<Master_matrix>::Index Chain_vine_swap<Master_matrix>::vine_swap_with_z_eq_1_case(
+    Index columnIndex1, Index columnIndex2) 
 {
   const bool col1IsNeg = _is_negative_in_pair(columnIndex1);
   const bool col2IsNeg = _is_negative_in_pair(columnIndex2);
@@ -386,8 +388,8 @@ inline typename Chain_vine_swap<Master_matrix>::index Chain_vine_swap<Master_mat
 }
 
 template <class Master_matrix>
-inline typename Chain_vine_swap<Master_matrix>::index Chain_vine_swap<Master_matrix>::vine_swap(index columnIndex1,
-                                                                                                index columnIndex2) 
+inline typename Chain_vine_swap<Master_matrix>::Index Chain_vine_swap<Master_matrix>::vine_swap(Index columnIndex1,
+                                                                                                Index columnIndex2) 
 {
   if constexpr (Master_matrix::Option_list::has_column_pairings) {
     GUDHI_CHECK(CP::are_adjacent(_matrix()->get_pivot(columnIndex1), _matrix()->get_pivot(columnIndex2)),
@@ -401,8 +403,8 @@ inline typename Chain_vine_swap<Master_matrix>::index Chain_vine_swap<Master_mat
   if (col1IsNeg && col2IsNeg) {
     if (_matrix()->is_zero_cell(columnIndex2, _matrix()->get_pivot(columnIndex1))) {
       if constexpr (Master_matrix::Option_list::has_column_pairings) {
-        id_index pivot1 = _matrix()->get_pivot(columnIndex1);
-        id_index pivot2 = _matrix()->get_pivot(columnIndex2);
+        ID_index pivot1 = _matrix()->get_pivot(columnIndex1);
+        ID_index pivot2 = _matrix()->get_pivot(columnIndex2);
 
         CP::negative_transpose(pivot1, pivot2);
         CP::swap_positions(pivot1, pivot2);
@@ -415,8 +417,8 @@ inline typename Chain_vine_swap<Master_matrix>::index Chain_vine_swap<Master_mat
   if (col1IsNeg) {
     if (_matrix()->is_zero_cell(columnIndex2, _matrix()->get_pivot(columnIndex1))) {
       if constexpr (Master_matrix::Option_list::has_column_pairings) {
-        id_index pivot1 = _matrix()->get_pivot(columnIndex1);
-        id_index pivot2 = _matrix()->get_pivot(columnIndex2);
+        ID_index pivot1 = _matrix()->get_pivot(columnIndex1);
+        ID_index pivot2 = _matrix()->get_pivot(columnIndex2);
 
         CP::negative_positive_transpose(pivot1, pivot2);
         CP::swap_positions(pivot1, pivot2);
@@ -429,8 +431,8 @@ inline typename Chain_vine_swap<Master_matrix>::index Chain_vine_swap<Master_mat
   if (col2IsNeg) {
     if (_matrix()->is_zero_cell(columnIndex2, _matrix()->get_pivot(columnIndex1))) {
       if constexpr (Master_matrix::Option_list::has_column_pairings) {
-        id_index pivot1 = _matrix()->get_pivot(columnIndex1);
-        id_index pivot2 = _matrix()->get_pivot(columnIndex2);
+        ID_index pivot1 = _matrix()->get_pivot(columnIndex1);
+        ID_index pivot2 = _matrix()->get_pivot(columnIndex2);
 
         CP::positive_negative_transpose(pivot1, pivot2);
         CP::swap_positions(pivot1, pivot2);
@@ -442,8 +444,8 @@ inline typename Chain_vine_swap<Master_matrix>::index Chain_vine_swap<Master_mat
 
   if (_matrix()->is_zero_cell(columnIndex2, _matrix()->get_pivot(columnIndex1))) {
     if constexpr (Master_matrix::Option_list::has_column_pairings) {
-      id_index pivot1 = _matrix()->get_pivot(columnIndex1);
-      id_index pivot2 = _matrix()->get_pivot(columnIndex2);
+      ID_index pivot1 = _matrix()->get_pivot(columnIndex1);
+      ID_index pivot2 = _matrix()->get_pivot(columnIndex2);
 
       CP::positive_transpose(pivot1, pivot2);
       CP::swap_positions(pivot1, pivot2);
@@ -463,7 +465,7 @@ inline Chain_vine_swap<Master_matrix>& Chain_vine_swap<Master_matrix>::operator=
 }
 
 template <class Master_matrix>
-inline bool Chain_vine_swap<Master_matrix>::_is_negative_in_pair(index columnIndex) 
+inline bool Chain_vine_swap<Master_matrix>::_is_negative_in_pair(Index columnIndex) 
 {
   if constexpr (Master_matrix::Option_list::has_column_pairings) {
     return CP::is_negative_in_pair(_matrix()->get_pivot(columnIndex));
@@ -475,8 +477,8 @@ inline bool Chain_vine_swap<Master_matrix>::_is_negative_in_pair(index columnInd
 }
 
 template <class Master_matrix>
-inline typename Chain_vine_swap<Master_matrix>::index Chain_vine_swap<Master_matrix>::_positive_vine_swap(
-    index columnIndex1, index columnIndex2) 
+inline typename Chain_vine_swap<Master_matrix>::Index Chain_vine_swap<Master_matrix>::_positive_vine_swap(
+    Index columnIndex1, Index columnIndex2) 
 {
   auto& col1 = _matrix()->get_column(columnIndex1);
   auto& col2 = _matrix()->get_column(columnIndex2);
@@ -507,7 +509,7 @@ inline typename Chain_vine_swap<Master_matrix>::index Chain_vine_swap<Master_mat
   }
 
   if (!col2.is_paired()) {  // G x F
-    static_cast<chain_matrix*>(this)->add_to(columnIndex1, columnIndex2);
+    static_cast<Master_chain_matrix*>(this)->add_to(columnIndex1, columnIndex2);
     if constexpr (Master_matrix::Option_list::has_column_pairings) {
       CP::positive_transpose(col1.get_pivot(), col2.get_pivot());
     }
@@ -540,14 +542,14 @@ inline typename Chain_vine_swap<Master_matrix>::index Chain_vine_swap<Master_mat
 }
 
 template <class Master_matrix>
-inline typename Chain_vine_swap<Master_matrix>::index Chain_vine_swap<Master_matrix>::_positive_negative_vine_swap(
-    index columnIndex1, index columnIndex2) 
+inline typename Chain_vine_swap<Master_matrix>::Index Chain_vine_swap<Master_matrix>::_positive_negative_vine_swap(
+    Index columnIndex1, Index columnIndex2) 
 {
   _matrix()->add_to(columnIndex1, columnIndex2);
 
   if constexpr (Master_matrix::Option_list::has_column_pairings) {
-    id_index pivot1 = _matrix()->get_pivot(columnIndex1);
-    id_index pivot2 = _matrix()->get_pivot(columnIndex2);
+    ID_index pivot1 = _matrix()->get_pivot(columnIndex1);
+    ID_index pivot2 = _matrix()->get_pivot(columnIndex2);
 
     CP::positive_negative_transpose(pivot1, pivot2);
     CP::swap_positions(pivot1, pivot2);
@@ -557,8 +559,8 @@ inline typename Chain_vine_swap<Master_matrix>::index Chain_vine_swap<Master_mat
 }
 
 template <class Master_matrix>
-inline typename Chain_vine_swap<Master_matrix>::index Chain_vine_swap<Master_matrix>::_negative_positive_vine_swap(
-    index columnIndex1, index columnIndex2) 
+inline typename Chain_vine_swap<Master_matrix>::Index Chain_vine_swap<Master_matrix>::_negative_positive_vine_swap(
+    Index columnIndex1, Index columnIndex2) 
 {
   _matrix()->add_to(columnIndex2, columnIndex1);
 
@@ -570,14 +572,14 @@ inline typename Chain_vine_swap<Master_matrix>::index Chain_vine_swap<Master_mat
 }
 
 template <class Master_matrix>
-inline typename Chain_vine_swap<Master_matrix>::index Chain_vine_swap<Master_matrix>::_negative_vine_swap(
-    index columnIndex1, index columnIndex2) 
+inline typename Chain_vine_swap<Master_matrix>::Index Chain_vine_swap<Master_matrix>::_negative_vine_swap(
+    Index columnIndex1, Index columnIndex2) 
 {
   auto& col1 = _matrix()->get_column(columnIndex1);
   auto& col2 = _matrix()->get_column(columnIndex2);
 
-  index pairedIndex1 = col1.get_paired_chain_index();
-  index pairedIndex2 = col2.get_paired_chain_index();
+  Index pairedIndex1 = col1.get_paired_chain_index();
+  Index pairedIndex2 = col2.get_paired_chain_index();
 
   bool hasSmallerBirth;
   if constexpr (Master_matrix::Option_list::has_column_pairings) {

--- a/src/Persistence_matrix/include/gudhi/Persistence_matrix/columns/cell_types.h
+++ b/src/Persistence_matrix/include/gudhi/Persistence_matrix/columns/cell_types.h
@@ -36,8 +36,8 @@ namespace persistence_matrix {
 struct Dummy_cell_column_index_mixin 
 {
   Dummy_cell_column_index_mixin() {}
-  template <typename index>
-  Dummy_cell_column_index_mixin([[maybe_unused]] index columnIndex) {}
+  template <typename Index>
+  Dummy_cell_column_index_mixin([[maybe_unused]] Index columnIndex) {}
 };
 
 /**
@@ -49,8 +49,8 @@ struct Dummy_cell_column_index_mixin
 struct Dummy_cell_field_element_mixin 
 {
   Dummy_cell_field_element_mixin() {}
-  template <class Field_element_type>
-  Dummy_cell_field_element_mixin([[maybe_unused]] Field_element_type t) {}
+  template <class Field_element>
+  Dummy_cell_field_element_mixin([[maybe_unused]] Field_element t) {}
 };
 
 /**
@@ -58,9 +58,9 @@ struct Dummy_cell_field_element_mixin
  *
  * @brief Class managing the column index access of a cell.
  * 
- * @tparam index @ref MatIdx index type.
+ * @tparam Index @ref MatIdx index type.
  */
-template <typename index>
+template <typename Index>
 class Cell_column_index 
 {
  public:
@@ -73,7 +73,7 @@ class Cell_column_index
    * 
    * @param columnIndex Column index of the cell.
    */
-  Cell_column_index(index columnIndex) : columnIndex_(columnIndex){};
+  Cell_column_index(Index columnIndex) : columnIndex_(columnIndex){};
   /**
    * @brief Copy constructor.
    * 
@@ -92,13 +92,13 @@ class Cell_column_index
    * 
    * @return Column index of the cell.
    */
-  index get_column_index() const { return columnIndex_; };
+  Index get_column_index() const { return columnIndex_; };
   /**
    * @brief Sets the column index to the given value.
    * 
    * @param columnIndex Column index of the cell.
    */
-  void set_column_index(index columnIndex) { columnIndex_ = columnIndex; }
+  void set_column_index(Index columnIndex) { columnIndex_ = columnIndex; }
 
   /**
    * @brief Assign operator.
@@ -109,7 +109,7 @@ class Cell_column_index
   };
 
  private:
-  index columnIndex_;   /**< Column index. */
+  Index columnIndex_;   /**< Column index. */
 };
 
 /**
@@ -117,9 +117,9 @@ class Cell_column_index
  *
  * @brief Class managing the value access of a cell.
  * 
- * @tparam Field_element_type Type of a cell value.
+ * @tparam Field_element Type of a cell value.
  */
-template <class Field_element_type>
+template <class Field_element>
 class Cell_field_element 
 {
  public:
@@ -132,7 +132,7 @@ class Cell_field_element
    * 
    * @param element Value to store.
    */
-  Cell_field_element(Field_element_type element) : element_(element){};
+  Cell_field_element(Field_element element) : element_(element){};
   /**
    * @brief Copy constructor.
    * 
@@ -151,19 +151,19 @@ class Cell_field_element
    * 
    * @return Reference to the value of the cell.
    */
-  Field_element_type& get_element() { return element_; };
+  Field_element& get_element() { return element_; };
   /**
    * @brief Returns the value stored in the cell.
    * 
    * @return Const reference to the value of the cell.
    */
-  const Field_element_type& get_element() const { return element_; };
+  const Field_element& get_element() const { return element_; };
   /**
    * @brief Sets the value.
    * 
    * @param element Value to store.
    */
-  void set_element(const Field_element_type& element) { element_ = element; }
+  void set_element(const Field_element& element) { element_ = element; }
 
   /**
    * @brief Assign operator.
@@ -174,7 +174,7 @@ class Cell_field_element
   };
 
  private:
-  Field_element_type element_;  /**< Value of the cell. */
+  Field_element element_;  /**< Value of the cell. */
 };
 
 /**
@@ -190,18 +190,18 @@ class Cell_field_element
 template <class Master_matrix>
 class Cell : public Master_matrix::Cell_column_index_option,
              public Master_matrix::Cell_field_element_option,
-             public Master_matrix::row_hook_type,
-             public Master_matrix::column_hook_type 
+             public Master_matrix::Row_hook,
+             public Master_matrix::Column_hook 
 {
  private:
   using col_opt = typename Master_matrix::Cell_column_index_option;
   using field_opt = typename Master_matrix::Cell_field_element_option;
 
  public:
-  using Master = Master_matrix;                                     /**< Access to options from outside. */
-  using index = typename Master_matrix::index;                      /**< Column index type. */
-  using id_index = typename Master_matrix::id_index;                /**< Row index type. */
-  using Field_element_type = typename Master_matrix::element_type;  /**< Value type. */
+  using Master = Master_matrix;                           /**< Access to options from outside. */
+  using Index = typename Master_matrix::Index;            /**< Column index type. */
+  using ID_index = typename Master_matrix::ID_index;      /**< Row index type. */
+  using Field_element = typename Master_matrix::Element;  /**< Value type. */
 
   /**
    * @brief Constructs an cell with all attributes at default values.
@@ -212,14 +212,14 @@ class Cell : public Master_matrix::Cell_column_index_option,
    * 
    * @param rowIndex @ref rowindex "Row index" of the cell.
    */
-  Cell(id_index rowIndex) : col_opt(), field_opt(), rowIndex_(rowIndex){};
+  Cell(ID_index rowIndex) : col_opt(), field_opt(), rowIndex_(rowIndex){};
   /**
    * @brief Constructs a cell with given row and column index. Other possible attributes are set at default values.
    * 
    * @param columnIndex Column index of the cell.
    * @param rowIndex @ref rowindex "Row index" of the cell.
    */
-  Cell(index columnIndex, id_index rowIndex) : col_opt(columnIndex), field_opt(), rowIndex_(rowIndex){};
+  Cell(Index columnIndex, ID_index rowIndex) : col_opt(columnIndex), field_opt(), rowIndex_(rowIndex){};
   /**
    * @brief Copy constructor.
    * 
@@ -244,13 +244,13 @@ class Cell : public Master_matrix::Cell_column_index_option,
    * 
    * @return @ref rowindex "Row index" of the cell.
    */
-  id_index get_row_index() const { return rowIndex_; };
+  ID_index get_row_index() const { return rowIndex_; };
   /**
    * @brief Sets the row index stored in the cell.
    * 
    * @param rowIndex @ref rowindex "Row index" of the cell.
    */
-  void set_row_index(id_index rowIndex) { rowIndex_ = rowIndex; };
+  void set_row_index(ID_index rowIndex) { rowIndex_ = rowIndex; };
 
   /**
    * @brief Assign operator.
@@ -286,13 +286,13 @@ class Cell : public Master_matrix::Cell_column_index_option,
    * 
    * @return The row index of the cell.
    */
-  operator id_index() const { return rowIndex_; }
+  operator ID_index() const { return rowIndex_; }
   /**
    * @brief Converts the cell into a pair of row index and cell value.
    * 
    * @return A std::pair with first element the row index and second element the value.
    */
-  operator std::pair<id_index, Field_element_type>() const {
+  operator std::pair<ID_index, Field_element>() const {
     if constexpr (Master_matrix::Option_list::is_z2) {
       return {rowIndex_, 1};
     } else {
@@ -301,7 +301,7 @@ class Cell : public Master_matrix::Cell_column_index_option,
   }
 
  private:
-  id_index rowIndex_;   /**< Row index of the cell. */
+  ID_index rowIndex_;   /**< Row index of the cell. */
 };
 
 }  // namespace persistence_matrix
@@ -319,7 +319,7 @@ class Cell : public Master_matrix::Cell_column_index_option,
  */
 template <class Master_matrix>
 struct std::hash<Gudhi::persistence_matrix::Cell<Master_matrix> > {
-  size_t operator()(const Gudhi::persistence_matrix::Cell<Master_matrix>& cell) const {
+  std::size_t operator()(const Gudhi::persistence_matrix::Cell<Master_matrix>& cell) const {
     return std::hash<unsigned int>()(cell.get_row_index());
   }
 };

--- a/src/Persistence_matrix/include/gudhi/Persistence_matrix/columns/chain_column_extra_properties.h
+++ b/src/Persistence_matrix/include/gudhi/Persistence_matrix/columns/chain_column_extra_properties.h
@@ -56,8 +56,8 @@ template <class Master_matrix>
 class Chain_column_extra_properties 
 {
  public:
-  using index = typename Master_matrix::index;        /**< @ref MatIdx index type. */
-  using id_index = typename Master_matrix::id_index;  /**< @ref IDIdx index type. */
+  using Index = typename Master_matrix::Index;        /**< @ref MatIdx index type. */
+  using ID_index = typename Master_matrix::ID_index;  /**< @ref IDIdx index type. */
 
   /**
    * @brief Default constructor. Sets the pivot and pair to -1, which means "not existing".
@@ -69,7 +69,7 @@ class Chain_column_extra_properties
    * @param pivot @ref rowindex "Row index" of the pivot. Corresponds to the @ref IDIdx index of the face represented
    * by the column.
    */
-  Chain_column_extra_properties(id_index pivot) : pivot_(pivot), pairedColumn_(-1) {}
+  Chain_column_extra_properties(ID_index pivot) : pivot_(pivot), pairedColumn_(-1) {}
   /**
    * @brief Constructor setting the pivot and the pair at the given values.
    * 
@@ -77,7 +77,7 @@ class Chain_column_extra_properties
    * by the column.
    * @param pair @ref MatIdx index of the pair of the column.
    */
-  Chain_column_extra_properties(id_index pivot, index pair) : pivot_(pivot), pairedColumn_(pair) {}
+  Chain_column_extra_properties(ID_index pivot, Index pair) : pivot_(pivot), pairedColumn_(pair) {}
   /**
    * @brief Copy constructor.
    * 
@@ -98,20 +98,20 @@ class Chain_column_extra_properties
    * 
    * @return -1 if the column is not paired, the @ref MatIdx of the pair otherwise.
    */
-  index get_paired_chain_index() const { return pairedColumn_; }
+  Index get_paired_chain_index() const { return pairedColumn_; }
   /**
    * @brief Indicates if the column is paired or not.
    * 
    * @return true If the column is paired.
    * @return false Otherwise.
    */
-  bool is_paired() const { return pairedColumn_ != static_cast<index>(-1); }
+  bool is_paired() const { return pairedColumn_ != static_cast<Index>(-1); }
   /**
    * @brief Sets the value of the pair.
    * 
    * @param other_col @ref MatIdx of the pair column.
    */
-  void assign_paired_chain(index other_col) { pairedColumn_ = other_col; }
+  void assign_paired_chain(Index other_col) { pairedColumn_ = other_col; }
   /**
    * @brief Un-pairs a column.
    */
@@ -134,12 +134,12 @@ class Chain_column_extra_properties
   }
 
  protected:
-  id_index get_pivot() const { return pivot_; }
+  ID_index get_pivot() const { return pivot_; }
   void swap_pivots(Chain_column_extra_properties& other) { std::swap(pivot_, other.pivot_); }
 
  private:
-  id_index pivot_;      /**< @ref IDIdx index associated to the chain */
-  index pairedColumn_;  /**< Represents the (F, G x H) partition of the columns.
+  ID_index pivot_;      /**< @ref IDIdx index associated to the chain */
+  Index pairedColumn_;  /**< Represents the (F, G x H) partition of the columns.
                              -1 if in F, @ref MatIdx of image of bijection otherwise. 
                              The pivot of a column in G will always be smaller than the pivot of its image in H. */
 };

--- a/src/Persistence_matrix/include/gudhi/Persistence_matrix/columns/column_dimension_holder.h
+++ b/src/Persistence_matrix/include/gudhi/Persistence_matrix/columns/column_dimension_holder.h
@@ -32,8 +32,8 @@ namespace persistence_matrix {
 struct Dummy_dimension_holder 
 {
   Dummy_dimension_holder() {}
-  template <typename dimension_type>
-  Dummy_dimension_holder([[maybe_unused]] dimension_type dim) {}
+  template <typename Dimension>
+  Dummy_dimension_holder([[maybe_unused]] Dimension dim) {}
 
   friend void swap([[maybe_unused]] Dummy_dimension_holder& col1, [[maybe_unused]] Dummy_dimension_holder& col2) {}
 };
@@ -49,7 +49,7 @@ struct Dummy_dimension_holder
 template <class Master_matrix>
 struct Column_dimension_holder 
 {
-  using dimension_type = typename Master_matrix::dimension_type;  /**< Dimension value type. */
+  using Dimension = typename Master_matrix::Dimension;  /**< Dimension value type. */
 
   /**
    * @brief Default constructor. Sets the dimension to 0 for @ref boundarymatrix "boundary matrices" and to -1 for @ref chainmatrix "chain matrices".
@@ -60,7 +60,7 @@ struct Column_dimension_holder
    * 
    * @param dim Dimension of the column.
    */
-  Column_dimension_holder(dimension_type dim) : dim_(dim) {}
+  Column_dimension_holder(Dimension dim) : dim_(dim) {}
   /**
    * @brief Copy constructor.
    * 
@@ -79,7 +79,7 @@ struct Column_dimension_holder
    * 
    * @return The dimension of the column.
    */
-  dimension_type get_dimension() const { return dim_; }
+  Dimension get_dimension() const { return dim_; }
 
   /**
    * @brief Assign operator.
@@ -97,7 +97,7 @@ struct Column_dimension_holder
   void swap_dimension(Column_dimension_holder& other) { std::swap(dim_, other.dim_); }
 
  private:
-  dimension_type dim_;  /**< Dimension of the column. */
+  Dimension dim_;  /**< Dimension of the column. */
 };
 
 }  // namespace persistence_matrix

--- a/src/Persistence_matrix/include/gudhi/Persistence_matrix/columns/column_utilities.h
+++ b/src/Persistence_matrix/include/gudhi/Persistence_matrix/columns/column_utilities.h
@@ -37,17 +37,17 @@ Cell* _get_cell(const Cell_iterator& itTarget)
 }
 
 // works only for ordered columns
-template <class Column_type, class Cell_iterator, typename F1, typename F2, typename F3, typename F4>
-void _generic_merge_cell_to_column(Column_type& targetColumn,
+template <class Column, class Cell_iterator, typename F1, typename F2, typename F3, typename F4>
+void _generic_merge_cell_to_column(Column& targetColumn,
                                    Cell_iterator& itSource,
-                                   typename Column_type::Column_type::iterator& itTarget,
+                                   typename Column::Column::iterator& itTarget,
                                    F1&& process_target,
                                    F2&& process_source,
                                    F3&& update_target1,
                                    F4&& update_target2,
                                    bool& pivotIsZeroed)
 {
-  typename Column_type::Cell* targetCell = _get_cell<typename Column_type::Cell>(itTarget);
+  typename Column::Cell* targetCell = _get_cell<typename Column::Cell>(itTarget);
 
   if (targetCell->get_row_index() < itSource->get_row_index()) {
     process_target(targetCell);
@@ -56,22 +56,22 @@ void _generic_merge_cell_to_column(Column_type& targetColumn,
     process_source(itSource, itTarget);
     ++itSource;
   } else {
-    if constexpr (Column_type::Master::Option_list::is_z2) {
+    if constexpr (Column::Master::Option_list::is_z2) {
       //_multiply_*_and_add never enters here so not treated
-      if constexpr (Column_type::Master::isNonBasic && !Column_type::Master::Option_list::is_of_boundary_type) {
+      if constexpr (Column::Master::isNonBasic && !Column::Master::Option_list::is_of_boundary_type) {
         if (targetCell->get_row_index() == targetColumn.get_pivot()) pivotIsZeroed = true;
       }
       targetColumn._delete_cell(itTarget);
     } else {
       update_target1(targetCell->get_element(), itSource);
-      if (targetCell->get_element() == Column_type::Field_operators::get_additive_identity()) {
-        if constexpr (Column_type::Master::isNonBasic && !Column_type::Master::Option_list::is_of_boundary_type) {
+      if (targetCell->get_element() == Column::Field_operators::get_additive_identity()) {
+        if constexpr (Column::Master::isNonBasic && !Column::Master::Option_list::is_of_boundary_type) {
           if (targetCell->get_row_index() == targetColumn.get_pivot()) pivotIsZeroed = true;
         }
         targetColumn._delete_cell(itTarget);
       } else {
         update_target2(targetCell);
-        if constexpr (Column_type::Master::Option_list::has_row_access)
+        if constexpr (Column::Master::Option_list::has_row_access)
           targetColumn.update_cell(*targetCell);
         ++itTarget;
       }
@@ -81,9 +81,9 @@ void _generic_merge_cell_to_column(Column_type& targetColumn,
 }
 
 // works only for ordered columns
-template <class Column_type, class Cell_range, typename F1, typename F2, typename F3, typename F4, typename F5>
+template <class Column, class Cell_range, typename F1, typename F2, typename F3, typename F4, typename F5>
 bool _generic_add_to_column(const Cell_range& source,
-                            Column_type& targetColumn,
+                            Column& targetColumn,
                             F1&& process_target,
                             F2&& process_source,
                             F3&& update_target1,
@@ -111,34 +111,34 @@ bool _generic_add_to_column(const Cell_range& source,
   return pivotIsZeroed;
 }
 
-template <class Column_type, class Cell_range>
-bool _add_to_column(const Cell_range& source, Column_type& targetColumn)
+template <class Column, class Cell_range>
+bool _add_to_column(const Cell_range& source, Column& targetColumn)
 {
   return _generic_add_to_column(
       source,
-      targetColumn, [&]([[maybe_unused]] typename Column_type::Cell* cellTarget) {},
-      [&](typename Cell_range::const_iterator& itSource, const typename Column_type::Column_type::iterator& itTarget) {
-        if constexpr (Column_type::Master::Option_list::is_z2) {
+      targetColumn, [&]([[maybe_unused]] typename Column::Cell* cellTarget) {},
+      [&](typename Cell_range::const_iterator& itSource, const typename Column::Column::iterator& itTarget) {
+        if constexpr (Column::Master::Option_list::is_z2) {
           targetColumn._insert_cell(itSource->get_row_index(), itTarget);
         } else {
           targetColumn._insert_cell(itSource->get_element(), itSource->get_row_index(), itTarget);
         }
       },
-      [&](typename Column_type::Field_element_type& targetElement, typename Cell_range::const_iterator& itSource) {
-        if constexpr (!Column_type::Master::Option_list::is_z2)
+      [&](typename Column::Field_element& targetElement, typename Cell_range::const_iterator& itSource) {
+        if constexpr (!Column::Master::Option_list::is_z2)
           targetColumn.operators_->add_inplace(targetElement, itSource->get_element());
       },
-      [&]([[maybe_unused]] typename Column_type::Cell* cellTarget) {},
-      [&]([[maybe_unused]] typename Column_type::Column_type::iterator& itTarget) {});
+      [&]([[maybe_unused]] typename Column::Cell* cellTarget) {},
+      [&]([[maybe_unused]] typename Column::Column::iterator& itTarget) {});
 }
 
-template <class Column_type, class Cell_range>
-bool _multiply_target_and_add_to_column(const typename Column_type::Field_element_type& val,
+template <class Column, class Cell_range>
+bool _multiply_target_and_add_to_column(const typename Column::Field_element& val,
                                         const Cell_range& source,
-                                        Column_type& targetColumn)
+                                        Column& targetColumn)
 {
   if (val == 0u) {
-    if constexpr (Column_type::Master::isNonBasic && !Column_type::Master::Option_list::is_of_boundary_type) {
+    if constexpr (Column::Master::isNonBasic && !Column::Master::Option_list::is_of_boundary_type) {
       throw std::invalid_argument("A chain column should not be multiplied by 0.");
       // this would not only mess up the base, but also the pivots stored.
     } else {
@@ -149,34 +149,34 @@ bool _multiply_target_and_add_to_column(const typename Column_type::Field_elemen
   return _generic_add_to_column(
       source,
       targetColumn,
-      [&](typename Column_type::Cell* cellTarget) {
+      [&](typename Column::Cell* cellTarget) {
         targetColumn.operators_->multiply_inplace(cellTarget->get_element(), val);
-        // targetColumn.ra_opt::update_cell(*itTarget) produces an internal compiler error
+        // targetColumn.RA_opt::update_cell(*itTarget) produces an internal compiler error
         // even though it works in _generic_add_to_column... Probably because of the lambda.
-        if constexpr (Column_type::Master::Option_list::has_row_access)
+        if constexpr (Column::Master::Option_list::has_row_access)
           targetColumn.update_cell(*cellTarget);
       },
-      [&](typename Cell_range::const_iterator& itSource, const typename Column_type::Column_type::iterator& itTarget) {
+      [&](typename Cell_range::const_iterator& itSource, const typename Column::Column::iterator& itTarget) {
         targetColumn._insert_cell(itSource->get_element(), itSource->get_row_index(), itTarget);
       },
-      [&](typename Column_type::Field_element_type& targetElement, typename Cell_range::const_iterator& itSource) {
+      [&](typename Column::Field_element& targetElement, typename Cell_range::const_iterator& itSource) {
         targetColumn.operators_->multiply_and_add_inplace_front(targetElement, val, itSource->get_element());
       },
-      [&]([[maybe_unused]] typename Column_type::Cell* cellTarget) {},
-      [&](typename Column_type::Column_type::iterator& itTarget) {
+      [&]([[maybe_unused]] typename Column::Cell* cellTarget) {},
+      [&](typename Column::Column::iterator& itTarget) {
         while (itTarget != targetColumn.column_.end()) {
-          typename Column_type::Cell* targetCell = _get_cell<typename Column_type::Cell>(itTarget);
+          typename Column::Cell* targetCell = _get_cell<typename Column::Cell>(itTarget);
           targetColumn.operators_->multiply_inplace(targetCell->get_element(), val);
-          if constexpr (Column_type::Master::Option_list::has_row_access)
+          if constexpr (Column::Master::Option_list::has_row_access)
             targetColumn.update_cell(*targetCell);
           itTarget++;
         }
       });
 }
 
-template <class Column_type, class Cell_range>
-bool _multiply_source_and_add_to_column(const typename Column_type::Field_element_type& val, const Cell_range& source,
-                                        Column_type& targetColumn)
+template <class Column, class Cell_range>
+bool _multiply_source_and_add_to_column(const typename Column::Field_element& val, const Cell_range& source,
+                                        Column& targetColumn)
 {
   if (val == 0u) {
     return false;
@@ -184,25 +184,25 @@ bool _multiply_source_and_add_to_column(const typename Column_type::Field_elemen
 
   return _generic_add_to_column(
       source,
-      targetColumn, []([[maybe_unused]] typename Column_type::Cell* cellTarget) {},
-      [&](typename Cell_range::const_iterator& itSource, const typename Column_type::Column_type::iterator& itTarget) {
-        typename Column_type::Cell* cell =
+      targetColumn, []([[maybe_unused]] typename Column::Cell* cellTarget) {},
+      [&](typename Cell_range::const_iterator& itSource, const typename Column::Column::iterator& itTarget) {
+        typename Column::Cell* cell =
             targetColumn._insert_cell(itSource->get_element(), itSource->get_row_index(), itTarget);
         targetColumn.operators_->multiply_inplace(cell->get_element(), val);
-        if constexpr (Column_type::Master::Option_list::has_row_access)
+        if constexpr (Column::Master::Option_list::has_row_access)
           targetColumn.update_cell(*cell);
       },
-      [&](typename Column_type::Field_element_type& targetElement, typename Cell_range::const_iterator& itSource) {
+      [&](typename Column::Field_element& targetElement, typename Cell_range::const_iterator& itSource) {
         targetColumn.operators_->multiply_and_add_inplace_back(itSource->get_element(), val, targetElement);
       },
-      [&]([[maybe_unused]] typename Column_type::Cell* cellTarget) {},
-      []([[maybe_unused]] typename Column_type::Column_type::iterator& itTarget) {});
+      [&]([[maybe_unused]] typename Column::Cell* cellTarget) {},
+      []([[maybe_unused]] typename Column::Column::iterator& itTarget) {});
 }
 
 // column has to be ordered (ie. not suited for unordered_map and heap) and contain the exact values
 // (ie. not suited for vector and heap). A same column but ordered differently will have another hash value.
-template <class Column_type>
-std::size_t hash_column(const Column_type& column) {
+template <class Column>
+std::size_t hash_column(const Column& column) {
   std::size_t seed = 0;
   for (auto& cell : column) {
     seed ^= std::hash<unsigned int>()(cell.get_row_index() * static_cast<unsigned int>(cell.get_element())) +

--- a/src/Persistence_matrix/include/gudhi/Persistence_matrix/columns/heap_column.h
+++ b/src/Persistence_matrix/include/gudhi/Persistence_matrix/columns/heap_column.h
@@ -42,75 +42,73 @@ namespace persistence_matrix {
  * into the heap of the target. Therefore the underlying vector can contain several cells with the same row index.
  * The real value of a cell at a row index corresponds to the sum in the coefficient field of all values with same
  * row index. Additionally, the given cell range added into the heap does not need to be somehow ordered.
- * 
+ *
  * @tparam Master_matrix An instantiation of @ref Matrix from which all types and options are deduced.
  * @tparam Cell_constructor Factory of @ref Cell classes.
  */
 template <class Master_matrix>
-class Heap_column : public Master_matrix::Column_dimension_option, public Master_matrix::Chain_column_option 
+class Heap_column : public Master_matrix::Column_dimension_option, public Master_matrix::Chain_column_option
 {
  public:
   using Master = Master_matrix;
-  using index = typename Master_matrix::index;
-  using id_index = typename Master_matrix::id_index;
-  using dimension_type = typename Master_matrix::dimension_type;
-  using Field_element_type = typename Master_matrix::element_type;
-  using Cell = typename Master_matrix::Cell_type;
+  using Index = typename Master_matrix::Index;
+  using ID_index = typename Master_matrix::ID_index;
+  using Dimension = typename Master_matrix::Dimension;
+  using Field_element = typename Master_matrix::Element;
+  using Cell = typename Master_matrix::Matrix_cell;
   using Column_settings = typename Master_matrix::Column_settings;
 
  private:
   using Field_operators = typename Master_matrix::Field_operators;
-  using Column_type = std::vector<Cell*>;
+  using Column = std::vector<Cell*>;
   using Cell_constructor = typename Master_matrix::Cell_constructor;
 
  public:
-  using iterator = boost::indirect_iterator<typename Column_type::iterator>;
-  using const_iterator = boost::indirect_iterator<typename Column_type::const_iterator>;
-  using reverse_iterator = boost::indirect_iterator<typename Column_type::reverse_iterator>;
-  using const_reverse_iterator = boost::indirect_iterator<typename Column_type::const_reverse_iterator>;
+  using iterator = boost::indirect_iterator<typename Column::iterator>;
+  using const_iterator = boost::indirect_iterator<typename Column::const_iterator>;
+  using reverse_iterator = boost::indirect_iterator<typename Column::reverse_iterator>;
+  using const_reverse_iterator = boost::indirect_iterator<typename Column::const_reverse_iterator>;
 
   Heap_column(Column_settings* colSettings = nullptr);
-  template <class Container_type = typename Master_matrix::boundary_type>
-  Heap_column(const Container_type& nonZeroRowIndices, Column_settings* colSettings);
-  template <class Container_type = typename Master_matrix::boundary_type>
-  Heap_column(const Container_type& nonZeroChainRowIndices, 
-              dimension_type dimension, 
-              Column_settings* colSettings);
+  template <class Container = typename Master_matrix::Boundary>
+  Heap_column(const Container& nonZeroRowIndices, Column_settings* colSettings);
+  template <class Container = typename Master_matrix::Boundary>
+  Heap_column(const Container& nonZeroChainRowIndices, Dimension dimension, Column_settings* colSettings);
   Heap_column(const Heap_column& column, Column_settings* colSettings = nullptr);
   Heap_column(Heap_column&& column) noexcept;
   ~Heap_column();
 
   // just for the sake of the interface
   // row containers and column index are ignored as row access is not implemented for heap columns
-  template <class Container_type = typename Master_matrix::boundary_type, class Row_container_type>
-  Heap_column(index columnIndex, 
-              const Container_type& nonZeroRowIndices, 
-              Row_container_type* rowContainer,
+  template <class Container = typename Master_matrix::Boundary, class Row_container>
+  Heap_column(Index columnIndex,
+              const Container& nonZeroRowIndices,
+              Row_container* rowContainer,
               Column_settings* colSettings);
-  template <class Container_type = typename Master_matrix::boundary_type, class Row_container_type>
-  Heap_column(index columnIndex, 
-              const Container_type& nonZeroChainRowIndices, 
-              dimension_type dimension,
-              Row_container_type* rowContainer, 
+  template <class Container = typename Master_matrix::Boundary, class Row_container>
+  Heap_column(Index columnIndex,
+              const Container& nonZeroChainRowIndices,
+              Dimension dimension,
+              Row_container* rowContainer,
               Column_settings* colSettings);
-  template <class Row_container_type>
-  Heap_column(const Heap_column& column, 
-              index columnIndex, 
-              Row_container_type* rowContainer,
+  template <class Row_container>
+  Heap_column(const Heap_column& column,
+              Index columnIndex,
+              Row_container* rowContainer,
               Column_settings* colSettings = nullptr);
 
-  std::vector<Field_element_type> get_content(int columnLength = -1) const;
-  bool is_non_zero(id_index rowIndex) const;
+  std::vector<Field_element> get_content(int columnLength = -1) const;
+  bool is_non_zero(ID_index rowIndex) const;
   bool is_empty();
   std::size_t size() const;
 
-  template <class Map_type>
-  void reorder(const Map_type& valueMap, [[maybe_unused]] index columnIndex = -1);
+  template <class Row_index_map>
+  void reorder(const Row_index_map& valueMap, [[maybe_unused]] Index columnIndex = -1);
   void clear();
-  void clear(id_index rowIndex);
+  void clear(ID_index rowIndex);
 
-  id_index get_pivot();
-  Field_element_type get_pivot_value();
+  ID_index get_pivot();
+  Field_element get_pivot_value();
 
   iterator begin() noexcept;
   const_iterator begin() const noexcept;
@@ -129,12 +127,12 @@ class Heap_column : public Master_matrix::Column_dimension_option, public Master
 
   // this = v * this + column
   template <class Cell_range>
-  Heap_column& multiply_target_and_add(const Field_element_type& val, const Cell_range& column);
-  Heap_column& multiply_target_and_add(const Field_element_type& val, Heap_column& column);
+  Heap_column& multiply_target_and_add(const Field_element& val, const Cell_range& column);
+  Heap_column& multiply_target_and_add(const Field_element& val, Heap_column& column);
   // this = this + column * v
   template <class Cell_range>
-  Heap_column& multiply_source_and_add(const Cell_range& column, const Field_element_type& val);
-  Heap_column& multiply_source_and_add(Heap_column& column, const Field_element_type& val);
+  Heap_column& multiply_source_and_add(const Cell_range& column, const Field_element& val);
+  Heap_column& multiply_source_and_add(Heap_column& column, const Field_element& val);
 
   std::size_t compute_hash_value();
 
@@ -150,7 +148,7 @@ class Heap_column : public Master_matrix::Column_dimension_option, public Master
         c2.cellPool_->destroy(p2);
         return false;
       }
-      if constexpr (!Master_matrix::Option_list::is_z2){
+      if constexpr (!Master_matrix::Option_list::is_z2) {
         if (p1->get_element() != p2->get_element()) {
           c1.cellPool_->destroy(p1);
           c2.cellPool_->destroy(p2);
@@ -174,7 +172,7 @@ class Heap_column : public Master_matrix::Column_dimension_option, public Master
   friend bool operator<(const Heap_column& c1, const Heap_column& c2) {
     if (&c1 == &c2) return false;
 
-    //lexicographical order but starting from last value and not first
+    // lexicographical order but starting from last value and not first
     Heap_column cc1(c1), cc2(c2);
     Cell* p1 = cc1._pop_pivot();
     Cell* p2 = cc2._pop_pivot();
@@ -189,7 +187,7 @@ class Heap_column : public Master_matrix::Column_dimension_option, public Master
         c2.cellPool_->destroy(p2);
         return true;
       }
-      if constexpr (!Master_matrix::Option_list::is_z2){
+      if constexpr (!Master_matrix::Option_list::is_z2) {
         if (p1->get_element() > p2->get_element()) {
           c1.cellPool_->destroy(p1);
           c2.cellPool_->destroy(p2);
@@ -230,14 +228,14 @@ class Heap_column : public Master_matrix::Column_dimension_option, public Master
   }
 
  private:
-  using dim_opt = typename Master_matrix::Column_dimension_option;
-  using chain_opt = typename Master_matrix::Chain_column_option;
+  using Dim_opt = typename Master_matrix::Column_dimension_option;
+  using Chain_opt = typename Master_matrix::Chain_column_option;
 
   struct CellPointerComp {
     bool operator()(const Cell* c1, const Cell* c2) const { return *c1 < *c2; }
   } cellPointerComp_;
 
-  Column_type column_;
+  Column column_;
   unsigned int insertsSinceLastPrune_;
   Field_operators* operators_;
   Cell_constructor* cellPool_;
@@ -247,15 +245,15 @@ class Heap_column : public Master_matrix::Column_dimension_option, public Master
   template <class Cell_range>
   bool _add(const Cell_range& column);
   template <class Cell_range>
-  bool _multiply_target_and_add(const Field_element_type& val, const Cell_range& column);
+  bool _multiply_target_and_add(const Field_element& val, const Cell_range& column);
   template <class Cell_range>
-  bool _multiply_source_and_add(const Cell_range& column, const Field_element_type& val);
+  bool _multiply_source_and_add(const Cell_range& column, const Field_element& val);
 };
 
 template <class Master_matrix>
 inline Heap_column<Master_matrix>::Heap_column(Column_settings* colSettings)
-    : dim_opt(),
-      chain_opt(),
+    : Dim_opt(),
+      Chain_opt(),
       insertsSinceLastPrune_(0),
       operators_(nullptr),
       cellPool_(colSettings == nullptr ? nullptr : &(colSettings->cellConstructor))
@@ -268,25 +266,25 @@ inline Heap_column<Master_matrix>::Heap_column(Column_settings* colSettings)
 }
 
 template <class Master_matrix>
-template <class Container_type>
-inline Heap_column<Master_matrix>::Heap_column(const Container_type& nonZeroRowIndices, Column_settings* colSettings)
-    : dim_opt(nonZeroRowIndices.size() == 0 ? 0 : nonZeroRowIndices.size() - 1),
-      chain_opt(),
+template <class Container>
+inline Heap_column<Master_matrix>::Heap_column(const Container& nonZeroRowIndices, Column_settings* colSettings)
+    : Dim_opt(nonZeroRowIndices.size() == 0 ? 0 : nonZeroRowIndices.size() - 1),
+      Chain_opt(),
       column_(nonZeroRowIndices.size(), nullptr),
       insertsSinceLastPrune_(0),
       operators_(nullptr),
-      cellPool_(&(colSettings->cellConstructor)) 
+      cellPool_(&(colSettings->cellConstructor))
 {
   static_assert(!Master_matrix::isNonBasic || Master_matrix::Option_list::is_of_boundary_type,
                 "Constructor not available for chain columns, please specify the dimension of the chain.");
 
-  if constexpr (!Master_matrix::Option_list::is_z2){
+  if constexpr (!Master_matrix::Option_list::is_z2) {
     operators_ = &(colSettings->operators);
   }
 
-  index i = 0;
+  Index i = 0;
   if constexpr (Master_matrix::Option_list::is_z2) {
-    for (id_index id : nonZeroRowIndices) {
+    for (ID_index id : nonZeroRowIndices) {
       column_[i++] = cellPool_->construct(id);
     }
   } else {
@@ -299,12 +297,12 @@ inline Heap_column<Master_matrix>::Heap_column(const Container_type& nonZeroRowI
 }
 
 template <class Master_matrix>
-template <class Container_type>
-inline Heap_column<Master_matrix>::Heap_column(const Container_type& nonZeroRowIndices,
-                                                                 dimension_type dimension, 
-                                                                 Column_settings* colSettings)
-    : dim_opt(dimension),
-      chain_opt([&] {
+template <class Container>
+inline Heap_column<Master_matrix>::Heap_column(const Container& nonZeroRowIndices,
+                                               Dimension dimension,
+                                               Column_settings* colSettings)
+    : Dim_opt(dimension),
+      Chain_opt([&] {
         if constexpr (Master_matrix::Option_list::is_z2) {
           return nonZeroRowIndices.begin() == nonZeroRowIndices.end() ? -1 : *std::prev(nonZeroRowIndices.end());
         } else {
@@ -316,9 +314,9 @@ inline Heap_column<Master_matrix>::Heap_column(const Container_type& nonZeroRowI
       operators_(nullptr),
       cellPool_(&(colSettings->cellConstructor))
 {
-  index i = 0;
+  Index i = 0;
   if constexpr (Master_matrix::Option_list::is_z2) {
-    for (id_index id : nonZeroRowIndices) {
+    for (ID_index id : nonZeroRowIndices) {
       column_[i++] = cellPool_->construct(id);
     }
   } else {
@@ -332,10 +330,9 @@ inline Heap_column<Master_matrix>::Heap_column(const Container_type& nonZeroRowI
 }
 
 template <class Master_matrix>
-inline Heap_column<Master_matrix>::Heap_column(const Heap_column& column, 
-                                                                 Column_settings* colSettings)
-    : dim_opt(static_cast<const dim_opt&>(column)),
-      chain_opt(static_cast<const chain_opt&>(column)),
+inline Heap_column<Master_matrix>::Heap_column(const Heap_column& column, Column_settings* colSettings)
+    : Dim_opt(static_cast<const Dim_opt&>(column)),
+      Chain_opt(static_cast<const Chain_opt&>(column)),
       column_(column.column_.size(), nullptr),
       insertsSinceLastPrune_(0),
       operators_(colSettings == nullptr ? column.operators_ : nullptr),
@@ -345,11 +342,11 @@ inline Heap_column<Master_matrix>::Heap_column(const Heap_column& column,
                 "Simple copy constructor not available when row access option enabled. Please specify the new column "
                 "index and the row container.");
 
-  if constexpr (!Master_matrix::Option_list::is_z2){
+  if constexpr (!Master_matrix::Option_list::is_z2) {
     if (colSettings != nullptr) operators_ = &(colSettings->operators);
   }
 
-  index i = 0;
+  Index i = 0;
   for (const Cell* cell : column.column_) {
     if constexpr (Master_matrix::Option_list::is_z2) {
       column_[i++] = cellPool_->construct(cell->get_row_index());
@@ -363,22 +360,22 @@ inline Heap_column<Master_matrix>::Heap_column(const Heap_column& column,
 
 template <class Master_matrix>
 inline Heap_column<Master_matrix>::Heap_column(Heap_column&& column) noexcept
-    : dim_opt(std::move(static_cast<dim_opt&>(column))),
-      chain_opt(std::move(static_cast<chain_opt&>(column))),
+    : Dim_opt(std::move(static_cast<Dim_opt&>(column))),
+      Chain_opt(std::move(static_cast<Chain_opt&>(column))),
       column_(std::move(column.column_)),
       insertsSinceLastPrune_(std::exchange(column.insertsSinceLastPrune_, 0)),
       operators_(std::exchange(column.operators_, nullptr)),
-      cellPool_(std::exchange(column.cellPool_, nullptr)) 
+      cellPool_(std::exchange(column.cellPool_, nullptr))
 {}
 
 template <class Master_matrix>
-template <class Container_type, class Row_container_type>
-inline Heap_column<Master_matrix>::Heap_column(index columnIndex,
-                                               const Container_type& nonZeroRowIndices,
-                                               Row_container_type* rowContainer,
+template <class Container, class Row_container>
+inline Heap_column<Master_matrix>::Heap_column(Index columnIndex,
+                                               const Container& nonZeroRowIndices,
+                                               Row_container* rowContainer,
                                                Column_settings* colSettings)
-    : dim_opt(nonZeroRowIndices.size() == 0 ? 0 : nonZeroRowIndices.size() - 1),
-      chain_opt([&] {
+    : Dim_opt(nonZeroRowIndices.size() == 0 ? 0 : nonZeroRowIndices.size() - 1),
+      Chain_opt([&] {
         if constexpr (Master_matrix::Option_list::is_z2) {
           return nonZeroRowIndices.begin() == nonZeroRowIndices.end() ? -1 : *std::prev(nonZeroRowIndices.end());
         } else {
@@ -393,9 +390,9 @@ inline Heap_column<Master_matrix>::Heap_column(index columnIndex,
   static_assert(!Master_matrix::isNonBasic || Master_matrix::Option_list::is_of_boundary_type,
                 "Constructor not available for chain columns, please specify the dimension of the chain.");
 
-  index i = 0;
+  Index i = 0;
   if constexpr (Master_matrix::Option_list::is_z2) {
-    for (id_index id : nonZeroRowIndices) {
+    for (ID_index id : nonZeroRowIndices) {
       column_[i++] = cellPool_->construct(id);
     }
   } else {
@@ -409,15 +406,14 @@ inline Heap_column<Master_matrix>::Heap_column(index columnIndex,
 }
 
 template <class Master_matrix>
-template <class Container_type, class Row_container_type>
-inline Heap_column<Master_matrix>::Heap_column(
-    index columnIndex, 
-    const Container_type& nonZeroRowIndices, 
-    dimension_type dimension,
-    Row_container_type* rowContainer, 
-    Column_settings* colSettings)
-    : dim_opt(dimension),
-      chain_opt([&] {
+template <class Container, class Row_container>
+inline Heap_column<Master_matrix>::Heap_column(Index columnIndex,
+                                               const Container& nonZeroRowIndices,
+                                               Dimension dimension,
+                                               Row_container* rowContainer,
+                                               Column_settings* colSettings)
+    : Dim_opt(dimension),
+      Chain_opt([&] {
         if constexpr (Master_matrix::Option_list::is_z2) {
           return nonZeroRowIndices.begin() == nonZeroRowIndices.end() ? -1 : *std::prev(nonZeroRowIndices.end());
         } else {
@@ -429,9 +425,9 @@ inline Heap_column<Master_matrix>::Heap_column(
       operators_(nullptr),
       cellPool_(&(colSettings->cellConstructor))
 {
-  index i = 0;
+  Index i = 0;
   if constexpr (Master_matrix::Option_list::is_z2) {
-    for (id_index id : nonZeroRowIndices) {
+    for (ID_index id : nonZeroRowIndices) {
       column_[i++] = cellPool_->construct(id);
     }
   } else {
@@ -445,23 +441,23 @@ inline Heap_column<Master_matrix>::Heap_column(
 }
 
 template <class Master_matrix>
-template <class Row_container_type>
+template <class Row_container>
 inline Heap_column<Master_matrix>::Heap_column(const Heap_column& column,
-                                               index columnIndex,
-                                               Row_container_type* rowContainer,
+                                               Index columnIndex,
+                                               Row_container* rowContainer,
                                                Column_settings* colSettings)
-    : dim_opt(static_cast<const dim_opt&>(column)),
-      chain_opt(static_cast<const chain_opt&>(column)),
+    : Dim_opt(static_cast<const Dim_opt&>(column)),
+      Chain_opt(static_cast<const Chain_opt&>(column)),
       column_(column.column_.size(), nullptr),
       insertsSinceLastPrune_(0),
       operators_(colSettings == nullptr ? column.operators_ : nullptr),
-      cellPool_(colSettings == nullptr ? column.cellPool_ : &(colSettings->cellConstructor)) 
+      cellPool_(colSettings == nullptr ? column.cellPool_ : &(colSettings->cellConstructor))
 {
-  if constexpr (!Master_matrix::Option_list::is_z2){
+  if constexpr (!Master_matrix::Option_list::is_z2) {
     if (colSettings != nullptr) operators_ = &(colSettings->operators);
   }
 
-  index i = 0;
+  Index i = 0;
   for (const Cell* cell : column.column_) {
     if constexpr (Master_matrix::Option_list::is_z2) {
       column_[i++] = cellPool_->construct(cell->get_row_index());
@@ -474,7 +470,7 @@ inline Heap_column<Master_matrix>::Heap_column(const Heap_column& column,
 }
 
 template <class Master_matrix>
-inline Heap_column<Master_matrix>::~Heap_column() 
+inline Heap_column<Master_matrix>::~Heap_column()
 {
   for (auto* cell : column_) {
     cellPool_->destroy(cell);
@@ -482,18 +478,18 @@ inline Heap_column<Master_matrix>::~Heap_column()
 }
 
 template <class Master_matrix>
-inline std::vector<typename Heap_column<Master_matrix>::Field_element_type>
-Heap_column<Master_matrix>::get_content(int columnLength) const 
+inline std::vector<typename Heap_column<Master_matrix>::Field_element> Heap_column<Master_matrix>::get_content(
+    int columnLength) const
 {
   bool pivotLength = (columnLength < 0);
   if (columnLength < 0 && column_.size() > 0)
     columnLength = column_.front()->get_row_index() + 1;
   else if (columnLength < 0)
-    return std::vector<Field_element_type>();
+    return std::vector<Field_element>();
 
-  std::vector<Field_element_type> container(columnLength, 0);
+  std::vector<Field_element> container(columnLength, 0);
   for (auto it = column_.begin(); it != column_.end(); ++it) {
-    if ((*it)->get_row_index() < static_cast<id_index>(columnLength)) {
+    if ((*it)->get_row_index() < static_cast<ID_index>(columnLength)) {
       if constexpr (Master_matrix::Option_list::is_z2) {
         container[(*it)->get_row_index()] = !container[(*it)->get_row_index()];
       } else {
@@ -510,20 +506,22 @@ Heap_column<Master_matrix>::get_content(int columnLength) const
 }
 
 template <class Master_matrix>
-inline bool Heap_column<Master_matrix>::is_non_zero(id_index rowIndex) const 
+inline bool Heap_column<Master_matrix>::is_non_zero(ID_index rowIndex) const
 {
-  Field_element_type c(0);
+  Field_element c(0);
   for (const Cell* cell : column_) {
     if (cell->get_row_index() == rowIndex) {
-      if constexpr (Master_matrix::Option_list::is_z2) c = !c;
-      else operators_->add_inplace(c, cell->get_element());
+      if constexpr (Master_matrix::Option_list::is_z2)
+        c = !c;
+      else
+        operators_->add_inplace(c, cell->get_element());
     }
   }
   return c != Field_operators::get_additive_identity();
 }
 
 template <class Master_matrix>
-inline bool Heap_column<Master_matrix>::is_empty() 
+inline bool Heap_column<Master_matrix>::is_empty()
 {
   Cell* pivot = _pop_pivot();
   if (pivot != nullptr) {
@@ -535,20 +533,19 @@ inline bool Heap_column<Master_matrix>::is_empty()
 }
 
 template <class Master_matrix>
-inline std::size_t Heap_column<Master_matrix>::size() const 
+inline std::size_t Heap_column<Master_matrix>::size() const
 {
   return column_.size();
 }
 
 template <class Master_matrix>
-template <class Map_type>
-inline void Heap_column<Master_matrix>::reorder(const Map_type& valueMap,
-                                                                  [[maybe_unused]] index columnIndex) 
+template <class Row_index_map>
+inline void Heap_column<Master_matrix>::reorder(const Row_index_map& valueMap, [[maybe_unused]] Index columnIndex)
 {
   static_assert(!Master_matrix::isNonBasic || Master_matrix::Option_list::is_of_boundary_type,
                 "Method not available for chain columns.");
 
-  Column_type tempCol;
+  Column tempCol;
   Cell* pivot = _pop_pivot();
   while (pivot != nullptr) {
     pivot->set_row_index(valueMap.at(pivot->get_row_index()));
@@ -562,7 +559,7 @@ inline void Heap_column<Master_matrix>::reorder(const Map_type& valueMap,
 }
 
 template <class Master_matrix>
-inline void Heap_column<Master_matrix>::clear() 
+inline void Heap_column<Master_matrix>::clear()
 {
   static_assert(!Master_matrix::isNonBasic || Master_matrix::Option_list::is_of_boundary_type,
                 "Method not available for chain columns as a base element should not be empty.");
@@ -576,15 +573,15 @@ inline void Heap_column<Master_matrix>::clear()
 }
 
 template <class Master_matrix>
-inline void Heap_column<Master_matrix>::clear(id_index rowIndex) 
+inline void Heap_column<Master_matrix>::clear(ID_index rowIndex)
 {
   static_assert(!Master_matrix::isNonBasic || Master_matrix::Option_list::is_of_boundary_type,
                 "Method not available for chain columns.");
 
-  Column_type tempCol;
+  Column tempCol;
   Cell* pivot = _pop_pivot();
   while (pivot != nullptr) {
-    if (pivot->get_row_index() != rowIndex){
+    if (pivot->get_row_index() != rowIndex) {
       tempCol.push_back(pivot);
     } else {
       cellPool_->destroy(pivot);
@@ -597,8 +594,7 @@ inline void Heap_column<Master_matrix>::clear(id_index rowIndex)
 }
 
 template <class Master_matrix>
-inline typename Heap_column<Master_matrix>::id_index
-Heap_column<Master_matrix>::get_pivot() 
+inline typename Heap_column<Master_matrix>::ID_index Heap_column<Master_matrix>::get_pivot()
 {
   static_assert(Master_matrix::isNonBasic,
                 "Method not available for base columns.");  // could technically be, but is the notion useful then?
@@ -612,13 +608,12 @@ Heap_column<Master_matrix>::get_pivot()
     }
     return -1;
   } else {
-    return chain_opt::get_pivot();
+    return Chain_opt::get_pivot();
   }
 }
 
 template <class Master_matrix>
-inline typename Heap_column<Master_matrix>::Field_element_type
-Heap_column<Master_matrix>::get_pivot_value() 
+inline typename Heap_column<Master_matrix>::Field_element Heap_column<Master_matrix>::get_pivot_value()
 {
   static_assert(Master_matrix::isNonBasic,
                 "Method not available for base columns.");  // could technically be, but is the notion useful then?
@@ -635,10 +630,10 @@ Heap_column<Master_matrix>::get_pivot_value()
       }
       return 0;
     } else {
-      Field_element_type sum(0);
-      if (chain_opt::get_pivot() == static_cast<id_index>(-1)) return sum;
+      Field_element sum(0);
+      if (Chain_opt::get_pivot() == static_cast<ID_index>(-1)) return sum;
       for (const Cell* cell : column_) {
-        if (cell->get_row_index() == chain_opt::get_pivot()) operators_->add_inplace(sum, cell->get_element());
+        if (cell->get_row_index() == Chain_opt::get_pivot()) operators_->add_inplace(sum, cell->get_element());
       }
       return sum;  // should not be 0 if properly used.
     }
@@ -646,64 +641,56 @@ Heap_column<Master_matrix>::get_pivot_value()
 }
 
 template <class Master_matrix>
-inline typename Heap_column<Master_matrix>::iterator
-Heap_column<Master_matrix>::begin() noexcept 
+inline typename Heap_column<Master_matrix>::iterator Heap_column<Master_matrix>::begin() noexcept
 {
   return column_.begin();
 }
 
 template <class Master_matrix>
-inline typename Heap_column<Master_matrix>::const_iterator
-Heap_column<Master_matrix>::begin() const noexcept 
+inline typename Heap_column<Master_matrix>::const_iterator Heap_column<Master_matrix>::begin() const noexcept
 {
   return column_.begin();
 }
 
 template <class Master_matrix>
-inline typename Heap_column<Master_matrix>::iterator
-Heap_column<Master_matrix>::end() noexcept 
+inline typename Heap_column<Master_matrix>::iterator Heap_column<Master_matrix>::end() noexcept
 {
   return column_.end();
 }
 
 template <class Master_matrix>
-inline typename Heap_column<Master_matrix>::const_iterator
-Heap_column<Master_matrix>::end() const noexcept 
+inline typename Heap_column<Master_matrix>::const_iterator Heap_column<Master_matrix>::end() const noexcept
 {
   return column_.end();
 }
 
 template <class Master_matrix>
-inline typename Heap_column<Master_matrix>::reverse_iterator
-Heap_column<Master_matrix>::rbegin() noexcept 
+inline typename Heap_column<Master_matrix>::reverse_iterator Heap_column<Master_matrix>::rbegin() noexcept
 {
   return column_.rbegin();
 }
 
 template <class Master_matrix>
-inline typename Heap_column<Master_matrix>::const_reverse_iterator
-Heap_column<Master_matrix>::rbegin() const noexcept 
+inline typename Heap_column<Master_matrix>::const_reverse_iterator Heap_column<Master_matrix>::rbegin() const noexcept
 {
   return column_.rbegin();
 }
 
 template <class Master_matrix>
-inline typename Heap_column<Master_matrix>::reverse_iterator
-Heap_column<Master_matrix>::rend() noexcept 
+inline typename Heap_column<Master_matrix>::reverse_iterator Heap_column<Master_matrix>::rend() noexcept
 {
   return column_.rend();
 }
 
 template <class Master_matrix>
-inline typename Heap_column<Master_matrix>::const_reverse_iterator
-Heap_column<Master_matrix>::rend() const noexcept 
+inline typename Heap_column<Master_matrix>::const_reverse_iterator Heap_column<Master_matrix>::rend() const noexcept
 {
   return column_.rend();
 }
 
 template <class Master_matrix>
 template <class Cell_range>
-inline Heap_column<Master_matrix>& Heap_column<Master_matrix>::operator+=(const Cell_range& column) 
+inline Heap_column<Master_matrix>& Heap_column<Master_matrix>::operator+=(const Cell_range& column)
 {
   static_assert((!Master_matrix::isNonBasic || std::is_same_v<Cell_range, Heap_column>),
                 "For boundary columns, the range has to be a column of same type to help ensure the validity of the "
@@ -717,13 +704,13 @@ inline Heap_column<Master_matrix>& Heap_column<Master_matrix>::operator+=(const 
 }
 
 template <class Master_matrix>
-inline Heap_column<Master_matrix>& Heap_column<Master_matrix>::operator+=(Heap_column& column) 
+inline Heap_column<Master_matrix>& Heap_column<Master_matrix>::operator+=(Heap_column& column)
 {
   if constexpr (Master_matrix::isNonBasic && !Master_matrix::Option_list::is_of_boundary_type) {
     // assumes that the addition never zeros out this column.
     if (_add(column)) {
-      chain_opt::swap_pivots(column);
-      dim_opt::swap_dimension(column);
+      Chain_opt::swap_pivots(column);
+      Dim_opt::swap_dimension(column);
     }
   } else {
     _add(column);
@@ -733,7 +720,7 @@ inline Heap_column<Master_matrix>& Heap_column<Master_matrix>::operator+=(Heap_c
 }
 
 template <class Master_matrix>
-inline Heap_column<Master_matrix>& Heap_column<Master_matrix>::operator*=(unsigned int v) 
+inline Heap_column<Master_matrix>& Heap_column<Master_matrix>::operator*=(unsigned int v)
 {
   if constexpr (Master_matrix::Option_list::is_z2) {
     if (v % 2 == 0) {
@@ -744,7 +731,7 @@ inline Heap_column<Master_matrix>& Heap_column<Master_matrix>::operator*=(unsign
       }
     }
   } else {
-    Field_element_type val = operators_->get_value(v);
+    Field_element val = operators_->get_value(v);
 
     if (val == Field_operators::get_additive_identity()) {
       if constexpr (Master_matrix::isNonBasic && !Master_matrix::Option_list::is_of_boundary_type) {
@@ -767,8 +754,8 @@ inline Heap_column<Master_matrix>& Heap_column<Master_matrix>::operator*=(unsign
 
 template <class Master_matrix>
 template <class Cell_range>
-inline Heap_column<Master_matrix>& Heap_column<Master_matrix>::multiply_target_and_add(
-    const Field_element_type& val, const Cell_range& column) 
+inline Heap_column<Master_matrix>& Heap_column<Master_matrix>::multiply_target_and_add(const Field_element& val,
+                                                                                       const Cell_range& column)
 {
   static_assert((!Master_matrix::isNonBasic || std::is_same_v<Cell_range, Heap_column>),
                 "For boundary columns, the range has to be a column of same type to help ensure the validity of the "
@@ -791,24 +778,24 @@ inline Heap_column<Master_matrix>& Heap_column<Master_matrix>::multiply_target_a
 }
 
 template <class Master_matrix>
-inline Heap_column<Master_matrix>& Heap_column<Master_matrix>::multiply_target_and_add(
-    const Field_element_type& val, Heap_column& column) 
+inline Heap_column<Master_matrix>& Heap_column<Master_matrix>::multiply_target_and_add(const Field_element& val,
+                                                                                       Heap_column& column)
 {
   if constexpr (Master_matrix::isNonBasic && !Master_matrix::Option_list::is_of_boundary_type) {
     // assumes that the addition never zeros out this column.
     if constexpr (Master_matrix::Option_list::is_z2) {
       if (val) {
         if (_add(column)) {
-          chain_opt::swap_pivots(column);
-          dim_opt::swap_dimension(column);
+          Chain_opt::swap_pivots(column);
+          Dim_opt::swap_dimension(column);
         }
       } else {
         throw std::invalid_argument("A chain column should not be multiplied by 0.");
       }
     } else {
       if (_multiply_target_and_add(val, column)) {
-        chain_opt::swap_pivots(column);
-        dim_opt::swap_dimension(column);
+        Chain_opt::swap_pivots(column);
+        Dim_opt::swap_dimension(column);
       }
     }
   } else {
@@ -829,8 +816,8 @@ inline Heap_column<Master_matrix>& Heap_column<Master_matrix>::multiply_target_a
 
 template <class Master_matrix>
 template <class Cell_range>
-inline Heap_column<Master_matrix>& Heap_column<Master_matrix>::multiply_source_and_add(
-    const Cell_range& column, const Field_element_type& val) 
+inline Heap_column<Master_matrix>& Heap_column<Master_matrix>::multiply_source_and_add(const Cell_range& column,
+                                                                                       const Field_element& val)
 {
   static_assert((!Master_matrix::isNonBasic || std::is_same_v<Cell_range, Heap_column>),
                 "For boundary columns, the range has to be a column of same type to help ensure the validity of the "
@@ -850,22 +837,22 @@ inline Heap_column<Master_matrix>& Heap_column<Master_matrix>::multiply_source_a
 }
 
 template <class Master_matrix>
-inline Heap_column<Master_matrix>& Heap_column<Master_matrix>::multiply_source_and_add(
-    Heap_column& column, const Field_element_type& val) 
+inline Heap_column<Master_matrix>& Heap_column<Master_matrix>::multiply_source_and_add(Heap_column& column,
+                                                                                       const Field_element& val)
 {
   if constexpr (Master_matrix::isNonBasic && !Master_matrix::Option_list::is_of_boundary_type) {
     // assumes that the addition never zeros out this column.
     if constexpr (Master_matrix::Option_list::is_z2) {
       if (val) {
         if (_add(column)) {
-          chain_opt::swap_pivots(column);
-          dim_opt::swap_dimension(column);
+          Chain_opt::swap_pivots(column);
+          Dim_opt::swap_dimension(column);
         }
       }
     } else {
       if (_multiply_source_and_add(column, val)) {
-        chain_opt::swap_pivots(column);
-        dim_opt::swap_dimension(column);
+        Chain_opt::swap_pivots(column);
+        Dim_opt::swap_dimension(column);
       }
     }
   } else {
@@ -882,12 +869,12 @@ inline Heap_column<Master_matrix>& Heap_column<Master_matrix>::multiply_source_a
 }
 
 template <class Master_matrix>
-inline Heap_column<Master_matrix>& Heap_column<Master_matrix>::operator=(const Heap_column& other) 
+inline Heap_column<Master_matrix>& Heap_column<Master_matrix>::operator=(const Heap_column& other)
 {
   static_assert(!Master_matrix::Option_list::has_row_access, "= assignment not enabled with row access option.");
 
-  dim_opt::operator=(other);
-  chain_opt::operator=(other);
+  Dim_opt::operator=(other);
+  Chain_opt::operator=(other);
 
   while (column_.size() > other.column_.size()) {
     if (column_.back() != nullptr) cellPool_->destroy(column_.back());
@@ -895,7 +882,7 @@ inline Heap_column<Master_matrix>& Heap_column<Master_matrix>::operator=(const H
   }
 
   column_.resize(other.column_.size(), nullptr);
-  index i = 0;
+  Index i = 0;
   for (const Cell* cell : other.column_) {
     if (column_[i] != nullptr) {
       cellPool_->destroy(column_[i]);
@@ -921,11 +908,11 @@ inline std::size_t Heap_column<Master_matrix>::compute_hash_value()
 }
 
 template <class Master_matrix>
-inline void Heap_column<Master_matrix>::_prune() 
+inline void Heap_column<Master_matrix>::_prune()
 {
   if (insertsSinceLastPrune_ == 0) return;
 
-  Column_type tempCol;
+  Column tempCol;
   Cell* pivot = _pop_pivot();
   while (pivot != nullptr) {
     tempCol.push_back(pivot);
@@ -937,8 +924,7 @@ inline void Heap_column<Master_matrix>::_prune()
 }
 
 template <class Master_matrix>
-inline typename Heap_column<Master_matrix>::Cell*
-Heap_column<Master_matrix>::_pop_pivot() 
+inline typename Heap_column<Master_matrix>::Cell* Heap_column<Master_matrix>::_pop_pivot()
 {
   if (column_.empty()) {
     return nullptr;
@@ -980,12 +966,12 @@ Heap_column<Master_matrix>::_pop_pivot()
 
 template <class Master_matrix>
 template <class Cell_range>
-inline bool Heap_column<Master_matrix>::_add(const Cell_range& column) 
+inline bool Heap_column<Master_matrix>::_add(const Cell_range& column)
 {
   if (column.begin() == column.end()) return false;
   if (column_.empty()) {  // chain should never enter here.
     column_.resize(column.size());
-    index i = 0;
+    Index i = 0;
     for (const Cell& cell : column) {
       column_[i] = cellPool_->construct(cell.get_row_index());
       if constexpr (!Master_matrix::Option_list::is_z2) {
@@ -997,7 +983,7 @@ inline bool Heap_column<Master_matrix>::_add(const Cell_range& column)
     return true;
   }
 
-  Field_element_type pivotVal(1);
+  Field_element pivotVal(1);
 
   if constexpr (Master_matrix::isNonBasic && !Master_matrix::Option_list::is_of_boundary_type)
     pivotVal = get_pivot_value();
@@ -1006,12 +992,12 @@ inline bool Heap_column<Master_matrix>::_add(const Cell_range& column)
     ++insertsSinceLastPrune_;
     if constexpr (Master_matrix::Option_list::is_z2) {
       if constexpr (Master_matrix::isNonBasic && !Master_matrix::Option_list::is_of_boundary_type) {
-        if (cell.get_row_index() == chain_opt::get_pivot()) pivotVal = !pivotVal;
+        if (cell.get_row_index() == Chain_opt::get_pivot()) pivotVal = !pivotVal;
       }
       column_.push_back(cellPool_->construct(cell.get_row_index()));
     } else {
       if constexpr (Master_matrix::isNonBasic && !Master_matrix::Option_list::is_of_boundary_type) {
-        if (cell.get_row_index() == chain_opt::get_pivot()) operators_->add_inplace(pivotVal, cell.get_element());
+        if (cell.get_row_index() == Chain_opt::get_pivot()) operators_->add_inplace(pivotVal, cell.get_element());
       }
       column_.push_back(cellPool_->construct(cell.get_row_index()));
       column_.back()->set_element(cell.get_element());
@@ -1023,14 +1009,13 @@ inline bool Heap_column<Master_matrix>::_add(const Cell_range& column)
 
   if constexpr (Master_matrix::Option_list::is_z2)
     return !pivotVal;
-  else 
+  else
     return pivotVal == Field_operators::get_additive_identity();
 }
 
 template <class Master_matrix>
 template <class Cell_range>
-inline bool Heap_column<Master_matrix>::_multiply_target_and_add(const Field_element_type& val,
-                                                                 const Cell_range& column) 
+inline bool Heap_column<Master_matrix>::_multiply_target_and_add(const Field_element& val, const Cell_range& column)
 {
   if (val == 0u) {
     if constexpr (Master_matrix::isNonBasic && !Master_matrix::Option_list::is_of_boundary_type) {
@@ -1042,7 +1027,7 @@ inline bool Heap_column<Master_matrix>::_multiply_target_and_add(const Field_ele
   }
   if (column_.empty()) {  // chain should never enter here.
     column_.resize(column.size());
-    index i = 0;
+    Index i = 0;
     for (const Cell& cell : column) {
       column_[i] = cellPool_->construct(cell.get_row_index());
       column_[i++]->set_element(cell.get_element());
@@ -1051,19 +1036,19 @@ inline bool Heap_column<Master_matrix>::_multiply_target_and_add(const Field_ele
     return true;
   }
 
-  Field_element_type pivotVal(0);
+  Field_element pivotVal(0);
 
   for (Cell* cell : column_) {
     operators_->multiply_inplace(cell->get_element(), val);
     if constexpr (Master_matrix::isNonBasic && !Master_matrix::Option_list::is_of_boundary_type) {
-      if (cell->get_row_index() == chain_opt::get_pivot()) operators_->add_inplace(pivotVal, cell->get_element());
+      if (cell->get_row_index() == Chain_opt::get_pivot()) operators_->add_inplace(pivotVal, cell->get_element());
     }
   }
 
   for (const Cell& cell : column) {
     ++insertsSinceLastPrune_;
     if constexpr (Master_matrix::isNonBasic && !Master_matrix::Option_list::is_of_boundary_type) {
-      if (cell.get_row_index() == chain_opt::get_pivot()) operators_->add_inplace(pivotVal, cell.get_element());
+      if (cell.get_row_index() == Chain_opt::get_pivot()) operators_->add_inplace(pivotVal, cell.get_element());
     }
     column_.push_back(cellPool_->construct(cell.get_row_index()));
     column_.back()->set_element(cell.get_element());
@@ -1074,21 +1059,20 @@ inline bool Heap_column<Master_matrix>::_multiply_target_and_add(const Field_ele
 
   if constexpr (Master_matrix::Option_list::is_z2)
     return !pivotVal;
-  else 
+  else
     return pivotVal == Field_operators::get_additive_identity();
 }
 
 template <class Master_matrix>
 template <class Cell_range>
-inline bool Heap_column<Master_matrix>::_multiply_source_and_add(const Cell_range& column,
-                                                                 const Field_element_type& val) 
+inline bool Heap_column<Master_matrix>::_multiply_source_and_add(const Cell_range& column, const Field_element& val)
 {
   if (val == 0u || column.begin() == column.end()) {
     return false;
   }
   if (column_.empty()) {  // chain should never enter here.
     column_.resize(column.size());
-    index i = 0;
+    Index i = 0;
     for (const Cell& cell : column) {
       column_[i] = cellPool_->construct(cell.get_row_index());
       column_[i++]->set_element(cell.get_element());
@@ -1097,7 +1081,7 @@ inline bool Heap_column<Master_matrix>::_multiply_source_and_add(const Cell_rang
     return true;
   }
 
-  Field_element_type pivotVal(1);
+  Field_element pivotVal(1);
 
   if constexpr (Master_matrix::isNonBasic && !Master_matrix::Option_list::is_of_boundary_type)
     pivotVal = get_pivot_value();
@@ -1108,7 +1092,7 @@ inline bool Heap_column<Master_matrix>::_multiply_source_and_add(const Cell_rang
     column_.back()->set_element(cell.get_element());
     operators_->multiply_inplace(column_.back()->get_element(), val);
     if constexpr (Master_matrix::isNonBasic && !Master_matrix::Option_list::is_of_boundary_type) {
-      if (cell.get_row_index() == chain_opt::get_pivot()){
+      if (cell.get_row_index() == Chain_opt::get_pivot()) {
         operators_->add_inplace(pivotVal, column_.back()->get_element());
       }
     }
@@ -1127,13 +1111,12 @@ inline bool Heap_column<Master_matrix>::_multiply_source_and_add(const Cell_rang
  * @ingroup persistence_matrix
  *
  * @brief Hash method for @ref Gudhi::persistence_matrix::Heap_column.
- * 
+ *
  * @tparam Master_matrix Template parameter of @ref Gudhi::persistence_matrix::Heap_column.
  * @tparam Cell_constructor Template parameter of @ref Gudhi::persistence_matrix::Heap_column.
  */
 template <class Master_matrix>
-struct std::hash<Gudhi::persistence_matrix::Heap_column<Master_matrix> > 
-{
+struct std::hash<Gudhi::persistence_matrix::Heap_column<Master_matrix> > {
   size_t operator()(Gudhi::persistence_matrix::Heap_column<Master_matrix>& column) const {
     return column.compute_hash_value();
   }

--- a/src/Persistence_matrix/include/gudhi/Persistence_matrix/columns/intrusive_list_column.h
+++ b/src/Persistence_matrix/include/gudhi/Persistence_matrix/columns/intrusive_list_column.h
@@ -21,7 +21,7 @@
 #include <vector>
 #include <stdexcept>
 #include <type_traits>
-#include <utility>      //std::swap, std::move & std::exchange
+#include <utility>  //std::swap, std::move & std::exchange
 
 #include <boost/intrusive/list.hpp>
 
@@ -39,79 +39,74 @@ namespace persistence_matrix {
  *
  * Column based on a intrusive list structure. The cells are always ordered by row index and only non-zero values
  * are stored uniquely in the underlying container.
- * 
+ *
  * @tparam Master_matrix An instantiation of @ref Matrix from which all types and options are deduced.
  * @tparam Cell_constructor Factory of @ref Cell classes.
  */
 template <class Master_matrix>
 class Intrusive_list_column : public Master_matrix::Row_access_option,
                               public Master_matrix::Column_dimension_option,
-                              public Master_matrix::Chain_column_option 
+                              public Master_matrix::Chain_column_option
 {
  public:
   using Master = Master_matrix;
-  using index = typename Master_matrix::index;
-  using id_index = typename Master_matrix::id_index;
-  using dimension_type = typename Master_matrix::dimension_type;
-  using Field_element_type = typename Master_matrix::element_type;
-  using Cell = typename Master_matrix::Cell_type;
+  using Index = typename Master_matrix::Index;
+  using ID_index = typename Master_matrix::ID_index;
+  using Dimension = typename Master_matrix::Dimension;
+  using Field_element = typename Master_matrix::Element;
+  using Cell = typename Master_matrix::Matrix_cell;
   using Column_settings = typename Master_matrix::Column_settings;
 
  private:
   using Field_operators = typename Master_matrix::Field_operators;
-  using Column_type =
-      boost::intrusive::list<Cell, 
-                             boost::intrusive::constant_time_size<false>,
-                             boost::intrusive::base_hook<typename Master_matrix::base_hook_matrix_list_column> >;
+  using Column =
+      boost::intrusive::list<Cell, boost::intrusive::constant_time_size<false>,
+                             boost::intrusive::base_hook<typename Master_matrix::Base_hook_matrix_list_column> >;
   using Cell_constructor = typename Master_matrix::Cell_constructor;
 
  public:
-  using iterator = typename Column_type::iterator;
-  using const_iterator = typename Column_type::const_iterator;
-  using reverse_iterator = typename Column_type::reverse_iterator;
-  using const_reverse_iterator = typename Column_type::const_reverse_iterator;
+  using iterator = typename Column::iterator;
+  using const_iterator = typename Column::const_iterator;
+  using reverse_iterator = typename Column::reverse_iterator;
+  using const_reverse_iterator = typename Column::const_reverse_iterator;
 
   Intrusive_list_column(Column_settings* colSettings = nullptr);
-  template <class Container_type = typename Master_matrix::boundary_type>
-  Intrusive_list_column(const Container_type& nonZeroRowIndices, 
+  template <class Container = typename Master_matrix::Boundary>
+  Intrusive_list_column(const Container& nonZeroRowIndices, Column_settings* colSettings);
+  template <class Container = typename Master_matrix::Boundary, class Row_container>
+  Intrusive_list_column(Index columnIndex,
+                        const Container& nonZeroRowIndices,
+                        Row_container* rowContainer,
                         Column_settings* colSettings);
-  template <class Container_type = typename Master_matrix::boundary_type, class Row_container_type>
-  Intrusive_list_column(index columnIndex, 
-                        const Container_type& nonZeroRowIndices, 
-                        Row_container_type* rowContainer,
+  template <class Container = typename Master_matrix::Boundary>
+  Intrusive_list_column(const Container& nonZeroChainRowIndices, Dimension dimension, Column_settings* colSettings);
+  template <class Container = typename Master_matrix::Boundary, class Row_container>
+  Intrusive_list_column(Index columnIndex,
+                        const Container& nonZeroChainRowIndices,
+                        Dimension dimension,
+                        Row_container* rowContainer,
                         Column_settings* colSettings);
-  template <class Container_type = typename Master_matrix::boundary_type>
-  Intrusive_list_column(const Container_type& nonZeroChainRowIndices, 
-                        dimension_type dimension,
-                        Column_settings* colSettings);
-  template <class Container_type = typename Master_matrix::boundary_type, class Row_container_type>
-  Intrusive_list_column(index columnIndex, 
-                        const Container_type& nonZeroChainRowIndices, 
-                        dimension_type dimension,
-                        Row_container_type* rowContainer, 
-                        Column_settings* colSettings);
-  Intrusive_list_column(const Intrusive_list_column& column, 
-                        Column_settings* colSettings = nullptr);
-  template <class Row_container_type>
-  Intrusive_list_column(const Intrusive_list_column& column, 
-                        index columnIndex, 
-                        Row_container_type* rowContainer,
+  Intrusive_list_column(const Intrusive_list_column& column, Column_settings* colSettings = nullptr);
+  template <class Row_container>
+  Intrusive_list_column(const Intrusive_list_column& column,
+                        Index columnIndex,
+                        Row_container* rowContainer,
                         Column_settings* colSettings = nullptr);
   Intrusive_list_column(Intrusive_list_column&& column) noexcept;
   ~Intrusive_list_column();
 
-  std::vector<Field_element_type> get_content(int columnLength = -1) const;
-  bool is_non_zero(id_index rowIndex) const;
+  std::vector<Field_element> get_content(int columnLength = -1) const;
+  bool is_non_zero(ID_index rowIndex) const;
   bool is_empty() const;
   std::size_t size() const;
 
-  template <class Map_type>
-  void reorder(const Map_type& valueMap, [[maybe_unused]] index columnIndex = -1);
+  template <class Row_index_map>
+  void reorder(const Row_index_map& valueMap, [[maybe_unused]] Index columnIndex = -1);
   void clear();
-  void clear(id_index rowIndex);
+  void clear(ID_index rowIndex);
 
-  id_index get_pivot() const;
-  Field_element_type get_pivot_value() const;
+  ID_index get_pivot() const;
+  Field_element get_pivot_value() const;
 
   iterator begin() noexcept;
   const_iterator begin() const noexcept;
@@ -126,16 +121,16 @@ class Intrusive_list_column : public Master_matrix::Row_access_option,
   Intrusive_list_column& operator+=(const Cell_range& column);
   Intrusive_list_column& operator+=(Intrusive_list_column& column);
 
-  Intrusive_list_column& operator*=(const Field_element_type& val);
+  Intrusive_list_column& operator*=(const Field_element& val);
 
   // this = v * this + column
   template <class Cell_range>
-  Intrusive_list_column& multiply_target_and_add(const Field_element_type& val, const Cell_range& column);
-  Intrusive_list_column& multiply_target_and_add(const Field_element_type& val, Intrusive_list_column& column);
+  Intrusive_list_column& multiply_target_and_add(const Field_element& val, const Cell_range& column);
+  Intrusive_list_column& multiply_target_and_add(const Field_element& val, Intrusive_list_column& column);
   // this = this + column * v
   template <class Cell_range>
-  Intrusive_list_column& multiply_source_and_add(const Cell_range& column, const Field_element_type& val);
-  Intrusive_list_column& multiply_source_and_add(Intrusive_list_column& column, const Field_element_type& val);
+  Intrusive_list_column& multiply_source_and_add(const Cell_range& column, const Field_element& val);
+  Intrusive_list_column& multiply_source_and_add(Intrusive_list_column& column, const Field_element& val);
 
   friend bool operator==(const Intrusive_list_column& c1, const Intrusive_list_column& c2) {
     if (&c1 == &c2) return true;
@@ -188,13 +183,13 @@ class Intrusive_list_column : public Master_matrix::Row_access_option,
   }
 
  private:
-  using ra_opt = typename Master_matrix::Row_access_option;
-  using dim_opt = typename Master_matrix::Column_dimension_option;
-  using chain_opt = typename Master_matrix::Chain_column_option;
+  using RA_opt = typename Master_matrix::Row_access_option;
+  using Dim_opt = typename Master_matrix::Column_dimension_option;
+  using Chain_opt = typename Master_matrix::Chain_column_option;
 
   // Cloner object function for boost intrusive container
-  struct new_cloner {
-    new_cloner(Cell_constructor* cellPool) : cellPool_(cellPool){};
+  struct New_cloner {
+    New_cloner(Cell_constructor* cellPool) : cellPool_(cellPool) {};
 
     Cell* operator()(const Cell& clone_this) { return cellPool_->construct(clone_this); }
 
@@ -202,9 +197,9 @@ class Intrusive_list_column : public Master_matrix::Row_access_option,
   };
 
   // The disposer object function for boost intrusive container
-  struct delete_disposer {
-    delete_disposer(){};
-    delete_disposer(Intrusive_list_column* col) : col_(col){};
+  struct Delete_disposer {
+    Delete_disposer() {};
+    Delete_disposer(Intrusive_list_column* col) : col_(col) {};
 
     void operator()(Cell* delete_this) {
       if constexpr (Master_matrix::Option_list::has_row_access) col_->unlink(delete_this);
@@ -216,52 +211,52 @@ class Intrusive_list_column : public Master_matrix::Row_access_option,
 
   Field_operators* operators_;
   Cell_constructor* cellPool_;
-  Column_type column_;
+  Column column_;
 
-  template <class Column_type, class Cell_iterator, typename F1, typename F2, typename F3, typename F4>
-  friend void _generic_merge_cell_to_column(Column_type& targetColumn,
+  template <class Column, class Cell_iterator, typename F1, typename F2, typename F3, typename F4>
+  friend void _generic_merge_cell_to_column(Column& targetColumn,
                                             Cell_iterator& itSource,
-                                            typename Column_type::Column_type::iterator& itTarget,
+                                            typename Column::Column::iterator& itTarget,
                                             F1&& process_target,
                                             F2&& process_source,
                                             F3&& update_target1,
                                             F4&& update_target2,
                                             bool& pivotIsZeroed);
-  template <class Column_type, class Cell_range, typename F1, typename F2, typename F3, typename F4, typename F5>
+  template <class Column, class Cell_range, typename F1, typename F2, typename F3, typename F4, typename F5>
   friend bool _generic_add_to_column(const Cell_range& source,
-                                     Column_type& targetColumn,
+                                     Column& targetColumn,
                                      F1&& process_target,
                                      F2&& process_source,
                                      F3&& update_target1,
                                      F4&& update_target2,
                                      F5&& finish_target);
-  template <class Column_type, class Cell_range>
-  friend bool _add_to_column(const Cell_range& source, Column_type& targetColumn);
-  template <class Column_type, class Cell_range>
-  friend bool _multiply_target_and_add_to_column(const typename Column_type::Field_element_type& val,
+  template <class Column, class Cell_range>
+  friend bool _add_to_column(const Cell_range& source, Column& targetColumn);
+  template <class Column, class Cell_range>
+  friend bool _multiply_target_and_add_to_column(const typename Column::Field_element& val,
                                                  const Cell_range& source,
-                                                 Column_type& targetColumn);
-  template <class Column_type, class Cell_range>
-  friend bool _multiply_source_and_add_to_column(const typename Column_type::Field_element_type& val,
+                                                 Column& targetColumn);
+  template <class Column, class Cell_range>
+  friend bool _multiply_source_and_add_to_column(const typename Column::Field_element& val,
                                                  const Cell_range& source,
-                                                 Column_type& targetColumn);
+                                                 Column& targetColumn);
 
   void _delete_cell(iterator& it);
-  Cell* _insert_cell(const Field_element_type& value, id_index rowIndex, const iterator& position);
-  void _insert_cell(id_index rowIndex, const iterator& position);
+  Cell* _insert_cell(const Field_element& value, ID_index rowIndex, const iterator& position);
+  void _insert_cell(ID_index rowIndex, const iterator& position);
   template <class Cell_range>
   bool _add(const Cell_range& column);
   template <class Cell_range>
-  bool _multiply_target_and_add(const Field_element_type& val, const Cell_range& column);
+  bool _multiply_target_and_add(const Field_element& val, const Cell_range& column);
   template <class Cell_range>
-  bool _multiply_source_and_add(const Cell_range& column, const Field_element_type& val);
+  bool _multiply_source_and_add(const Cell_range& column, const Field_element& val);
 };
 
 template <class Master_matrix>
 inline Intrusive_list_column<Master_matrix>::Intrusive_list_column(Column_settings* colSettings)
-    : ra_opt(),
-      dim_opt(),
-      chain_opt(),
+    : RA_opt(),
+      Dim_opt(),
+      Chain_opt(),
       operators_(nullptr),
       cellPool_(colSettings == nullptr ? nullptr : &(colSettings->cellConstructor)),
       column_()
@@ -273,21 +268,21 @@ inline Intrusive_list_column<Master_matrix>::Intrusive_list_column(Column_settin
 }
 
 template <class Master_matrix>
-template <class Container_type>
-inline Intrusive_list_column<Master_matrix>::Intrusive_list_column(
-    const Container_type& nonZeroRowIndices, Column_settings* colSettings)
-    : ra_opt(),
-      dim_opt(nonZeroRowIndices.size() == 0 ? 0 : nonZeroRowIndices.size() - 1),
-      chain_opt(),
+template <class Container>
+inline Intrusive_list_column<Master_matrix>::Intrusive_list_column(const Container& nonZeroRowIndices,
+                                                                   Column_settings* colSettings)
+    : RA_opt(),
+      Dim_opt(nonZeroRowIndices.size() == 0 ? 0 : nonZeroRowIndices.size() - 1),
+      Chain_opt(),
       operators_(nullptr),
       cellPool_(&(colSettings->cellConstructor)),
-      column_() 
+      column_()
 {
   static_assert(!Master_matrix::isNonBasic || Master_matrix::Option_list::is_of_boundary_type,
                 "Constructor not available for chain columns, please specify the dimension of the chain.");
 
   if constexpr (Master_matrix::Option_list::is_z2) {
-    for (id_index id : nonZeroRowIndices) {
+    for (ID_index id : nonZeroRowIndices) {
       _insert_cell(id, column_.end());
     }
   } else {
@@ -299,15 +294,14 @@ inline Intrusive_list_column<Master_matrix>::Intrusive_list_column(
 }
 
 template <class Master_matrix>
-template <class Container_type, class Row_container_type>
-inline Intrusive_list_column<Master_matrix>::Intrusive_list_column(
-    index columnIndex, 
-    const Container_type& nonZeroRowIndices, 
-    Row_container_type* rowContainer,
-    Column_settings* colSettings)
-    : ra_opt(columnIndex, rowContainer),
-      dim_opt(nonZeroRowIndices.size() == 0 ? 0 : nonZeroRowIndices.size() - 1),
-      chain_opt([&] {
+template <class Container, class Row_container>
+inline Intrusive_list_column<Master_matrix>::Intrusive_list_column(Index columnIndex,
+                                                                   const Container& nonZeroRowIndices,
+                                                                   Row_container* rowContainer,
+                                                                   Column_settings* colSettings)
+    : RA_opt(columnIndex, rowContainer),
+      Dim_opt(nonZeroRowIndices.size() == 0 ? 0 : nonZeroRowIndices.size() - 1),
+      Chain_opt([&] {
         if constexpr (Master_matrix::Option_list::is_z2) {
           return nonZeroRowIndices.begin() == nonZeroRowIndices.end() ? -1 : *std::prev(nonZeroRowIndices.end());
         } else {
@@ -316,13 +310,13 @@ inline Intrusive_list_column<Master_matrix>::Intrusive_list_column(
       }()),
       operators_(nullptr),
       cellPool_(&(colSettings->cellConstructor)),
-      column_() 
+      column_()
 {
   static_assert(!Master_matrix::isNonBasic || Master_matrix::Option_list::is_of_boundary_type,
                 "Constructor not available for chain columns, please specify the dimension of the chain.");
 
   if constexpr (Master_matrix::Option_list::is_z2) {
-    for (id_index id : nonZeroRowIndices) {
+    for (ID_index id : nonZeroRowIndices) {
       _insert_cell(id, column_.end());
     }
   } else {
@@ -334,14 +328,13 @@ inline Intrusive_list_column<Master_matrix>::Intrusive_list_column(
 }
 
 template <class Master_matrix>
-template <class Container_type>
-inline Intrusive_list_column<Master_matrix>::Intrusive_list_column(
-    const Container_type& nonZeroRowIndices, 
-    dimension_type dimension, 
-    Column_settings* colSettings)
-    : ra_opt(),
-      dim_opt(dimension),
-      chain_opt([&] {
+template <class Container>
+inline Intrusive_list_column<Master_matrix>::Intrusive_list_column(const Container& nonZeroRowIndices,
+                                                                   Dimension dimension,
+                                                                   Column_settings* colSettings)
+    : RA_opt(),
+      Dim_opt(dimension),
+      Chain_opt([&] {
         if constexpr (Master_matrix::Option_list::is_z2) {
           return nonZeroRowIndices.begin() == nonZeroRowIndices.end() ? -1 : *std::prev(nonZeroRowIndices.end());
         } else {
@@ -350,10 +343,10 @@ inline Intrusive_list_column<Master_matrix>::Intrusive_list_column(
       }()),
       operators_(nullptr),
       cellPool_(&(colSettings->cellConstructor)),
-      column_() 
+      column_()
 {
   if constexpr (Master_matrix::Option_list::is_z2) {
-    for (id_index id : nonZeroRowIndices) {
+    for (ID_index id : nonZeroRowIndices) {
       _insert_cell(id, column_.end());
     }
   } else {
@@ -365,16 +358,15 @@ inline Intrusive_list_column<Master_matrix>::Intrusive_list_column(
 }
 
 template <class Master_matrix>
-template <class Container_type, class Row_container_type>
-inline Intrusive_list_column<Master_matrix>::Intrusive_list_column(
-    index columnIndex, 
-    const Container_type& nonZeroRowIndices, 
-    dimension_type dimension,
-    Row_container_type* rowContainer, 
-    Column_settings* colSettings)
-    : ra_opt(columnIndex, rowContainer),
-      dim_opt(dimension),
-      chain_opt([&] {
+template <class Container, class Row_container>
+inline Intrusive_list_column<Master_matrix>::Intrusive_list_column(Index columnIndex,
+                                                                   const Container& nonZeroRowIndices,
+                                                                   Dimension dimension,
+                                                                   Row_container* rowContainer,
+                                                                   Column_settings* colSettings)
+    : RA_opt(columnIndex, rowContainer),
+      Dim_opt(dimension),
+      Chain_opt([&] {
         if constexpr (Master_matrix::Option_list::is_z2) {
           return nonZeroRowIndices.begin() == nonZeroRowIndices.end() ? -1 : *std::prev(nonZeroRowIndices.end());
         } else {
@@ -383,10 +375,10 @@ inline Intrusive_list_column<Master_matrix>::Intrusive_list_column(
       }()),
       operators_(nullptr),
       cellPool_(&(colSettings->cellConstructor)),
-      column_() 
+      column_()
 {
   if constexpr (Master_matrix::Option_list::is_z2) {
-    for (id_index id : nonZeroRowIndices) {
+    for (ID_index id : nonZeroRowIndices) {
       _insert_cell(id, column_.end());
     }
   } else {
@@ -398,38 +390,39 @@ inline Intrusive_list_column<Master_matrix>::Intrusive_list_column(
 }
 
 template <class Master_matrix>
-inline Intrusive_list_column<Master_matrix>::Intrusive_list_column(
-    const Intrusive_list_column& column, Column_settings* colSettings)
-    : ra_opt(),
-      dim_opt(static_cast<const dim_opt&>(column)),
-      chain_opt(static_cast<const chain_opt&>(column)),
+inline Intrusive_list_column<Master_matrix>::Intrusive_list_column(const Intrusive_list_column& column,
+                                                                   Column_settings* colSettings)
+    : RA_opt(),
+      Dim_opt(static_cast<const Dim_opt&>(column)),
+      Chain_opt(static_cast<const Chain_opt&>(column)),
       operators_(colSettings == nullptr ? column.operators_ : nullptr),
       cellPool_(colSettings == nullptr ? column.cellPool_ : &(colSettings->cellConstructor)),
-      column_() 
+      column_()
 {
   static_assert(!Master_matrix::Option_list::has_row_access,
                 "Simple copy constructor not available when row access option enabled. Please specify the new column "
                 "index and the row container.");
-  if constexpr (!Master_matrix::Option_list::is_z2){
+  if constexpr (!Master_matrix::Option_list::is_z2) {
     if (colSettings != nullptr) operators_ = &(colSettings->operators);
   }
 
-  column_.clone_from(column.column_, new_cloner(cellPool_), delete_disposer(this));
+  column_.clone_from(column.column_, New_cloner(cellPool_), Delete_disposer(this));
 }
 
 template <class Master_matrix>
-template <class Row_container_type>
-inline Intrusive_list_column<Master_matrix>::Intrusive_list_column(
-    const Intrusive_list_column& column, index columnIndex, Row_container_type* rowContainer,
-    Column_settings* colSettings)
-    : ra_opt(columnIndex, rowContainer),
-      dim_opt(static_cast<const dim_opt&>(column)),
-      chain_opt(static_cast<const chain_opt&>(column)),
+template <class Row_container>
+inline Intrusive_list_column<Master_matrix>::Intrusive_list_column(const Intrusive_list_column& column,
+                                                                   Index columnIndex,
+                                                                   Row_container* rowContainer,
+                                                                   Column_settings* colSettings)
+    : RA_opt(columnIndex, rowContainer),
+      Dim_opt(static_cast<const Dim_opt&>(column)),
+      Chain_opt(static_cast<const Chain_opt&>(column)),
       operators_(colSettings == nullptr ? column.operators_ : nullptr),
       cellPool_(colSettings == nullptr ? column.cellPool_ : &(colSettings->cellConstructor)),
-      column_() 
+      column_()
 {
-  if constexpr (!Master_matrix::Option_list::is_z2){
+  if constexpr (!Master_matrix::Option_list::is_z2) {
     if (colSettings != nullptr) operators_ = &(colSettings->operators);
   }
 
@@ -443,33 +436,32 @@ inline Intrusive_list_column<Master_matrix>::Intrusive_list_column(
 }
 
 template <class Master_matrix>
-inline Intrusive_list_column<Master_matrix>::Intrusive_list_column(
-    Intrusive_list_column&& column) noexcept
-    : ra_opt(std::move(static_cast<ra_opt&>(column))),
-      dim_opt(std::move(static_cast<dim_opt&>(column))),
-      chain_opt(std::move(static_cast<chain_opt&>(column))),
+inline Intrusive_list_column<Master_matrix>::Intrusive_list_column(Intrusive_list_column&& column) noexcept
+    : RA_opt(std::move(static_cast<RA_opt&>(column))),
+      Dim_opt(std::move(static_cast<Dim_opt&>(column))),
+      Chain_opt(std::move(static_cast<Chain_opt&>(column))),
       operators_(std::exchange(column.operators_, nullptr)),
       cellPool_(std::exchange(column.cellPool_, nullptr)),
-      column_(std::move(column.column_)) 
+      column_(std::move(column.column_))
 {}
 
 template <class Master_matrix>
-inline Intrusive_list_column<Master_matrix>::~Intrusive_list_column() 
+inline Intrusive_list_column<Master_matrix>::~Intrusive_list_column()
 {
-  column_.clear_and_dispose(delete_disposer(this));
+  column_.clear_and_dispose(Delete_disposer(this));
 }
 
 template <class Master_matrix>
-inline std::vector<typename Intrusive_list_column<Master_matrix>::Field_element_type>
-Intrusive_list_column<Master_matrix>::get_content(int columnLength) const 
+inline std::vector<typename Intrusive_list_column<Master_matrix>::Field_element>
+Intrusive_list_column<Master_matrix>::get_content(int columnLength) const
 {
   if (columnLength < 0 && column_.size() > 0)
     columnLength = column_.back().get_row_index() + 1;
   else if (columnLength < 0)
-    return std::vector<Field_element_type>();
+    return std::vector<Field_element>();
 
-  std::vector<Field_element_type> container(columnLength);
-  for (auto it = column_.begin(); it != column_.end() && it->get_row_index() < static_cast<id_index>(columnLength);
+  std::vector<Field_element> container(columnLength);
+  for (auto it = column_.begin(); it != column_.end() && it->get_row_index() < static_cast<ID_index>(columnLength);
        ++it) {
     if constexpr (Master_matrix::Option_list::is_z2) {
       container[it->get_row_index()] = 1;
@@ -481,7 +473,7 @@ Intrusive_list_column<Master_matrix>::get_content(int columnLength) const
 }
 
 template <class Master_matrix>
-inline bool Intrusive_list_column<Master_matrix>::is_non_zero(id_index rowIndex) const 
+inline bool Intrusive_list_column<Master_matrix>::is_non_zero(ID_index rowIndex) const
 {
   // could be changed to dichotomic search as column is ordered by row index,
   // but I am not sure if it is really worth it as there is no random access
@@ -493,21 +485,21 @@ inline bool Intrusive_list_column<Master_matrix>::is_non_zero(id_index rowIndex)
 }
 
 template <class Master_matrix>
-inline bool Intrusive_list_column<Master_matrix>::is_empty() const 
+inline bool Intrusive_list_column<Master_matrix>::is_empty() const
 {
   return column_.empty();
 }
 
 template <class Master_matrix>
-inline std::size_t Intrusive_list_column<Master_matrix>::size() const 
+inline std::size_t Intrusive_list_column<Master_matrix>::size() const
 {
   return column_.size();
 }
 
 template <class Master_matrix>
-template <class Map_type>
-inline void Intrusive_list_column<Master_matrix>::reorder(const Map_type& valueMap,
-                                                                            [[maybe_unused]] index columnIndex) 
+template <class Row_index_map>
+inline void Intrusive_list_column<Master_matrix>::reorder(const Row_index_map& valueMap,
+                                                          [[maybe_unused]] Index columnIndex)
 {
   static_assert(!Master_matrix::isNonBasic || Master_matrix::Option_list::is_of_boundary_type,
                 "Method not available for chain columns.");
@@ -515,19 +507,19 @@ inline void Intrusive_list_column<Master_matrix>::reorder(const Map_type& valueM
   for (auto it = column_.begin(); it != column_.end(); ++it) {
     Cell* cell = &(*it);
     if constexpr (Master_matrix::Option_list::has_row_access) {
-      ra_opt::unlink(cell);
-      if (columnIndex != static_cast<index>(-1)) cell->set_column_index(columnIndex);
+      RA_opt::unlink(cell);
+      if (columnIndex != static_cast<Index>(-1)) cell->set_column_index(columnIndex);
     }
     cell->set_row_index(valueMap.at(cell->get_row_index()));
     if constexpr (Master_matrix::Option_list::has_intrusive_rows && Master_matrix::Option_list::has_row_access)
-      ra_opt::insert_cell(cell->get_row_index(), cell);
+      RA_opt::insert_cell(cell->get_row_index(), cell);
   }
 
   // all cells have to be deleted first, to avoid problem with insertion when row is a set
   if constexpr (!Master_matrix::Option_list::has_intrusive_rows && Master_matrix::Option_list::has_row_access) {
     for (auto it = column_.begin(); it != column_.end(); ++it) {
       Cell* cell = &(*it);
-      ra_opt::insert_cell(cell->get_row_index(), cell);
+      RA_opt::insert_cell(cell->get_row_index(), cell);
     }
   }
 
@@ -535,16 +527,16 @@ inline void Intrusive_list_column<Master_matrix>::reorder(const Map_type& valueM
 }
 
 template <class Master_matrix>
-inline void Intrusive_list_column<Master_matrix>::clear() 
+inline void Intrusive_list_column<Master_matrix>::clear()
 {
   static_assert(!Master_matrix::isNonBasic || Master_matrix::Option_list::is_of_boundary_type,
                 "Method not available for chain columns as a base element should not be empty.");
 
-  column_.clear_and_dispose(delete_disposer(this));
+  column_.clear_and_dispose(Delete_disposer(this));
 }
 
 template <class Master_matrix>
-inline void Intrusive_list_column<Master_matrix>::clear(id_index rowIndex) 
+inline void Intrusive_list_column<Master_matrix>::clear(ID_index rowIndex)
 {
   static_assert(!Master_matrix::isNonBasic || Master_matrix::Option_list::is_of_boundary_type,
                 "Method not available for chain columns.");
@@ -555,8 +547,7 @@ inline void Intrusive_list_column<Master_matrix>::clear(id_index rowIndex)
 }
 
 template <class Master_matrix>
-inline typename Intrusive_list_column<Master_matrix>::id_index
-Intrusive_list_column<Master_matrix>::get_pivot() const 
+inline typename Intrusive_list_column<Master_matrix>::ID_index Intrusive_list_column<Master_matrix>::get_pivot() const
 {
   static_assert(Master_matrix::isNonBasic,
                 "Method not available for base columns.");  // could technically be, but is the notion useful then?
@@ -565,13 +556,13 @@ Intrusive_list_column<Master_matrix>::get_pivot() const
     if (column_.empty()) return -1;
     return column_.back().get_row_index();
   } else {
-    return chain_opt::get_pivot();
+    return Chain_opt::get_pivot();
   }
 }
 
 template <class Master_matrix>
-inline typename Intrusive_list_column<Master_matrix>::Field_element_type
-Intrusive_list_column<Master_matrix>::get_pivot_value() const 
+inline typename Intrusive_list_column<Master_matrix>::Field_element
+Intrusive_list_column<Master_matrix>::get_pivot_value() const
 {
   static_assert(Master_matrix::isNonBasic,
                 "Method not available for base columns.");  // could technically be, but is the notion useful then?
@@ -583,75 +574,73 @@ Intrusive_list_column<Master_matrix>::get_pivot_value() const
       if (column_.empty()) return 0;
       return column_.back().get_element();
     } else {
-      if (chain_opt::get_pivot() == static_cast<id_index>(-1)) return Field_element_type();
+      if (Chain_opt::get_pivot() == static_cast<ID_index>(-1)) return Field_element();
       for (const Cell& cell : column_) {
-        if (cell.get_row_index() == chain_opt::get_pivot()) return cell.get_element();
+        if (cell.get_row_index() == Chain_opt::get_pivot()) return cell.get_element();
       }
-      return Field_element_type();  // should never happen if chain column is used properly
+      return Field_element();  // should never happen if chain column is used properly
     }
   }
 }
 
 template <class Master_matrix>
-inline typename Intrusive_list_column<Master_matrix>::iterator
-Intrusive_list_column<Master_matrix>::begin() noexcept 
+inline typename Intrusive_list_column<Master_matrix>::iterator Intrusive_list_column<Master_matrix>::begin() noexcept
 {
   return column_.begin();
 }
 
 template <class Master_matrix>
-inline typename Intrusive_list_column<Master_matrix>::const_iterator
-Intrusive_list_column<Master_matrix>::begin() const noexcept 
+inline typename Intrusive_list_column<Master_matrix>::const_iterator Intrusive_list_column<Master_matrix>::begin()
+    const noexcept
 {
   return column_.begin();
 }
 
 template <class Master_matrix>
-inline typename Intrusive_list_column<Master_matrix>::iterator
-Intrusive_list_column<Master_matrix>::end() noexcept 
+inline typename Intrusive_list_column<Master_matrix>::iterator Intrusive_list_column<Master_matrix>::end() noexcept
 {
   return column_.end();
 }
 
 template <class Master_matrix>
-inline typename Intrusive_list_column<Master_matrix>::const_iterator
-Intrusive_list_column<Master_matrix>::end() const noexcept 
+inline typename Intrusive_list_column<Master_matrix>::const_iterator Intrusive_list_column<Master_matrix>::end()
+    const noexcept
 {
   return column_.end();
 }
 
 template <class Master_matrix>
 inline typename Intrusive_list_column<Master_matrix>::reverse_iterator
-Intrusive_list_column<Master_matrix>::rbegin() noexcept 
+Intrusive_list_column<Master_matrix>::rbegin() noexcept
 {
   return column_.rbegin();
 }
 
 template <class Master_matrix>
 inline typename Intrusive_list_column<Master_matrix>::const_reverse_iterator
-Intrusive_list_column<Master_matrix>::rbegin() const noexcept 
+Intrusive_list_column<Master_matrix>::rbegin() const noexcept
 {
   return column_.rbegin();
 }
 
 template <class Master_matrix>
 inline typename Intrusive_list_column<Master_matrix>::reverse_iterator
-Intrusive_list_column<Master_matrix>::rend() noexcept 
+Intrusive_list_column<Master_matrix>::rend() noexcept
 {
   return column_.rend();
 }
 
 template <class Master_matrix>
 inline typename Intrusive_list_column<Master_matrix>::const_reverse_iterator
-Intrusive_list_column<Master_matrix>::rend() const noexcept 
+Intrusive_list_column<Master_matrix>::rend() const noexcept
 {
   return column_.rend();
 }
 
 template <class Master_matrix>
 template <class Cell_range>
-inline Intrusive_list_column<Master_matrix>&
-Intrusive_list_column<Master_matrix>::operator+=(const Cell_range& column) 
+inline Intrusive_list_column<Master_matrix>& Intrusive_list_column<Master_matrix>::operator+=(
+    const Cell_range& column)
 {
   static_assert((!Master_matrix::isNonBasic || std::is_same_v<Cell_range, Intrusive_list_column>),
                 "For boundary columns, the range has to be a column of same type to help ensure the validity of the "
@@ -665,14 +654,14 @@ Intrusive_list_column<Master_matrix>::operator+=(const Cell_range& column)
 }
 
 template <class Master_matrix>
-inline Intrusive_list_column<Master_matrix>&
-Intrusive_list_column<Master_matrix>::operator+=(Intrusive_list_column& column) 
+inline Intrusive_list_column<Master_matrix>& Intrusive_list_column<Master_matrix>::operator+=(
+    Intrusive_list_column& column)
 {
   if constexpr (Master_matrix::isNonBasic && !Master_matrix::Option_list::is_of_boundary_type) {
     // assumes that the addition never zeros out this column.
     if (_add(column)) {
-      chain_opt::swap_pivots(column);
-      dim_opt::swap_dimension(column);
+      Chain_opt::swap_pivots(column);
+      Dim_opt::swap_dimension(column);
     }
   } else {
     _add(column);
@@ -682,8 +671,8 @@ Intrusive_list_column<Master_matrix>::operator+=(Intrusive_list_column& column)
 }
 
 template <class Master_matrix>
-inline Intrusive_list_column<Master_matrix>&
-Intrusive_list_column<Master_matrix>::operator*=(const Field_element_type& val) 
+inline Intrusive_list_column<Master_matrix>& Intrusive_list_column<Master_matrix>::operator*=(
+    const Field_element& val)
 {
   if constexpr (Master_matrix::Option_list::is_z2) {
     if (val % 2 == 0) {
@@ -694,7 +683,7 @@ Intrusive_list_column<Master_matrix>::operator*=(const Field_element_type& val)
       }
     }
   } else {
-    Field_element_type realVal = operators_->get_value(val);
+    Field_element realVal = operators_->get_value(val);
 
     if (realVal == Field_operators::get_additive_identity()) {
       if constexpr (Master_matrix::isNonBasic && !Master_matrix::Option_list::is_of_boundary_type) {
@@ -709,7 +698,7 @@ Intrusive_list_column<Master_matrix>::operator*=(const Field_element_type& val)
 
     for (Cell& cell : column_) {
       operators_->multiply_inplace(cell.get_element(), realVal);
-      if constexpr (Master_matrix::Option_list::has_row_access) ra_opt::update_cell(cell);
+      if constexpr (Master_matrix::Option_list::has_row_access) RA_opt::update_cell(cell);
     }
   }
 
@@ -718,9 +707,8 @@ Intrusive_list_column<Master_matrix>::operator*=(const Field_element_type& val)
 
 template <class Master_matrix>
 template <class Cell_range>
-inline Intrusive_list_column<Master_matrix>&
-Intrusive_list_column<Master_matrix>::multiply_target_and_add(const Field_element_type& val,
-                                                              const Cell_range& column) 
+inline Intrusive_list_column<Master_matrix>& Intrusive_list_column<Master_matrix>::multiply_target_and_add(
+    const Field_element& val, const Cell_range& column)
 {
   static_assert((!Master_matrix::isNonBasic || std::is_same_v<Cell_range, Intrusive_list_column>),
                 "For boundary columns, the range has to be a column of same type to help ensure the validity of the "
@@ -743,25 +731,24 @@ Intrusive_list_column<Master_matrix>::multiply_target_and_add(const Field_elemen
 }
 
 template <class Master_matrix>
-inline Intrusive_list_column<Master_matrix>&
-Intrusive_list_column<Master_matrix>::multiply_target_and_add(const Field_element_type& val,
-                                                              Intrusive_list_column& column) 
+inline Intrusive_list_column<Master_matrix>& Intrusive_list_column<Master_matrix>::multiply_target_and_add(
+    const Field_element& val, Intrusive_list_column& column)
 {
   if constexpr (Master_matrix::isNonBasic && !Master_matrix::Option_list::is_of_boundary_type) {
     // assumes that the addition never zeros out this column.
     if constexpr (Master_matrix::Option_list::is_z2) {
       if (val) {
         if (_add(column)) {
-          chain_opt::swap_pivots(column);
-          dim_opt::swap_dimension(column);
+          Chain_opt::swap_pivots(column);
+          Dim_opt::swap_dimension(column);
         }
       } else {
         throw std::invalid_argument("A chain column should not be multiplied by 0.");
       }
     } else {
       if (_multiply_target_and_add(val, column)) {
-        chain_opt::swap_pivots(column);
-        dim_opt::swap_dimension(column);
+        Chain_opt::swap_pivots(column);
+        Dim_opt::swap_dimension(column);
       }
     }
   } else {
@@ -782,9 +769,8 @@ Intrusive_list_column<Master_matrix>::multiply_target_and_add(const Field_elemen
 
 template <class Master_matrix>
 template <class Cell_range>
-inline Intrusive_list_column<Master_matrix>&
-Intrusive_list_column<Master_matrix>::multiply_source_and_add(const Cell_range& column,
-                                                              const Field_element_type& val) 
+inline Intrusive_list_column<Master_matrix>& Intrusive_list_column<Master_matrix>::multiply_source_and_add(
+    const Cell_range& column, const Field_element& val)
 {
   static_assert((!Master_matrix::isNonBasic || std::is_same_v<Cell_range, Intrusive_list_column>),
                 "For boundary columns, the range has to be a column of same type to help ensure the validity of the "
@@ -804,23 +790,22 @@ Intrusive_list_column<Master_matrix>::multiply_source_and_add(const Cell_range& 
 }
 
 template <class Master_matrix>
-inline Intrusive_list_column<Master_matrix>&
-Intrusive_list_column<Master_matrix>::multiply_source_and_add(Intrusive_list_column& column,
-                                                              const Field_element_type& val) 
+inline Intrusive_list_column<Master_matrix>& Intrusive_list_column<Master_matrix>::multiply_source_and_add(
+    Intrusive_list_column& column, const Field_element& val)
 {
   if constexpr (Master_matrix::isNonBasic && !Master_matrix::Option_list::is_of_boundary_type) {
     // assumes that the addition never zeros out this column.
     if constexpr (Master_matrix::Option_list::is_z2) {
       if (val) {
         if (_add(column)) {
-          chain_opt::swap_pivots(column);
-          dim_opt::swap_dimension(column);
+          Chain_opt::swap_pivots(column);
+          Dim_opt::swap_dimension(column);
         }
       }
     } else {
       if (_multiply_source_and_add(column, val)) {
-        chain_opt::swap_pivots(column);
-        dim_opt::swap_dimension(column);
+        Chain_opt::swap_pivots(column);
+        Dim_opt::swap_dimension(column);
       }
     }
   } else {
@@ -837,38 +822,38 @@ Intrusive_list_column<Master_matrix>::multiply_source_and_add(Intrusive_list_col
 }
 
 template <class Master_matrix>
-inline Intrusive_list_column<Master_matrix>&
-Intrusive_list_column<Master_matrix>::operator=(const Intrusive_list_column& other) 
+inline Intrusive_list_column<Master_matrix>& Intrusive_list_column<Master_matrix>::operator=(
+    const Intrusive_list_column& other)
 {
   static_assert(!Master_matrix::Option_list::has_row_access, "= assignment not enabled with row access option.");
 
-  dim_opt::operator=(other);
-  chain_opt::operator=(other);
+  Dim_opt::operator=(other);
+  Chain_opt::operator=(other);
 
   // order is important
-  column_.clear_and_dispose(delete_disposer(this));
+  column_.clear_and_dispose(Delete_disposer(this));
   operators_ = other.operators_;
   cellPool_ = other.cellPool_;
-  column_.clone_from(other.column_, new_cloner(cellPool_), delete_disposer(this));
+  column_.clone_from(other.column_, New_cloner(cellPool_), Delete_disposer(this));
 
   return *this;
 }
 
 template <class Master_matrix>
-inline void Intrusive_list_column<Master_matrix>::_delete_cell(iterator& it) 
+inline void Intrusive_list_column<Master_matrix>::_delete_cell(iterator& it)
 {
-  it = column_.erase_and_dispose(it, delete_disposer(this));
+  it = column_.erase_and_dispose(it, Delete_disposer(this));
 }
 
 template <class Master_matrix>
 inline typename Intrusive_list_column<Master_matrix>::Cell* Intrusive_list_column<Master_matrix>::_insert_cell(
-    const Field_element_type& value, id_index rowIndex, const iterator& position)
+    const Field_element& value, ID_index rowIndex, const iterator& position)
 {
   if constexpr (Master_matrix::Option_list::has_row_access) {
-    Cell* newCell = cellPool_->construct(ra_opt::columnIndex_, rowIndex);
+    Cell* newCell = cellPool_->construct(RA_opt::columnIndex_, rowIndex);
     newCell->set_element(value);
     column_.insert(position, *newCell);
-    ra_opt::insert_cell(rowIndex, newCell);
+    RA_opt::insert_cell(rowIndex, newCell);
     return newCell;
   } else {
     Cell* newCell = cellPool_->construct(rowIndex);
@@ -879,13 +864,12 @@ inline typename Intrusive_list_column<Master_matrix>::Cell* Intrusive_list_colum
 }
 
 template <class Master_matrix>
-inline void Intrusive_list_column<Master_matrix>::_insert_cell(id_index rowIndex,
-                                                                                 const iterator& position) 
+inline void Intrusive_list_column<Master_matrix>::_insert_cell(ID_index rowIndex, const iterator& position)
 {
   if constexpr (Master_matrix::Option_list::has_row_access) {
-    Cell* newCell = cellPool_->construct(ra_opt::columnIndex_, rowIndex);
+    Cell* newCell = cellPool_->construct(RA_opt::columnIndex_, rowIndex);
     column_.insert(position, *newCell);
-    ra_opt::insert_cell(rowIndex, newCell);
+    RA_opt::insert_cell(rowIndex, newCell);
   } else {
     Cell* newCell = cellPool_->construct(rowIndex);
     column_.insert(position, *newCell);
@@ -901,7 +885,7 @@ inline bool Intrusive_list_column<Master_matrix>::_add(const Cell_range& column)
 
 template <class Master_matrix>
 template <class Cell_range>
-inline bool Intrusive_list_column<Master_matrix>::_multiply_target_and_add(const Field_element_type& val,
+inline bool Intrusive_list_column<Master_matrix>::_multiply_target_and_add(const Field_element& val,
                                                                            const Cell_range& column)
 {
   return _multiply_target_and_add_to_column(val, column, *this);
@@ -910,7 +894,7 @@ inline bool Intrusive_list_column<Master_matrix>::_multiply_target_and_add(const
 template <class Master_matrix>
 template <class Cell_range>
 inline bool Intrusive_list_column<Master_matrix>::_multiply_source_and_add(const Cell_range& column,
-                                                                           const Field_element_type& val)
+                                                                           const Field_element& val)
 {
   return _multiply_source_and_add_to_column(val, column, *this);
 }
@@ -922,13 +906,12 @@ inline bool Intrusive_list_column<Master_matrix>::_multiply_source_and_add(const
  * @ingroup persistence_matrix
  *
  * @brief Hash method for @ref Gudhi::persistence_matrix::Intrusive_list_column.
- * 
+ *
  * @tparam Master_matrix Template parameter of @ref Gudhi::persistence_matrix::Intrusive_list_column.
  * @tparam Cell_constructor Template parameter of @ref Gudhi::persistence_matrix::Intrusive_list_column.
  */
 template <class Master_matrix>
-struct std::hash<Gudhi::persistence_matrix::Intrusive_list_column<Master_matrix> > 
-{
+struct std::hash<Gudhi::persistence_matrix::Intrusive_list_column<Master_matrix> > {
   std::size_t operator()(const Gudhi::persistence_matrix::Intrusive_list_column<Master_matrix>& column) const {
     return Gudhi::persistence_matrix::hash_column(column);
   }

--- a/src/Persistence_matrix/include/gudhi/Persistence_matrix/columns/intrusive_set_column.h
+++ b/src/Persistence_matrix/include/gudhi/Persistence_matrix/columns/intrusive_set_column.h
@@ -21,7 +21,7 @@
 #include <vector>
 #include <stdexcept>
 #include <type_traits>
-#include <utility>      //std::swap, std::move & std::exchange
+#include <utility>  //std::swap, std::move & std::exchange
 
 #include <boost/intrusive/set.hpp>
 
@@ -40,79 +40,74 @@ namespace persistence_matrix {
  *
  * Column based on a intrusive set structure. The cells are ordered by row index and only non-zero values
  * are stored uniquely in the underlying container.
- * 
+ *
  * @tparam Master_matrix An instantiation of @ref Matrix from which all types and options are deduced.
  * @tparam Cell_constructor Factory of @ref Cell classes.
  */
 template <class Master_matrix>
 class Intrusive_set_column : public Master_matrix::Row_access_option,
                              public Master_matrix::Column_dimension_option,
-                             public Master_matrix::Chain_column_option 
+                             public Master_matrix::Chain_column_option
 {
  public:
   using Master = Master_matrix;
-  using index = typename Master_matrix::index;
-  using id_index = typename Master_matrix::id_index;
-  using dimension_type = typename Master_matrix::dimension_type;
-  using Field_element_type = typename Master_matrix::element_type;
-  using Cell = typename Master_matrix::Cell_type;
+  using Index = typename Master_matrix::Index;
+  using ID_index = typename Master_matrix::ID_index;
+  using Dimension = typename Master_matrix::Dimension;
+  using Field_element = typename Master_matrix::Element;
+  using Cell = typename Master_matrix::Matrix_cell;
   using Column_settings = typename Master_matrix::Column_settings;
 
  private:
   using Field_operators = typename Master_matrix::Field_operators;
-  using Column_type =
-      boost::intrusive::set<Cell, 
-                            boost::intrusive::constant_time_size<false>,
-                            boost::intrusive::base_hook<typename Master_matrix::base_hook_matrix_set_column> >;
+  using Column =
+      boost::intrusive::set<Cell, boost::intrusive::constant_time_size<false>,
+                            boost::intrusive::base_hook<typename Master_matrix::Base_hook_matrix_set_column> >;
   using Cell_constructor = typename Master_matrix::Cell_constructor;
 
  public:
-  using iterator = typename Column_type::iterator;
-  using const_iterator = typename Column_type::const_iterator;
-  using reverse_iterator = typename Column_type::reverse_iterator;
-  using const_reverse_iterator = typename Column_type::const_reverse_iterator;
+  using iterator = typename Column::iterator;
+  using const_iterator = typename Column::const_iterator;
+  using reverse_iterator = typename Column::reverse_iterator;
+  using const_reverse_iterator = typename Column::const_reverse_iterator;
 
   Intrusive_set_column(Column_settings* colSettings = nullptr);
-  template <class Container_type = typename Master_matrix::boundary_type>
-  Intrusive_set_column(const Container_type& nonZeroRowIndices, 
+  template <class Container = typename Master_matrix::Boundary>
+  Intrusive_set_column(const Container& nonZeroRowIndices, Column_settings* colSettings);
+  template <class Container = typename Master_matrix::Boundary, class Row_container>
+  Intrusive_set_column(Index columnIndex,
+                       const Container& nonZeroRowIndices,
+                       Row_container* rowContainer,
                        Column_settings* colSettings);
-  template <class Container_type = typename Master_matrix::boundary_type, class Row_container_type>
-  Intrusive_set_column(index columnIndex, 
-                       const Container_type& nonZeroRowIndices, 
-                       Row_container_type* rowContainer,
+  template <class Container = typename Master_matrix::Boundary>
+  Intrusive_set_column(const Container& nonZeroChainRowIndices, Dimension dimension, Column_settings* colSettings);
+  template <class Container = typename Master_matrix::Boundary, class Row_container>
+  Intrusive_set_column(Index columnIndex,
+                       const Container& nonZeroChainRowIndices,
+                       Dimension dimension,
+                       Row_container* rowContainer,
                        Column_settings* colSettings);
-  template <class Container_type = typename Master_matrix::boundary_type>
-  Intrusive_set_column(const Container_type& nonZeroChainRowIndices, 
-                       dimension_type dimension,
-                       Column_settings* colSettings);
-  template <class Container_type = typename Master_matrix::boundary_type, class Row_container_type>
-  Intrusive_set_column(index columnIndex, 
-                       const Container_type& nonZeroChainRowIndices, 
-                       dimension_type dimension,
-                       Row_container_type* rowContainer, 
-                       Column_settings* colSettings);
-  Intrusive_set_column(const Intrusive_set_column& column, 
-                       Column_settings* colSettings = nullptr);
-  template <class Row_container_type>
-  Intrusive_set_column(const Intrusive_set_column& column, 
-                       index columnIndex, 
-                       Row_container_type* rowContainer,
+  Intrusive_set_column(const Intrusive_set_column& column, Column_settings* colSettings = nullptr);
+  template <class Row_container>
+  Intrusive_set_column(const Intrusive_set_column& column,
+                       Index columnIndex,
+                       Row_container* rowContainer,
                        Column_settings* colSettings = nullptr);
   Intrusive_set_column(Intrusive_set_column&& column) noexcept;
   ~Intrusive_set_column();
 
-  std::vector<Field_element_type> get_content(int columnLength = -1) const;
-  bool is_non_zero(id_index rowIndex) const;
+  std::vector<Field_element> get_content(int columnLength = -1) const;
+  bool is_non_zero(ID_index rowIndex) const;
   bool is_empty() const;
   std::size_t size() const;
 
-  template <class Map_type>
-  void reorder(const Map_type& valueMap, [[maybe_unused]] index columnIndex = -1);
+  template <class Row_index_map>
+  void reorder(const Row_index_map& valueMap, [[maybe_unused]] Index columnIndex = -1);
   void clear();
-  void clear(id_index rowIndex);
+  void clear(ID_index rowIndex);
 
-  id_index get_pivot() const;
-  Field_element_type get_pivot_value() const;
+  ID_index get_pivot() const;
+  Field_element get_pivot_value() const;
 
   iterator begin() noexcept;
   const_iterator begin() const noexcept;
@@ -131,12 +126,12 @@ class Intrusive_set_column : public Master_matrix::Row_access_option,
 
   // this = v * this + column
   template <class Cell_range>
-  Intrusive_set_column& multiply_target_and_add(const Field_element_type& val, const Cell_range& column);
-  Intrusive_set_column& multiply_target_and_add(const Field_element_type& val, Intrusive_set_column& column);
+  Intrusive_set_column& multiply_target_and_add(const Field_element& val, const Cell_range& column);
+  Intrusive_set_column& multiply_target_and_add(const Field_element& val, Intrusive_set_column& column);
   // this = this + column * v
   template <class Cell_range>
-  Intrusive_set_column& multiply_source_and_add(const Cell_range& column, const Field_element_type& val);
-  Intrusive_set_column& multiply_source_and_add(Intrusive_set_column& column, const Field_element_type& val);
+  Intrusive_set_column& multiply_source_and_add(const Cell_range& column, const Field_element& val);
+  Intrusive_set_column& multiply_source_and_add(Intrusive_set_column& column, const Field_element& val);
 
   friend bool operator==(const Intrusive_set_column& c1, const Intrusive_set_column& c2) {
     if (&c1 == &c2) return true;
@@ -189,13 +184,13 @@ class Intrusive_set_column : public Master_matrix::Row_access_option,
   }
 
  private:
-  using ra_opt = typename Master_matrix::Row_access_option;
-  using dim_opt = typename Master_matrix::Column_dimension_option;
-  using chain_opt = typename Master_matrix::Chain_column_option;
+  using RA_opt = typename Master_matrix::Row_access_option;
+  using Dim_opt = typename Master_matrix::Column_dimension_option;
+  using Chain_opt = typename Master_matrix::Chain_column_option;
 
   // Cloner object function for boost intrusive container
-  struct new_cloner {
-    new_cloner(Cell_constructor* cellPool) : cellPool_(cellPool){};
+  struct New_cloner {
+    New_cloner(Cell_constructor* cellPool) : cellPool_(cellPool) {};
 
     Cell* operator()(const Cell& clone_this) { return cellPool_->construct(clone_this); }
 
@@ -203,9 +198,9 @@ class Intrusive_set_column : public Master_matrix::Row_access_option,
   };
 
   // The disposer object function for boost intrusive container
-  struct delete_disposer {
-    delete_disposer(){};
-    delete_disposer(Intrusive_set_column* col) : col_(col){};
+  struct Delete_disposer {
+    Delete_disposer() {};
+    Delete_disposer(Intrusive_set_column* col) : col_(col) {};
 
     void operator()(Cell* delete_this) {
       if constexpr (Master_matrix::Option_list::has_row_access) col_->unlink(delete_this);
@@ -215,70 +210,70 @@ class Intrusive_set_column : public Master_matrix::Row_access_option,
     Intrusive_set_column* col_;
   };
 
-  Column_type column_;
+  Column column_;
   Field_operators* operators_;
   Cell_constructor* cellPool_;
 
-  template <class Column_type, class Cell_iterator, typename F1, typename F2, typename F3, typename F4>
-  friend void _generic_merge_cell_to_column(Column_type& targetColumn,
+  template <class Column, class Cell_iterator, typename F1, typename F2, typename F3, typename F4>
+  friend void _generic_merge_cell_to_column(Column& targetColumn,
                                             Cell_iterator& itSource,
-                                            typename Column_type::Column_type::iterator& itTarget,
+                                            typename Column::Column::iterator& itTarget,
                                             F1&& process_target,
                                             F2&& process_source,
                                             F3&& update_target1,
                                             F4&& update_target2,
                                             bool& pivotIsZeroed);
-  template <class Column_type, class Cell_range, typename F1, typename F2, typename F3, typename F4, typename F5>
+  template <class Column, class Cell_range, typename F1, typename F2, typename F3, typename F4, typename F5>
   friend bool _generic_add_to_column(const Cell_range& source,
-                                     Column_type& targetColumn,
+                                     Column& targetColumn,
                                      F1&& process_target,
                                      F2&& process_source,
                                      F3&& update_target1,
                                      F4&& update_target2,
                                      F5&& finish_target);
-  template <class Column_type, class Cell_range>
-  friend bool _add_to_column(const Cell_range& source, Column_type& targetColumn);
-  template <class Column_type, class Cell_range>
-  friend bool _multiply_target_and_add_to_column(const typename Column_type::Field_element_type& val,
+  template <class Column, class Cell_range>
+  friend bool _add_to_column(const Cell_range& source, Column& targetColumn);
+  template <class Column, class Cell_range>
+  friend bool _multiply_target_and_add_to_column(const typename Column::Field_element& val,
                                                  const Cell_range& source,
-                                                 Column_type& targetColumn);
-  template <class Column_type, class Cell_range>
-  friend bool _multiply_source_and_add_to_column(const typename Column_type::Field_element_type& val,
+                                                 Column& targetColumn);
+  template <class Column, class Cell_range>
+  friend bool _multiply_source_and_add_to_column(const typename Column::Field_element& val,
                                                  const Cell_range& source,
-                                                 Column_type& targetColumn);
+                                                 Column& targetColumn);
 
   void _delete_cell(iterator& it);
-  Cell* _insert_cell(const Field_element_type& value, id_index rowIndex, const iterator& position);
-  void _insert_cell(id_index rowIndex, const iterator& position);
+  Cell* _insert_cell(const Field_element& value, ID_index rowIndex, const iterator& position);
+  void _insert_cell(ID_index rowIndex, const iterator& position);
   template <class Cell_range>
   bool _add(const Cell_range& column);
   template <class Cell_range>
-  bool _multiply_target_and_add(const Field_element_type& val, const Cell_range& column);
+  bool _multiply_target_and_add(const Field_element& val, const Cell_range& column);
   template <class Cell_range>
-  bool _multiply_source_and_add(const Cell_range& column, const Field_element_type& val);
+  bool _multiply_source_and_add(const Cell_range& column, const Field_element& val);
 };
 
 template <class Master_matrix>
 inline Intrusive_set_column<Master_matrix>::Intrusive_set_column(Column_settings* colSettings)
-    : ra_opt(),
-      dim_opt(),
-      chain_opt(),
+    : RA_opt(),
+      Dim_opt(),
+      Chain_opt(),
       operators_(nullptr),
       cellPool_(colSettings == nullptr ? nullptr : &(colSettings->cellConstructor))
 {
-  if (operators_ == nullptr && cellPool_ == nullptr) return; // to allow default constructor which gives a dummy column
+  if (operators_ == nullptr && cellPool_ == nullptr) return;  // to allow default constructor which gives a dummy column
   if constexpr (!Master_matrix::Option_list::is_z2) {
     operators_ = &(colSettings->operators);
   }
 }
 
 template <class Master_matrix>
-template <class Container_type>
-inline Intrusive_set_column<Master_matrix>::Intrusive_set_column(
-    const Container_type& nonZeroRowIndices, Column_settings* colSettings)
-    : ra_opt(),
-      dim_opt(nonZeroRowIndices.size() == 0 ? 0 : nonZeroRowIndices.size() - 1),
-      chain_opt(),
+template <class Container>
+inline Intrusive_set_column<Master_matrix>::Intrusive_set_column(const Container& nonZeroRowIndices,
+                                                                 Column_settings* colSettings)
+    : RA_opt(),
+      Dim_opt(nonZeroRowIndices.size() == 0 ? 0 : nonZeroRowIndices.size() - 1),
+      Chain_opt(),
       operators_(nullptr),
       cellPool_(&(colSettings->cellConstructor))
 {
@@ -286,7 +281,7 @@ inline Intrusive_set_column<Master_matrix>::Intrusive_set_column(
                 "Constructor not available for chain columns, please specify the dimension of the chain.");
 
   if constexpr (Master_matrix::Option_list::is_z2) {
-    for (id_index id : nonZeroRowIndices) {
+    for (ID_index id : nonZeroRowIndices) {
       _insert_cell(id, column_.end());
     }
   } else {
@@ -298,15 +293,14 @@ inline Intrusive_set_column<Master_matrix>::Intrusive_set_column(
 }
 
 template <class Master_matrix>
-template <class Container_type, class Row_container_type>
-inline Intrusive_set_column<Master_matrix>::Intrusive_set_column(
-    index columnIndex, 
-    const Container_type& nonZeroRowIndices, 
-    Row_container_type* rowContainer,
-    Column_settings* colSettings)
-    : ra_opt(columnIndex, rowContainer),
-      dim_opt(nonZeroRowIndices.size() == 0 ? 0 : nonZeroRowIndices.size() - 1),
-      chain_opt([&] {
+template <class Container, class Row_container>
+inline Intrusive_set_column<Master_matrix>::Intrusive_set_column(Index columnIndex,
+                                                                 const Container& nonZeroRowIndices,
+                                                                 Row_container* rowContainer,
+                                                                 Column_settings* colSettings)
+    : RA_opt(columnIndex, rowContainer),
+      Dim_opt(nonZeroRowIndices.size() == 0 ? 0 : nonZeroRowIndices.size() - 1),
+      Chain_opt([&] {
         if constexpr (Master_matrix::Option_list::is_z2) {
           return nonZeroRowIndices.begin() == nonZeroRowIndices.end() ? -1 : *std::prev(nonZeroRowIndices.end());
         } else {
@@ -320,7 +314,7 @@ inline Intrusive_set_column<Master_matrix>::Intrusive_set_column(
                 "Constructor not available for chain columns, please specify the dimension of the chain.");
 
   if constexpr (Master_matrix::Option_list::is_z2) {
-    for (id_index id : nonZeroRowIndices) {
+    for (ID_index id : nonZeroRowIndices) {
       _insert_cell(id, column_.end());
     }
   } else {
@@ -332,14 +326,13 @@ inline Intrusive_set_column<Master_matrix>::Intrusive_set_column(
 }
 
 template <class Master_matrix>
-template <class Container_type>
-inline Intrusive_set_column<Master_matrix>::Intrusive_set_column(
-    const Container_type& nonZeroRowIndices, 
-    dimension_type dimension, 
-    Column_settings* colSettings)
-    : ra_opt(),
-      dim_opt(dimension),
-      chain_opt([&] {
+template <class Container>
+inline Intrusive_set_column<Master_matrix>::Intrusive_set_column(const Container& nonZeroRowIndices,
+                                                                 Dimension dimension,
+                                                                 Column_settings* colSettings)
+    : RA_opt(),
+      Dim_opt(dimension),
+      Chain_opt([&] {
         if constexpr (Master_matrix::Option_list::is_z2) {
           return nonZeroRowIndices.begin() == nonZeroRowIndices.end() ? -1 : *std::prev(nonZeroRowIndices.end());
         } else {
@@ -350,7 +343,7 @@ inline Intrusive_set_column<Master_matrix>::Intrusive_set_column(
       cellPool_(&(colSettings->cellConstructor))
 {
   if constexpr (Master_matrix::Option_list::is_z2) {
-    for (id_index id : nonZeroRowIndices) {
+    for (ID_index id : nonZeroRowIndices) {
       _insert_cell(id, column_.end());
     }
   } else {
@@ -362,16 +355,15 @@ inline Intrusive_set_column<Master_matrix>::Intrusive_set_column(
 }
 
 template <class Master_matrix>
-template <class Container_type, class Row_container_type>
-inline Intrusive_set_column<Master_matrix>::Intrusive_set_column(
-    index columnIndex, 
-    const Container_type& nonZeroRowIndices, 
-    dimension_type dimension,
-    Row_container_type* rowContainer, 
-    Column_settings* colSettings)
-    : ra_opt(columnIndex, rowContainer),
-      dim_opt(dimension),
-      chain_opt([&] {
+template <class Container, class Row_container>
+inline Intrusive_set_column<Master_matrix>::Intrusive_set_column(Index columnIndex,
+                                                                 const Container& nonZeroRowIndices,
+                                                                 Dimension dimension,
+                                                                 Row_container* rowContainer,
+                                                                 Column_settings* colSettings)
+    : RA_opt(columnIndex, rowContainer),
+      Dim_opt(dimension),
+      Chain_opt([&] {
         if constexpr (Master_matrix::Option_list::is_z2) {
           return nonZeroRowIndices.begin() == nonZeroRowIndices.end() ? -1 : *std::prev(nonZeroRowIndices.end());
         } else {
@@ -379,10 +371,10 @@ inline Intrusive_set_column<Master_matrix>::Intrusive_set_column(
         }
       }()),
       operators_(nullptr),
-      cellPool_(&(colSettings->cellConstructor)) 
+      cellPool_(&(colSettings->cellConstructor))
 {
   if constexpr (Master_matrix::Option_list::is_z2) {
-    for (id_index id : nonZeroRowIndices) {
+    for (ID_index id : nonZeroRowIndices) {
       _insert_cell(id, column_.end());
     }
   } else {
@@ -395,10 +387,10 @@ inline Intrusive_set_column<Master_matrix>::Intrusive_set_column(
 
 template <class Master_matrix>
 inline Intrusive_set_column<Master_matrix>::Intrusive_set_column(const Intrusive_set_column& column,
-                                                                                   Column_settings* colSettings)
-    : ra_opt(),
-      dim_opt(static_cast<const dim_opt&>(column)),
-      chain_opt(static_cast<const chain_opt&>(column)),
+                                                                 Column_settings* colSettings)
+    : RA_opt(),
+      Dim_opt(static_cast<const Dim_opt&>(column)),
+      Chain_opt(static_cast<const Chain_opt&>(column)),
       operators_(colSettings == nullptr ? column.operators_ : nullptr),
       cellPool_(colSettings == nullptr ? column.cellPool_ : &(colSettings->cellConstructor))
 {
@@ -406,26 +398,26 @@ inline Intrusive_set_column<Master_matrix>::Intrusive_set_column(const Intrusive
                 "Simple copy constructor not available when row access option enabled. Please specify the new column "
                 "index and the row container.");
 
-  if constexpr (!Master_matrix::Option_list::is_z2){
+  if constexpr (!Master_matrix::Option_list::is_z2) {
     if (colSettings != nullptr) operators_ = &(colSettings->operators);
   }
 
-  column_.clone_from(column.column_, new_cloner(cellPool_), delete_disposer(this));
+  column_.clone_from(column.column_, New_cloner(cellPool_), Delete_disposer(this));
 }
 
 template <class Master_matrix>
-template <class Row_container_type>
+template <class Row_container>
 inline Intrusive_set_column<Master_matrix>::Intrusive_set_column(const Intrusive_set_column& column,
-                                                                                   index columnIndex,
-                                                                                   Row_container_type* rowContainer,
-                                                                                   Column_settings* colSettings)
-    : ra_opt(columnIndex, rowContainer),
-      dim_opt(static_cast<const dim_opt&>(column)),
-      chain_opt(static_cast<const chain_opt&>(column)),
+                                                                 Index columnIndex,
+                                                                 Row_container* rowContainer,
+                                                                 Column_settings* colSettings)
+    : RA_opt(columnIndex, rowContainer),
+      Dim_opt(static_cast<const Dim_opt&>(column)),
+      Chain_opt(static_cast<const Chain_opt&>(column)),
       operators_(colSettings == nullptr ? column.operators_ : nullptr),
       cellPool_(colSettings == nullptr ? column.cellPool_ : &(colSettings->cellConstructor))
 {
-  if constexpr (!Master_matrix::Option_list::is_z2){
+  if constexpr (!Master_matrix::Option_list::is_z2) {
     if (colSettings != nullptr) operators_ = &(colSettings->operators);
   }
 
@@ -439,33 +431,32 @@ inline Intrusive_set_column<Master_matrix>::Intrusive_set_column(const Intrusive
 }
 
 template <class Master_matrix>
-inline Intrusive_set_column<Master_matrix>::Intrusive_set_column(
-    Intrusive_set_column&& column) noexcept
-    : ra_opt(std::move(static_cast<ra_opt&>(column))),
-      dim_opt(std::move(static_cast<dim_opt&>(column))),
-      chain_opt(std::move(static_cast<chain_opt&>(column))),
+inline Intrusive_set_column<Master_matrix>::Intrusive_set_column(Intrusive_set_column&& column) noexcept
+    : RA_opt(std::move(static_cast<RA_opt&>(column))),
+      Dim_opt(std::move(static_cast<Dim_opt&>(column))),
+      Chain_opt(std::move(static_cast<Chain_opt&>(column))),
       column_(std::move(column.column_)),
       operators_(std::exchange(column.operators_, nullptr)),
-      cellPool_(std::exchange(column.cellPool_, nullptr)) 
+      cellPool_(std::exchange(column.cellPool_, nullptr))
 {}
 
 template <class Master_matrix>
-inline Intrusive_set_column<Master_matrix>::~Intrusive_set_column() 
+inline Intrusive_set_column<Master_matrix>::~Intrusive_set_column()
 {
-  column_.clear_and_dispose(delete_disposer(this));
+  column_.clear_and_dispose(Delete_disposer(this));
 }
 
 template <class Master_matrix>
-inline std::vector<typename Intrusive_set_column<Master_matrix>::Field_element_type>
-Intrusive_set_column<Master_matrix>::get_content(int columnLength) const 
+inline std::vector<typename Intrusive_set_column<Master_matrix>::Field_element>
+Intrusive_set_column<Master_matrix>::get_content(int columnLength) const
 {
   if (columnLength < 0 && column_.size() > 0)
     columnLength = column_.rbegin()->get_row_index() + 1;
   else if (columnLength < 0)
-    return std::vector<Field_element_type>();
+    return std::vector<Field_element>();
 
-  std::vector<Field_element_type> container(columnLength);
-  for (auto it = column_.begin(); it != column_.end() && it->get_row_index() < static_cast<id_index>(columnLength);
+  std::vector<Field_element> container(columnLength);
+  for (auto it = column_.begin(); it != column_.end() && it->get_row_index() < static_cast<ID_index>(columnLength);
        ++it) {
     if constexpr (Master_matrix::Option_list::is_z2) {
       container[it->get_row_index()] = 1;
@@ -477,51 +468,49 @@ Intrusive_set_column<Master_matrix>::get_content(int columnLength) const
 }
 
 template <class Master_matrix>
-inline bool Intrusive_set_column<Master_matrix>::is_non_zero(id_index rowIndex) const 
+inline bool Intrusive_set_column<Master_matrix>::is_non_zero(ID_index rowIndex) const
 {
   return column_.find(Cell(rowIndex)) != column_.end();
 }
 
 template <class Master_matrix>
-inline bool Intrusive_set_column<Master_matrix>::is_empty() const 
+inline bool Intrusive_set_column<Master_matrix>::is_empty() const
 {
   return column_.empty();
 }
 
 template <class Master_matrix>
-inline std::size_t Intrusive_set_column<Master_matrix>::size() const 
+inline std::size_t Intrusive_set_column<Master_matrix>::size() const
 {
   return column_.size();
 }
 
 template <class Master_matrix>
-template <class Map_type>
-inline void Intrusive_set_column<Master_matrix>::reorder(const Map_type& valueMap,
-                                                                           [[maybe_unused]] index columnIndex) 
+template <class Row_index_map>
+inline void Intrusive_set_column<Master_matrix>::reorder(const Row_index_map& valueMap, [[maybe_unused]] Index columnIndex)
 {
   static_assert(!Master_matrix::isNonBasic || Master_matrix::Option_list::is_of_boundary_type,
                 "Method not available for chain columns.");
 
-  Column_type newSet;
+  Column newSet;
 
   if constexpr (Master_matrix::Option_list::has_row_access) {
     for (auto it = column_.begin(); it != column_.end();) {
-      Cell* newCell = cellPool_->construct(columnIndex == static_cast<index>(-1) ? 
-                                            ra_opt::columnIndex_ : columnIndex,
-                                            valueMap.at(it->get_row_index()));
+      Cell* newCell = cellPool_->construct(columnIndex == static_cast<Index>(-1) ? RA_opt::columnIndex_ : columnIndex,
+                                           valueMap.at(it->get_row_index()));
       if constexpr (!Master_matrix::Option_list::is_z2) {
         newCell->set_element(it->get_element());
       }
       newSet.insert(newSet.end(), *newCell);
-      _delete_cell(it);   // increases it
-      if constexpr (Master_matrix::Option_list::has_intrusive_rows)   // intrusive list
-        ra_opt::insert_cell(newCell->get_row_index(), newCell);
+      _delete_cell(it);                                              // increases it
+      if constexpr (Master_matrix::Option_list::has_intrusive_rows)  // intrusive list
+        RA_opt::insert_cell(newCell->get_row_index(), newCell);
     }
 
     // when row is a set, all cells have to be deleted first, to avoid colliding when inserting
     if constexpr (!Master_matrix::Option_list::has_intrusive_rows) {  // set
       for (Cell& cell : newSet) {
-        ra_opt::insert_cell(cell.get_row_index(), &cell);
+        RA_opt::insert_cell(cell.get_row_index(), &cell);
       }
     }
   } else {
@@ -531,7 +520,7 @@ inline void Intrusive_set_column<Master_matrix>::reorder(const Map_type& valueMa
         newCell->set_element(it->get_element());
       }
       newSet.insert(newSet.end(), *newCell);
-      _delete_cell(it);   // increases it
+      _delete_cell(it);  // increases it
     }
   }
 
@@ -539,16 +528,16 @@ inline void Intrusive_set_column<Master_matrix>::reorder(const Map_type& valueMa
 }
 
 template <class Master_matrix>
-inline void Intrusive_set_column<Master_matrix>::clear() 
+inline void Intrusive_set_column<Master_matrix>::clear()
 {
   static_assert(!Master_matrix::isNonBasic || Master_matrix::Option_list::is_of_boundary_type,
                 "Method not available for chain columns as a base element should not be empty.");
 
-  column_.clear_and_dispose(delete_disposer(this));
+  column_.clear_and_dispose(Delete_disposer(this));
 }
 
 template <class Master_matrix>
-inline void Intrusive_set_column<Master_matrix>::clear(id_index rowIndex) 
+inline void Intrusive_set_column<Master_matrix>::clear(ID_index rowIndex)
 {
   static_assert(!Master_matrix::isNonBasic || Master_matrix::Option_list::is_of_boundary_type,
                 "Method not available for chain columns.");
@@ -560,8 +549,7 @@ inline void Intrusive_set_column<Master_matrix>::clear(id_index rowIndex)
 }
 
 template <class Master_matrix>
-inline typename Intrusive_set_column<Master_matrix>::id_index
-Intrusive_set_column<Master_matrix>::get_pivot() const 
+inline typename Intrusive_set_column<Master_matrix>::ID_index Intrusive_set_column<Master_matrix>::get_pivot() const
 {
   static_assert(Master_matrix::isNonBasic,
                 "Method not available for base columns.");  // could technically be, but is the notion useful then?
@@ -570,13 +558,13 @@ Intrusive_set_column<Master_matrix>::get_pivot() const
     if (column_.empty()) return -1;
     return column_.rbegin()->get_row_index();
   } else {
-    return chain_opt::get_pivot();
+    return Chain_opt::get_pivot();
   }
 }
 
 template <class Master_matrix>
-inline typename Intrusive_set_column<Master_matrix>::Field_element_type
-Intrusive_set_column<Master_matrix>::get_pivot_value() const 
+inline typename Intrusive_set_column<Master_matrix>::Field_element
+Intrusive_set_column<Master_matrix>::get_pivot_value() const
 {
   static_assert(Master_matrix::isNonBasic,
                 "Method not available for base columns.");  // could technically be, but is the notion useful then?
@@ -588,8 +576,8 @@ Intrusive_set_column<Master_matrix>::get_pivot_value() const
       if (column_.empty()) return 0;
       return column_.rbegin()->get_element();
     } else {
-      if (chain_opt::get_pivot() == static_cast<id_index>(-1)) return 0;
-      auto it = column_.find(Cell(chain_opt::get_pivot()));
+      if (Chain_opt::get_pivot() == static_cast<ID_index>(-1)) return 0;
+      auto it = column_.find(Cell(Chain_opt::get_pivot()));
       GUDHI_CHECK(it != column_.end(),
                   "Intrusive_set_column::get_pivot_value - Pivot not found only if the column was misused.");
       return it->get_element();
@@ -598,65 +586,62 @@ Intrusive_set_column<Master_matrix>::get_pivot_value() const
 }
 
 template <class Master_matrix>
-inline typename Intrusive_set_column<Master_matrix>::iterator
-Intrusive_set_column<Master_matrix>::begin() noexcept 
+inline typename Intrusive_set_column<Master_matrix>::iterator Intrusive_set_column<Master_matrix>::begin() noexcept
 {
   return column_.begin();
 }
 
 template <class Master_matrix>
-inline typename Intrusive_set_column<Master_matrix>::const_iterator
-Intrusive_set_column<Master_matrix>::begin() const noexcept 
+inline typename Intrusive_set_column<Master_matrix>::const_iterator Intrusive_set_column<Master_matrix>::begin()
+    const noexcept
 {
   return column_.begin();
 }
 
 template <class Master_matrix>
-inline typename Intrusive_set_column<Master_matrix>::iterator
-Intrusive_set_column<Master_matrix>::end() noexcept 
+inline typename Intrusive_set_column<Master_matrix>::iterator Intrusive_set_column<Master_matrix>::end() noexcept
 {
   return column_.end();
 }
 
 template <class Master_matrix>
-inline typename Intrusive_set_column<Master_matrix>::const_iterator
-Intrusive_set_column<Master_matrix>::end() const noexcept 
+inline typename Intrusive_set_column<Master_matrix>::const_iterator Intrusive_set_column<Master_matrix>::end()
+    const noexcept
 {
   return column_.end();
 }
 
 template <class Master_matrix>
 inline typename Intrusive_set_column<Master_matrix>::reverse_iterator
-Intrusive_set_column<Master_matrix>::rbegin() noexcept 
+Intrusive_set_column<Master_matrix>::rbegin() noexcept
 {
   return column_.rbegin();
 }
 
 template <class Master_matrix>
 inline typename Intrusive_set_column<Master_matrix>::const_reverse_iterator
-Intrusive_set_column<Master_matrix>::rbegin() const noexcept 
+Intrusive_set_column<Master_matrix>::rbegin() const noexcept
 {
   return column_.rbegin();
 }
 
 template <class Master_matrix>
 inline typename Intrusive_set_column<Master_matrix>::reverse_iterator
-Intrusive_set_column<Master_matrix>::rend() noexcept 
+Intrusive_set_column<Master_matrix>::rend() noexcept
 {
   return column_.rend();
 }
 
 template <class Master_matrix>
-inline typename Intrusive_set_column<Master_matrix>::const_reverse_iterator
-Intrusive_set_column<Master_matrix>::rend() const noexcept 
+inline typename Intrusive_set_column<Master_matrix>::const_reverse_iterator Intrusive_set_column<Master_matrix>::rend()
+    const noexcept
 {
   return column_.rend();
 }
 
 template <class Master_matrix>
 template <class Cell_range>
-inline Intrusive_set_column<Master_matrix>&
-Intrusive_set_column<Master_matrix>::operator+=(const Cell_range& column) 
+inline Intrusive_set_column<Master_matrix>& Intrusive_set_column<Master_matrix>::operator+=(const Cell_range& column)
 {
   static_assert((!Master_matrix::isNonBasic || std::is_same_v<Cell_range, Intrusive_set_column>),
                 "For boundary columns, the range has to be a column of same type to help ensure the validity of the "
@@ -670,14 +655,14 @@ Intrusive_set_column<Master_matrix>::operator+=(const Cell_range& column)
 }
 
 template <class Master_matrix>
-inline Intrusive_set_column<Master_matrix>&
-Intrusive_set_column<Master_matrix>::operator+=(Intrusive_set_column& column) 
+inline Intrusive_set_column<Master_matrix>& Intrusive_set_column<Master_matrix>::operator+=(
+    Intrusive_set_column& column)
 {
   if constexpr (Master_matrix::isNonBasic && !Master_matrix::Option_list::is_of_boundary_type) {
     // assumes that the addition never zeros out this column.
     if (_add(column)) {
-      chain_opt::swap_pivots(column);
-      dim_opt::swap_dimension(column);
+      Chain_opt::swap_pivots(column);
+      Dim_opt::swap_dimension(column);
     }
   } else {
     _add(column);
@@ -687,8 +672,7 @@ Intrusive_set_column<Master_matrix>::operator+=(Intrusive_set_column& column)
 }
 
 template <class Master_matrix>
-inline Intrusive_set_column<Master_matrix>&
-Intrusive_set_column<Master_matrix>::operator*=(unsigned int v) 
+inline Intrusive_set_column<Master_matrix>& Intrusive_set_column<Master_matrix>::operator*=(unsigned int v)
 {
   if constexpr (Master_matrix::Option_list::is_z2) {
     if (v % 2 == 0) {
@@ -699,7 +683,7 @@ Intrusive_set_column<Master_matrix>::operator*=(unsigned int v)
       }
     }
   } else {
-    Field_element_type val = operators_->get_value(v);
+    Field_element val = operators_->get_value(v);
 
     if (val == Field_operators::get_additive_identity()) {
       if constexpr (Master_matrix::isNonBasic && !Master_matrix::Option_list::is_of_boundary_type) {
@@ -714,7 +698,7 @@ Intrusive_set_column<Master_matrix>::operator*=(unsigned int v)
 
     for (Cell& cell : column_) {
       operators_->multiply_inplace(cell.get_element(), val);
-      if constexpr (Master_matrix::Option_list::has_row_access) ra_opt::update_cell(cell);
+      if constexpr (Master_matrix::Option_list::has_row_access) RA_opt::update_cell(cell);
     }
   }
 
@@ -723,9 +707,8 @@ Intrusive_set_column<Master_matrix>::operator*=(unsigned int v)
 
 template <class Master_matrix>
 template <class Cell_range>
-inline Intrusive_set_column<Master_matrix>&
-Intrusive_set_column<Master_matrix>::multiply_target_and_add(const Field_element_type& val,
-                                                                        const Cell_range& column) 
+inline Intrusive_set_column<Master_matrix>& Intrusive_set_column<Master_matrix>::multiply_target_and_add(
+    const Field_element& val, const Cell_range& column)
 {
   static_assert((!Master_matrix::isNonBasic || std::is_same_v<Cell_range, Intrusive_set_column>),
                 "For boundary columns, the range has to be a column of same type to help ensure the validity of the "
@@ -748,25 +731,24 @@ Intrusive_set_column<Master_matrix>::multiply_target_and_add(const Field_element
 }
 
 template <class Master_matrix>
-inline Intrusive_set_column<Master_matrix>&
-Intrusive_set_column<Master_matrix>::multiply_target_and_add(const Field_element_type& val,
-                                                                        Intrusive_set_column& column) 
+inline Intrusive_set_column<Master_matrix>& Intrusive_set_column<Master_matrix>::multiply_target_and_add(
+    const Field_element& val, Intrusive_set_column& column)
 {
   if constexpr (Master_matrix::isNonBasic && !Master_matrix::Option_list::is_of_boundary_type) {
     // assumes that the addition never zeros out this column.
     if constexpr (Master_matrix::Option_list::is_z2) {
       if (val) {
         if (_add(column)) {
-          chain_opt::swap_pivots(column);
-          dim_opt::swap_dimension(column);
+          Chain_opt::swap_pivots(column);
+          Dim_opt::swap_dimension(column);
         }
       } else {
         throw std::invalid_argument("A chain column should not be multiplied by 0.");
       }
     } else {
       if (_multiply_target_and_add(val, column)) {
-        chain_opt::swap_pivots(column);
-        dim_opt::swap_dimension(column);
+        Chain_opt::swap_pivots(column);
+        Dim_opt::swap_dimension(column);
       }
     }
   } else {
@@ -787,9 +769,8 @@ Intrusive_set_column<Master_matrix>::multiply_target_and_add(const Field_element
 
 template <class Master_matrix>
 template <class Cell_range>
-inline Intrusive_set_column<Master_matrix>&
-Intrusive_set_column<Master_matrix>::multiply_source_and_add(const Cell_range& column,
-                                                                        const Field_element_type& val) 
+inline Intrusive_set_column<Master_matrix>& Intrusive_set_column<Master_matrix>::multiply_source_and_add(
+    const Cell_range& column, const Field_element& val)
 {
   static_assert((!Master_matrix::isNonBasic || std::is_same_v<Cell_range, Intrusive_set_column>),
                 "For boundary columns, the range has to be a column of same type to help ensure the validity of the "
@@ -809,23 +790,22 @@ Intrusive_set_column<Master_matrix>::multiply_source_and_add(const Cell_range& c
 }
 
 template <class Master_matrix>
-inline Intrusive_set_column<Master_matrix>&
-Intrusive_set_column<Master_matrix>::multiply_source_and_add(Intrusive_set_column& column,
-                                                                        const Field_element_type& val) 
+inline Intrusive_set_column<Master_matrix>& Intrusive_set_column<Master_matrix>::multiply_source_and_add(
+    Intrusive_set_column& column, const Field_element& val)
 {
   if constexpr (Master_matrix::isNonBasic && !Master_matrix::Option_list::is_of_boundary_type) {
     // assumes that the addition never zeros out this column.
     if constexpr (Master_matrix::Option_list::is_z2) {
       if (val) {
         if (_add(column)) {
-          chain_opt::swap_pivots(column);
-          dim_opt::swap_dimension(column);
+          Chain_opt::swap_pivots(column);
+          Dim_opt::swap_dimension(column);
         }
       }
     } else {
       if (_multiply_source_and_add(column, val)) {
-        chain_opt::swap_pivots(column);
-        dim_opt::swap_dimension(column);
+        Chain_opt::swap_pivots(column);
+        Dim_opt::swap_dimension(column);
       }
     }
   } else {
@@ -842,38 +822,38 @@ Intrusive_set_column<Master_matrix>::multiply_source_and_add(Intrusive_set_colum
 }
 
 template <class Master_matrix>
-inline Intrusive_set_column<Master_matrix>&
-Intrusive_set_column<Master_matrix>::operator=(const Intrusive_set_column& other) 
+inline Intrusive_set_column<Master_matrix>& Intrusive_set_column<Master_matrix>::operator=(
+    const Intrusive_set_column& other)
 {
   static_assert(!Master_matrix::Option_list::has_row_access, "= assignment not enabled with row access option.");
 
-  dim_opt::operator=(other);
-  chain_opt::operator=(other);
+  Dim_opt::operator=(other);
+  Chain_opt::operator=(other);
 
   // order is important
-  column_.clear_and_dispose(delete_disposer(this));
+  column_.clear_and_dispose(Delete_disposer(this));
   operators_ = other.operators_;
   cellPool_ = other.cellPool_;
-  column_.clone_from(other.column_, new_cloner(cellPool_), delete_disposer(this));
+  column_.clone_from(other.column_, New_cloner(cellPool_), Delete_disposer(this));
 
   return *this;
 }
 
 template <class Master_matrix>
-inline void Intrusive_set_column<Master_matrix>::_delete_cell(iterator& it) 
+inline void Intrusive_set_column<Master_matrix>::_delete_cell(iterator& it)
 {
-  it = column_.erase_and_dispose(it, delete_disposer(this));
+  it = column_.erase_and_dispose(it, Delete_disposer(this));
 }
 
 template <class Master_matrix>
 inline typename Intrusive_set_column<Master_matrix>::Cell* Intrusive_set_column<Master_matrix>::_insert_cell(
-    const Field_element_type& value, id_index rowIndex, const iterator& position)
+    const Field_element& value, ID_index rowIndex, const iterator& position)
 {
   if constexpr (Master_matrix::Option_list::has_row_access) {
-    Cell* newCell = cellPool_->construct(ra_opt::columnIndex_, rowIndex);
+    Cell* newCell = cellPool_->construct(RA_opt::columnIndex_, rowIndex);
     newCell->set_element(value);
     column_.insert(position, *newCell);
-    ra_opt::insert_cell(rowIndex, newCell);
+    RA_opt::insert_cell(rowIndex, newCell);
     return newCell;
   } else {
     Cell* newCell = cellPool_->construct(rowIndex);
@@ -884,13 +864,12 @@ inline typename Intrusive_set_column<Master_matrix>::Cell* Intrusive_set_column<
 }
 
 template <class Master_matrix>
-inline void Intrusive_set_column<Master_matrix>::_insert_cell(id_index rowIndex,
-                                                                                const iterator& position) 
+inline void Intrusive_set_column<Master_matrix>::_insert_cell(ID_index rowIndex, const iterator& position)
 {
   if constexpr (Master_matrix::Option_list::has_row_access) {
-    Cell* newCell = cellPool_->construct(ra_opt::columnIndex_, rowIndex);
+    Cell* newCell = cellPool_->construct(RA_opt::columnIndex_, rowIndex);
     column_.insert(position, *newCell);
-    ra_opt::insert_cell(rowIndex, newCell);
+    RA_opt::insert_cell(rowIndex, newCell);
   } else {
     Cell* newCell = cellPool_->construct(rowIndex);
     column_.insert(position, *newCell);
@@ -899,15 +878,15 @@ inline void Intrusive_set_column<Master_matrix>::_insert_cell(id_index rowIndex,
 
 template <class Master_matrix>
 template <class Cell_range>
-inline bool Intrusive_set_column<Master_matrix>::_add(const Cell_range& column) 
+inline bool Intrusive_set_column<Master_matrix>::_add(const Cell_range& column)
 {
   return _add_to_column(column, *this);
 }
 
 template <class Master_matrix>
 template <class Cell_range>
-inline bool Intrusive_set_column<Master_matrix>::_multiply_target_and_add(const Field_element_type& val,
-                                                                          const Cell_range& column) 
+inline bool Intrusive_set_column<Master_matrix>::_multiply_target_and_add(const Field_element& val,
+                                                                          const Cell_range& column)
 {
   return _multiply_target_and_add_to_column(val, column, *this);
 }
@@ -915,7 +894,7 @@ inline bool Intrusive_set_column<Master_matrix>::_multiply_target_and_add(const 
 template <class Master_matrix>
 template <class Cell_range>
 inline bool Intrusive_set_column<Master_matrix>::_multiply_source_and_add(const Cell_range& column,
-                                                                          const Field_element_type& val) 
+                                                                          const Field_element& val)
 {
   return _multiply_source_and_add_to_column(val, column, *this);
 }
@@ -923,18 +902,16 @@ inline bool Intrusive_set_column<Master_matrix>::_multiply_source_and_add(const 
 }  // namespace persistence_matrix
 }  // namespace Gudhi
 
-
 /**
  * @ingroup persistence_matrix
  *
  * @brief Hash method for @ref Gudhi::persistence_matrix::Intrusive_set_column.
- * 
+ *
  * @tparam Master_matrix Template parameter of @ref Gudhi::persistence_matrix::Intrusive_set_column.
  * @tparam Cell_constructor Template parameter of @ref Gudhi::persistence_matrix::Intrusive_set_column.
  */
 template <class Master_matrix>
-struct std::hash<Gudhi::persistence_matrix::Intrusive_set_column<Master_matrix> > 
-{
+struct std::hash<Gudhi::persistence_matrix::Intrusive_set_column<Master_matrix> > {
   std::size_t operator()(const Gudhi::persistence_matrix::Intrusive_set_column<Master_matrix>& column) const {
     return Gudhi::persistence_matrix::hash_column(column);
   }

--- a/src/Persistence_matrix/include/gudhi/Persistence_matrix/columns/list_column.h
+++ b/src/Persistence_matrix/include/gudhi/Persistence_matrix/columns/list_column.h
@@ -40,75 +40,72 @@ namespace persistence_matrix {
  *
  * Column based on a list structure. The cells are always ordered by row index and only non-zero values
  * are stored uniquely in the underlying container.
- * 
+ *
  * @tparam Master_matrix An instantiation of @ref Matrix from which all types and options are deduced.
  * @tparam Cell_constructor Factory of @ref Cell classes.
  */
 template <class Master_matrix>
 class List_column : public Master_matrix::Row_access_option,
                     public Master_matrix::Column_dimension_option,
-                    public Master_matrix::Chain_column_option 
+                    public Master_matrix::Chain_column_option
 {
  public:
   using Master = Master_matrix;
-  using index = typename Master_matrix::index;
-  using id_index = typename Master_matrix::id_index;
-  using dimension_type = typename Master_matrix::dimension_type;
-  using Field_element_type = typename Master_matrix::element_type;
-  using Cell = typename Master_matrix::Cell_type;
+  using Index = typename Master_matrix::Index;
+  using ID_index = typename Master_matrix::ID_index;
+  using Dimension = typename Master_matrix::Dimension;
+  using Field_element = typename Master_matrix::Element;
+  using Cell = typename Master_matrix::Matrix_cell;
   using Column_settings = typename Master_matrix::Column_settings;
 
  private:
   using Field_operators = typename Master_matrix::Field_operators;
-  using Column_type = std::list<Cell*>;
+  using Column = std::list<Cell*>;
   using Cell_constructor = typename Master_matrix::Cell_constructor;
 
  public:
-  using iterator = boost::indirect_iterator<typename Column_type::iterator>;
-  using const_iterator = boost::indirect_iterator<typename Column_type::const_iterator>;
-  using reverse_iterator = boost::indirect_iterator<typename Column_type::reverse_iterator>;
-  using const_reverse_iterator = boost::indirect_iterator<typename Column_type::const_reverse_iterator>;
+  using iterator = boost::indirect_iterator<typename Column::iterator>;
+  using const_iterator = boost::indirect_iterator<typename Column::const_iterator>;
+  using reverse_iterator = boost::indirect_iterator<typename Column::reverse_iterator>;
+  using const_reverse_iterator = boost::indirect_iterator<typename Column::const_reverse_iterator>;
 
   List_column(Column_settings* colSettings = nullptr);
-  template <class Container_type = typename Master_matrix::boundary_type>
-  List_column(const Container_type& nonZeroRowIndices, Column_settings* colSettings);
-  template <class Container_type = typename Master_matrix::boundary_type, class Row_container_type>
-  List_column(index columnIndex, 
-              const Container_type& nonZeroRowIndices, 
-              Row_container_type* rowContainer,
+  template <class Container = typename Master_matrix::Boundary>
+  List_column(const Container& nonZeroRowIndices, Column_settings* colSettings);
+  template <class Container = typename Master_matrix::Boundary, class Row_container>
+  List_column(Index columnIndex,
+              const Container& nonZeroRowIndices,
+              Row_container* rowContainer,
               Column_settings* colSettings);
-  template <class Container_type = typename Master_matrix::boundary_type>
-  List_column(const Container_type& nonZeroChainRowIndices, 
-              dimension_type dimension, 
+  template <class Container = typename Master_matrix::Boundary>
+  List_column(const Container& nonZeroChainRowIndices, Dimension dimension, Column_settings* colSettings);
+  template <class Container = typename Master_matrix::Boundary, class Row_container>
+  List_column(Index columnIndex,
+              const Container& nonZeroChainRowIndices,
+              Dimension dimension,
+              Row_container* rowContainer,
               Column_settings* colSettings);
-  template <class Container_type = typename Master_matrix::boundary_type, class Row_container_type>
-  List_column(index columnIndex, 
-              const Container_type& nonZeroChainRowIndices, 
-              dimension_type dimension,
-              Row_container_type* rowContainer, 
-              Column_settings* colSettings);
-  List_column(const List_column& column, 
-              Column_settings* colSettings = nullptr);
-  template <class Row_container_type>
-  List_column(const List_column& column, 
-              index columnIndex, 
-              Row_container_type* rowContainer,
+  List_column(const List_column& column, Column_settings* colSettings = nullptr);
+  template <class Row_container>
+  List_column(const List_column& column,
+              Index columnIndex,
+              Row_container* rowContainer,
               Column_settings* colSettings = nullptr);
   List_column(List_column&& column) noexcept;
   ~List_column();
 
-  std::vector<Field_element_type> get_content(int columnLength = -1) const;
-  bool is_non_zero(id_index rowIndex) const;
+  std::vector<Field_element> get_content(int columnLength = -1) const;
+  bool is_non_zero(ID_index rowIndex) const;
   bool is_empty() const;
   std::size_t size() const;
 
-  template <class Map_type>
-  void reorder(const Map_type& valueMap, [[maybe_unused]] index columnIndex = -1);
+  template <class Row_index_map>
+  void reorder(const Row_index_map& valueMap, [[maybe_unused]] Index columnIndex = -1);
   void clear();
-  void clear(id_index rowIndex);
+  void clear(ID_index rowIndex);
 
-  id_index get_pivot() const;
-  Field_element_type get_pivot_value() const;
+  ID_index get_pivot() const;
+  Field_element get_pivot_value() const;
 
   iterator begin() noexcept;
   const_iterator begin() const noexcept;
@@ -127,12 +124,12 @@ class List_column : public Master_matrix::Row_access_option,
 
   // this = v * this + column
   template <class Cell_range>
-  List_column& multiply_target_and_add(const Field_element_type& val, const Cell_range& column);
-  List_column& multiply_target_and_add(const Field_element_type& val, List_column& column);
+  List_column& multiply_target_and_add(const Field_element& val, const Cell_range& column);
+  List_column& multiply_target_and_add(const Field_element& val, List_column& column);
   // this = this + column * v
   template <class Cell_range>
-  List_column& multiply_source_and_add(const Cell_range& column, const Field_element_type& val);
-  List_column& multiply_source_and_add(List_column& column, const Field_element_type& val);
+  List_column& multiply_source_and_add(const Cell_range& column, const Field_element& val);
+  List_column& multiply_source_and_add(List_column& column, const Field_element& val);
 
   friend bool operator==(const List_column& c1, const List_column& c2) {
     if (&c1 == &c2) return true;
@@ -184,78 +181,75 @@ class List_column : public Master_matrix::Row_access_option,
   }
 
  private:
-  using ra_opt = typename Master_matrix::Row_access_option;
-  using dim_opt = typename Master_matrix::Column_dimension_option;
-  using chain_opt = typename Master_matrix::Chain_column_option;
+  using RA_opt = typename Master_matrix::Row_access_option;
+  using Dim_opt = typename Master_matrix::Column_dimension_option;
+  using Chain_opt = typename Master_matrix::Chain_column_option;
 
-  Column_type column_;
+  Column column_;
   Field_operators* operators_;
   Cell_constructor* cellPool_;
 
-  template <class Column_type, class Cell_iterator, typename F1, typename F2, typename F3, typename F4>
-  friend void _generic_merge_cell_to_column(Column_type& targetColumn,
+  template <class Column, class Cell_iterator, typename F1, typename F2, typename F3, typename F4>
+  friend void _generic_merge_cell_to_column(Column& targetColumn,
                                             Cell_iterator& itSource,
-                                            typename Column_type::Column_type::iterator& itTarget,
+                                            typename Column::Column::iterator& itTarget,
                                             F1&& process_target,
                                             F2&& process_source,
                                             F3&& update_target1,
                                             F4&& update_target2,
                                             bool& pivotIsZeroed);
-  template <class Column_type, class Cell_range, typename F1, typename F2, typename F3, typename F4, typename F5>
+  template <class Column, class Cell_range, typename F1, typename F2, typename F3, typename F4, typename F5>
   friend bool _generic_add_to_column(const Cell_range& source,
-                                     Column_type& targetColumn,
+                                     Column& targetColumn,
                                      F1&& process_target,
                                      F2&& process_source,
                                      F3&& update_target1,
                                      F4&& update_target2,
                                      F5&& finish_target);
-  template <class Column_type, class Cell_range>
-  friend bool _add_to_column(const Cell_range& source, Column_type& targetColumn);
-  template <class Column_type, class Cell_range>
-  friend bool _multiply_target_and_add_to_column(const typename Column_type::Field_element_type& val,
+  template <class Column, class Cell_range>
+  friend bool _add_to_column(const Cell_range& source, Column& targetColumn);
+  template <class Column, class Cell_range>
+  friend bool _multiply_target_and_add_to_column(const typename Column::Field_element& val,
                                                  const Cell_range& source,
-                                                 Column_type& targetColumn);
-  template <class Column_type, class Cell_range>
-  friend bool _multiply_source_and_add_to_column(const typename Column_type::Field_element_type& val,
+                                                 Column& targetColumn);
+  template <class Column, class Cell_range>
+  friend bool _multiply_source_and_add_to_column(const typename Column::Field_element& val,
                                                  const Cell_range& source,
-                                                 Column_type& targetColumn);
+                                                 Column& targetColumn);
 
-  void _delete_cell(typename Column_type::iterator& it);
-  Cell* _insert_cell(const Field_element_type& value,
-                     id_index rowIndex,
-                     const typename Column_type::iterator& position);
-  void _insert_cell(id_index rowIndex, const typename Column_type::iterator& position);
-  void _update_cell(const Field_element_type& value, id_index rowIndex, const typename Column_type::iterator& position);
-  void _update_cell(id_index rowIndex, const typename Column_type::iterator& position);
+  void _delete_cell(typename Column::iterator& it);
+  Cell* _insert_cell(const Field_element& value, ID_index rowIndex, const typename Column::iterator& position);
+  void _insert_cell(ID_index rowIndex, const typename Column::iterator& position);
+  void _update_cell(const Field_element& value, ID_index rowIndex, const typename Column::iterator& position);
+  void _update_cell(ID_index rowIndex, const typename Column::iterator& position);
   template <class Cell_range>
   bool _add(const Cell_range& column);
   template <class Cell_range>
-  bool _multiply_target_and_add(const Field_element_type& val, const Cell_range& column);
+  bool _multiply_target_and_add(const Field_element& val, const Cell_range& column);
   template <class Cell_range>
-  bool _multiply_source_and_add(const Cell_range& column, const Field_element_type& val);
+  bool _multiply_source_and_add(const Cell_range& column, const Field_element& val);
 };
 
 template <class Master_matrix>
 inline List_column<Master_matrix>::List_column(Column_settings* colSettings)
-    : ra_opt(),
-      dim_opt(),
-      chain_opt(),
+    : RA_opt(),
+      Dim_opt(),
+      Chain_opt(),
       operators_(nullptr),
       cellPool_(colSettings == nullptr ? nullptr : &(colSettings->cellConstructor))
 {
-  if (operators_ == nullptr && cellPool_ == nullptr) return; // to allow default constructor which gives a dummy column
+  if (operators_ == nullptr && cellPool_ == nullptr) return;  // to allow default constructor which gives a dummy column
   if constexpr (!Master_matrix::Option_list::is_z2) {
     operators_ = &(colSettings->operators);
   }
 }
 
 template <class Master_matrix>
-template <class Container_type>
-inline List_column<Master_matrix>::List_column(const Container_type& nonZeroRowIndices,
-                                                                 Column_settings* colSettings)
-    : ra_opt(),
-      dim_opt(nonZeroRowIndices.size() == 0 ? 0 : nonZeroRowIndices.size() - 1),
-      chain_opt(),
+template <class Container>
+inline List_column<Master_matrix>::List_column(const Container& nonZeroRowIndices, Column_settings* colSettings)
+    : RA_opt(),
+      Dim_opt(nonZeroRowIndices.size() == 0 ? 0 : nonZeroRowIndices.size() - 1),
+      Chain_opt(),
       column_(nonZeroRowIndices.size()),
       operators_(nullptr),
       cellPool_(&(colSettings->cellConstructor))
@@ -265,7 +259,7 @@ inline List_column<Master_matrix>::List_column(const Container_type& nonZeroRowI
 
   auto it = column_.begin();
   if constexpr (Master_matrix::Option_list::is_z2) {
-    for (id_index id : nonZeroRowIndices) {
+    for (ID_index id : nonZeroRowIndices) {
       _update_cell(id, it++);
     }
   } else {
@@ -277,14 +271,14 @@ inline List_column<Master_matrix>::List_column(const Container_type& nonZeroRowI
 }
 
 template <class Master_matrix>
-template <class Container_type, class Row_container_type>
-inline List_column<Master_matrix>::List_column(index columnIndex,
-                                                                 const Container_type& nonZeroRowIndices,
-                                                                 Row_container_type* rowContainer,
-                                                                 Column_settings* colSettings)
-    : ra_opt(columnIndex, rowContainer),
-      dim_opt(nonZeroRowIndices.size() == 0 ? 0 : nonZeroRowIndices.size() - 1),
-      chain_opt([&] {
+template <class Container, class Row_container>
+inline List_column<Master_matrix>::List_column(Index columnIndex,
+                                               const Container& nonZeroRowIndices,
+                                               Row_container* rowContainer,
+                                               Column_settings* colSettings)
+    : RA_opt(columnIndex, rowContainer),
+      Dim_opt(nonZeroRowIndices.size() == 0 ? 0 : nonZeroRowIndices.size() - 1),
+      Chain_opt([&] {
         if constexpr (Master_matrix::Option_list::is_z2) {
           return nonZeroRowIndices.begin() == nonZeroRowIndices.end() ? -1 : *std::prev(nonZeroRowIndices.end());
         } else {
@@ -300,7 +294,7 @@ inline List_column<Master_matrix>::List_column(index columnIndex,
 
   auto it = column_.begin();
   if constexpr (Master_matrix::Option_list::is_z2) {
-    for (id_index id : nonZeroRowIndices) {
+    for (ID_index id : nonZeroRowIndices) {
       _update_cell(id, it++);
     }
   } else {
@@ -312,13 +306,13 @@ inline List_column<Master_matrix>::List_column(index columnIndex,
 }
 
 template <class Master_matrix>
-template <class Container_type>
-inline List_column<Master_matrix>::List_column(const Container_type& nonZeroRowIndices,
-                                                                 dimension_type dimension, 
-                                                                 Column_settings* colSettings)
-    : ra_opt(),
-      dim_opt(dimension),
-      chain_opt([&] {
+template <class Container>
+inline List_column<Master_matrix>::List_column(const Container& nonZeroRowIndices,
+                                               Dimension dimension,
+                                               Column_settings* colSettings)
+    : RA_opt(),
+      Dim_opt(dimension),
+      Chain_opt([&] {
         if constexpr (Master_matrix::Option_list::is_z2) {
           return nonZeroRowIndices.begin() == nonZeroRowIndices.end() ? -1 : *std::prev(nonZeroRowIndices.end());
         } else {
@@ -331,7 +325,7 @@ inline List_column<Master_matrix>::List_column(const Container_type& nonZeroRowI
 {
   auto it = column_.begin();
   if constexpr (Master_matrix::Option_list::is_z2) {
-    for (id_index id : nonZeroRowIndices) {
+    for (ID_index id : nonZeroRowIndices) {
       _update_cell(id, it++);
     }
   } else {
@@ -343,16 +337,15 @@ inline List_column<Master_matrix>::List_column(const Container_type& nonZeroRowI
 }
 
 template <class Master_matrix>
-template <class Container_type, class Row_container_type>
-inline List_column<Master_matrix>::List_column(
-    index columnIndex, 
-    const Container_type& nonZeroRowIndices, 
-    dimension_type dimension,
-    Row_container_type* rowContainer, 
-    Column_settings* colSettings)
-    : ra_opt(columnIndex, rowContainer),
-      dim_opt(dimension),
-      chain_opt([&] {
+template <class Container, class Row_container>
+inline List_column<Master_matrix>::List_column(Index columnIndex,
+                                               const Container& nonZeroRowIndices,
+                                               Dimension dimension,
+                                               Row_container* rowContainer,
+                                               Column_settings* colSettings)
+    : RA_opt(columnIndex, rowContainer),
+      Dim_opt(dimension),
+      Chain_opt([&] {
         if constexpr (Master_matrix::Option_list::is_z2) {
           return nonZeroRowIndices.begin() == nonZeroRowIndices.end() ? -1 : *std::prev(nonZeroRowIndices.end());
         } else {
@@ -365,7 +358,7 @@ inline List_column<Master_matrix>::List_column(
 {
   auto it = column_.begin();
   if constexpr (Master_matrix::Option_list::is_z2) {
-    for (id_index id : nonZeroRowIndices) {
+    for (ID_index id : nonZeroRowIndices) {
       _update_cell(id, it++);
     }
   } else {
@@ -377,11 +370,10 @@ inline List_column<Master_matrix>::List_column(
 }
 
 template <class Master_matrix>
-inline List_column<Master_matrix>::List_column(const List_column& column, 
-                                                                 Column_settings* colSettings)
-    : ra_opt(),
-      dim_opt(static_cast<const dim_opt&>(column)),
-      chain_opt(static_cast<const chain_opt&>(column)),
+inline List_column<Master_matrix>::List_column(const List_column& column, Column_settings* colSettings)
+    : RA_opt(),
+      Dim_opt(static_cast<const Dim_opt&>(column)),
+      Chain_opt(static_cast<const Chain_opt&>(column)),
       column_(column.column_.size()),
       operators_(colSettings == nullptr ? column.operators_ : nullptr),
       cellPool_(colSettings == nullptr ? column.cellPool_ : &(colSettings->cellConstructor))
@@ -390,7 +382,7 @@ inline List_column<Master_matrix>::List_column(const List_column& column,
                 "Simple copy constructor not available when row access option enabled. Please specify the new column "
                 "index and the row container.");
 
-  if constexpr (!Master_matrix::Option_list::is_z2){
+  if constexpr (!Master_matrix::Option_list::is_z2) {
     if (colSettings != nullptr) operators_ = &(colSettings->operators);
   }
 
@@ -405,19 +397,19 @@ inline List_column<Master_matrix>::List_column(const List_column& column,
 }
 
 template <class Master_matrix>
-template <class Row_container_type>
-inline List_column<Master_matrix>::List_column(const List_column& column, 
-                                                                 index columnIndex,
-                                                                 Row_container_type* rowContainer,
-                                                                 Column_settings* colSettings)
-    : ra_opt(columnIndex, rowContainer),
-      dim_opt(static_cast<const dim_opt&>(column)),
-      chain_opt(static_cast<const chain_opt&>(column)),
+template <class Row_container>
+inline List_column<Master_matrix>::List_column(const List_column& column,
+                                               Index columnIndex,
+                                               Row_container* rowContainer,
+                                               Column_settings* colSettings)
+    : RA_opt(columnIndex, rowContainer),
+      Dim_opt(static_cast<const Dim_opt&>(column)),
+      Chain_opt(static_cast<const Chain_opt&>(column)),
       column_(column.column_.size()),
       operators_(colSettings == nullptr ? column.operators_ : nullptr),
       cellPool_(colSettings == nullptr ? column.cellPool_ : &(colSettings->cellConstructor))
 {
-  if constexpr (!Master_matrix::Option_list::is_z2){
+  if constexpr (!Master_matrix::Option_list::is_z2) {
     if (colSettings != nullptr) operators_ = &(colSettings->operators);
   }
 
@@ -433,34 +425,33 @@ inline List_column<Master_matrix>::List_column(const List_column& column,
 
 template <class Master_matrix>
 inline List_column<Master_matrix>::List_column(List_column&& column) noexcept
-    : ra_opt(std::move(static_cast<ra_opt&>(column))),
-      dim_opt(std::move(static_cast<dim_opt&>(column))),
-      chain_opt(std::move(static_cast<chain_opt&>(column))),
+    : RA_opt(std::move(static_cast<RA_opt&>(column))),
+      Dim_opt(std::move(static_cast<Dim_opt&>(column))),
+      Chain_opt(std::move(static_cast<Chain_opt&>(column))),
       column_(std::move(column.column_)),
       operators_(std::exchange(column.operators_, nullptr)),
-      cellPool_(std::exchange(column.cellPool_, nullptr)) 
+      cellPool_(std::exchange(column.cellPool_, nullptr))
 {}
 
 template <class Master_matrix>
-inline List_column<Master_matrix>::~List_column() 
-{
+inline List_column<Master_matrix>::~List_column() {
   for (auto* cell : column_) {
-    if constexpr (Master_matrix::Option_list::has_row_access) ra_opt::unlink(cell);
+    if constexpr (Master_matrix::Option_list::has_row_access) RA_opt::unlink(cell);
     cellPool_->destroy(cell);
   }
 }
 
 template <class Master_matrix>
-inline std::vector<typename List_column<Master_matrix>::Field_element_type>
-List_column<Master_matrix>::get_content(int columnLength) const 
+inline std::vector<typename List_column<Master_matrix>::Field_element> List_column<Master_matrix>::get_content(
+    int columnLength) const
 {
   if (columnLength < 0 && column_.size() > 0)
     columnLength = column_.back()->get_row_index() + 1;
   else if (columnLength < 0)
-    return std::vector<Field_element_type>();
+    return std::vector<Field_element>();
 
-  std::vector<Field_element_type> container(columnLength, 0);
-  for (auto it = column_.begin(); it != column_.end() && (*it)->get_row_index() < static_cast<id_index>(columnLength);
+  std::vector<Field_element> container(columnLength, 0);
+  for (auto it = column_.begin(); it != column_.end() && (*it)->get_row_index() < static_cast<ID_index>(columnLength);
        ++it) {
     if constexpr (Master_matrix::Option_list::is_z2) {
       container[(*it)->get_row_index()] = 1;
@@ -472,7 +463,7 @@ List_column<Master_matrix>::get_content(int columnLength) const
 }
 
 template <class Master_matrix>
-inline bool List_column<Master_matrix>::is_non_zero(id_index rowIndex) const 
+inline bool List_column<Master_matrix>::is_non_zero(ID_index rowIndex) const
 {
   // could be changed to dichotomic search as column is ordered by row index,
   // but I am not sure if it is really worth it as there is no random access
@@ -484,20 +475,20 @@ inline bool List_column<Master_matrix>::is_non_zero(id_index rowIndex) const
 }
 
 template <class Master_matrix>
-inline bool List_column<Master_matrix>::is_empty() const 
+inline bool List_column<Master_matrix>::is_empty() const
 {
   return column_.empty();
 }
 
 template <class Master_matrix>
-inline std::size_t List_column<Master_matrix>::size() const 
+inline std::size_t List_column<Master_matrix>::size() const
 {
   return column_.size();
 }
 
 template <class Master_matrix>
-template <class Map_type>
-inline void List_column<Master_matrix>::reorder(const Map_type& valueMap, [[maybe_unused]] index columnIndex) 
+template <class Row_index_map>
+inline void List_column<Master_matrix>::reorder(const Row_index_map& valueMap, [[maybe_unused]] Index columnIndex)
 {
   static_assert(!Master_matrix::isNonBasic || Master_matrix::Option_list::is_of_boundary_type,
                 "Method not available for chain columns.");
@@ -505,19 +496,19 @@ inline void List_column<Master_matrix>::reorder(const Map_type& valueMap, [[mayb
   for (auto it = column_.begin(); it != column_.end(); ++it) {
     Cell* cell = *it;
     if constexpr (Master_matrix::Option_list::has_row_access) {
-      ra_opt::unlink(cell);
-      if (columnIndex != static_cast<index>(-1)) cell->set_column_index(columnIndex);
+      RA_opt::unlink(cell);
+      if (columnIndex != static_cast<Index>(-1)) cell->set_column_index(columnIndex);
     }
     cell->set_row_index(valueMap.at(cell->get_row_index()));
     if constexpr (Master_matrix::Option_list::has_intrusive_rows && Master_matrix::Option_list::has_row_access)
-      ra_opt::insert_cell(cell->get_row_index(), cell);
+      RA_opt::insert_cell(cell->get_row_index(), cell);
   }
 
   // all cells have to be deleted first, to avoid problem with insertion when row is a set
   if constexpr (!Master_matrix::Option_list::has_intrusive_rows && Master_matrix::Option_list::has_row_access) {
     for (auto it = column_.begin(); it != column_.end(); ++it) {
       Cell* cell = *it;
-      ra_opt::insert_cell(cell->get_row_index(), cell);
+      RA_opt::insert_cell(cell->get_row_index(), cell);
     }
   }
 
@@ -525,13 +516,13 @@ inline void List_column<Master_matrix>::reorder(const Map_type& valueMap, [[mayb
 }
 
 template <class Master_matrix>
-inline void List_column<Master_matrix>::clear() 
+inline void List_column<Master_matrix>::clear()
 {
   static_assert(!Master_matrix::isNonBasic || Master_matrix::Option_list::is_of_boundary_type,
                 "Method not available for chain columns as a base element should not be empty.");
 
   for (auto* cell : column_) {
-    if constexpr (Master_matrix::Option_list::has_row_access) ra_opt::unlink(cell);
+    if constexpr (Master_matrix::Option_list::has_row_access) RA_opt::unlink(cell);
     cellPool_->destroy(cell);
   }
 
@@ -539,7 +530,7 @@ inline void List_column<Master_matrix>::clear()
 }
 
 template <class Master_matrix>
-inline void List_column<Master_matrix>::clear(id_index rowIndex) 
+inline void List_column<Master_matrix>::clear(ID_index rowIndex)
 {
   static_assert(!Master_matrix::isNonBasic || Master_matrix::Option_list::is_of_boundary_type,
                 "Method not available for chain columns.");
@@ -550,8 +541,7 @@ inline void List_column<Master_matrix>::clear(id_index rowIndex)
 }
 
 template <class Master_matrix>
-inline typename List_column<Master_matrix>::id_index
-List_column<Master_matrix>::get_pivot() const 
+inline typename List_column<Master_matrix>::ID_index List_column<Master_matrix>::get_pivot() const
 {
   static_assert(Master_matrix::isNonBasic,
                 "Method not available for base columns.");  // could technically be, but is the notion useful then?
@@ -560,13 +550,12 @@ List_column<Master_matrix>::get_pivot() const
     if (column_.empty()) return -1;
     return column_.back()->get_row_index();
   } else {
-    return chain_opt::get_pivot();
+    return Chain_opt::get_pivot();
   }
 }
 
 template <class Master_matrix>
-inline typename List_column<Master_matrix>::Field_element_type
-List_column<Master_matrix>::get_pivot_value() const 
+inline typename List_column<Master_matrix>::Field_element List_column<Master_matrix>::get_pivot_value() const
 {
   static_assert(Master_matrix::isNonBasic,
                 "Method not available for base columns.");  // could technically be, but is the notion useful then?
@@ -578,75 +567,66 @@ List_column<Master_matrix>::get_pivot_value() const
       if (column_.empty()) return 0;
       return column_.back()->get_element();
     } else {
-      if (chain_opt::get_pivot() == static_cast<id_index>(-1)) return Field_element_type();
+      if (Chain_opt::get_pivot() == static_cast<ID_index>(-1)) return Field_element();
       for (const Cell* cell : column_) {
-        if (cell->get_row_index() == chain_opt::get_pivot()) return cell->get_element();
+        if (cell->get_row_index() == Chain_opt::get_pivot()) return cell->get_element();
       }
-      return Field_element_type();  // should never happen if chain column is used properly
+      return Field_element();  // should never happen if chain column is used properly
     }
   }
 }
 
 template <class Master_matrix>
-inline typename List_column<Master_matrix>::iterator
-List_column<Master_matrix>::begin() noexcept 
+inline typename List_column<Master_matrix>::iterator List_column<Master_matrix>::begin() noexcept
 {
   return column_.begin();
 }
 
 template <class Master_matrix>
-inline typename List_column<Master_matrix>::const_iterator
-List_column<Master_matrix>::begin() const noexcept 
+inline typename List_column<Master_matrix>::const_iterator List_column<Master_matrix>::begin() const noexcept
 {
   return column_.begin();
 }
 
 template <class Master_matrix>
-inline typename List_column<Master_matrix>::iterator
-List_column<Master_matrix>::end() noexcept 
+inline typename List_column<Master_matrix>::iterator List_column<Master_matrix>::end() noexcept
 {
   return column_.end();
 }
 
 template <class Master_matrix>
-inline typename List_column<Master_matrix>::const_iterator
-List_column<Master_matrix>::end() const noexcept 
+inline typename List_column<Master_matrix>::const_iterator List_column<Master_matrix>::end() const noexcept
 {
   return column_.end();
 }
 
 template <class Master_matrix>
-inline typename List_column<Master_matrix>::reverse_iterator
-List_column<Master_matrix>::rbegin() noexcept 
+inline typename List_column<Master_matrix>::reverse_iterator List_column<Master_matrix>::rbegin() noexcept
 {
   return column_.rbegin();
 }
 
 template <class Master_matrix>
-inline typename List_column<Master_matrix>::const_reverse_iterator
-List_column<Master_matrix>::rbegin() const noexcept 
+inline typename List_column<Master_matrix>::const_reverse_iterator List_column<Master_matrix>::rbegin() const noexcept
 {
   return column_.rbegin();
 }
 
 template <class Master_matrix>
-inline typename List_column<Master_matrix>::reverse_iterator
-List_column<Master_matrix>::rend() noexcept 
+inline typename List_column<Master_matrix>::reverse_iterator List_column<Master_matrix>::rend() noexcept
 {
   return column_.rend();
 }
 
 template <class Master_matrix>
-inline typename List_column<Master_matrix>::const_reverse_iterator
-List_column<Master_matrix>::rend() const noexcept 
+inline typename List_column<Master_matrix>::const_reverse_iterator List_column<Master_matrix>::rend() const noexcept
 {
   return column_.rend();
 }
 
 template <class Master_matrix>
 template <class Cell_range>
-inline List_column<Master_matrix>& List_column<Master_matrix>::operator+=(
-    const Cell_range& column) 
+inline List_column<Master_matrix>& List_column<Master_matrix>::operator+=(const Cell_range& column)
 {
   static_assert((!Master_matrix::isNonBasic || std::is_same_v<Cell_range, List_column>),
                 "For boundary columns, the range has to be a column of same type to help ensure the validity of the "
@@ -660,14 +640,13 @@ inline List_column<Master_matrix>& List_column<Master_matrix>::operator+=(
 }
 
 template <class Master_matrix>
-inline List_column<Master_matrix>& List_column<Master_matrix>::operator+=(
-    List_column& column) 
+inline List_column<Master_matrix>& List_column<Master_matrix>::operator+=(List_column& column)
 {
   if constexpr (Master_matrix::isNonBasic && !Master_matrix::Option_list::is_of_boundary_type) {
     // assumes that the addition never zeros out this column.
     if (_add(column)) {
-      chain_opt::swap_pivots(column);
-      dim_opt::swap_dimension(column);
+      Chain_opt::swap_pivots(column);
+      Dim_opt::swap_dimension(column);
     }
   } else {
     _add(column);
@@ -677,8 +656,7 @@ inline List_column<Master_matrix>& List_column<Master_matrix>::operator+=(
 }
 
 template <class Master_matrix>
-inline List_column<Master_matrix>& List_column<Master_matrix>::operator*=(
-    unsigned int v) 
+inline List_column<Master_matrix>& List_column<Master_matrix>::operator*=(unsigned int v)
 {
   if constexpr (Master_matrix::Option_list::is_z2) {
     if (v % 2 == 0) {
@@ -689,7 +667,7 @@ inline List_column<Master_matrix>& List_column<Master_matrix>::operator*=(
       }
     }
   } else {
-    Field_element_type val = operators_->get_value(v);
+    Field_element val = operators_->get_value(v);
 
     if (val == 0u) {
       if constexpr (Master_matrix::isNonBasic && !Master_matrix::Option_list::is_of_boundary_type) {
@@ -704,7 +682,7 @@ inline List_column<Master_matrix>& List_column<Master_matrix>::operator*=(
 
     for (Cell* cell : column_) {
       operators_->multiply_inplace(cell->get_element(), val);
-      if constexpr (Master_matrix::Option_list::has_row_access) ra_opt::update_cell(*cell);
+      if constexpr (Master_matrix::Option_list::has_row_access) RA_opt::update_cell(*cell);
     }
   }
 
@@ -713,8 +691,8 @@ inline List_column<Master_matrix>& List_column<Master_matrix>::operator*=(
 
 template <class Master_matrix>
 template <class Cell_range>
-inline List_column<Master_matrix>& List_column<Master_matrix>::multiply_target_and_add(
-    const Field_element_type& val, const Cell_range& column) 
+inline List_column<Master_matrix>& List_column<Master_matrix>::multiply_target_and_add(const Field_element& val,
+                                                                                       const Cell_range& column)
 {
   static_assert((!Master_matrix::isNonBasic || std::is_same_v<Cell_range, List_column>),
                 "For boundary columns, the range has to be a column of same type to help ensure the validity of the "
@@ -737,24 +715,24 @@ inline List_column<Master_matrix>& List_column<Master_matrix>::multiply_target_a
 }
 
 template <class Master_matrix>
-inline List_column<Master_matrix>& List_column<Master_matrix>::multiply_target_and_add(
-    const Field_element_type& val, List_column& column) 
+inline List_column<Master_matrix>& List_column<Master_matrix>::multiply_target_and_add(const Field_element& val,
+                                                                                       List_column& column)
 {
   if constexpr (Master_matrix::isNonBasic && !Master_matrix::Option_list::is_of_boundary_type) {
     // assumes that the addition never zeros out this column.
     if constexpr (Master_matrix::Option_list::is_z2) {
       if (val) {
         if (_add(column)) {
-          chain_opt::swap_pivots(column);
-          dim_opt::swap_dimension(column);
+          Chain_opt::swap_pivots(column);
+          Dim_opt::swap_dimension(column);
         }
       } else {
         throw std::invalid_argument("A chain column should not be multiplied by 0.");
       }
     } else {
       if (_multiply_target_and_add(val, column)) {
-        chain_opt::swap_pivots(column);
-        dim_opt::swap_dimension(column);
+        Chain_opt::swap_pivots(column);
+        Dim_opt::swap_dimension(column);
       }
     }
   } else {
@@ -775,8 +753,8 @@ inline List_column<Master_matrix>& List_column<Master_matrix>::multiply_target_a
 
 template <class Master_matrix>
 template <class Cell_range>
-inline List_column<Master_matrix>& List_column<Master_matrix>::multiply_source_and_add(
-    const Cell_range& column, const Field_element_type& val) 
+inline List_column<Master_matrix>& List_column<Master_matrix>::multiply_source_and_add(const Cell_range& column,
+                                                                                       const Field_element& val)
 {
   static_assert((!Master_matrix::isNonBasic || std::is_same_v<Cell_range, List_column>),
                 "For boundary columns, the range has to be a column of same type to help ensure the validity of the "
@@ -796,22 +774,22 @@ inline List_column<Master_matrix>& List_column<Master_matrix>::multiply_source_a
 }
 
 template <class Master_matrix>
-inline List_column<Master_matrix>& List_column<Master_matrix>::multiply_source_and_add(
-    List_column& column, const Field_element_type& val) 
+inline List_column<Master_matrix>& List_column<Master_matrix>::multiply_source_and_add(List_column& column,
+                                                                                       const Field_element& val)
 {
   if constexpr (Master_matrix::isNonBasic && !Master_matrix::Option_list::is_of_boundary_type) {
     // assumes that the addition never zeros out this column.
     if constexpr (Master_matrix::Option_list::is_z2) {
       if (val) {
         if (_add(column)) {
-          chain_opt::swap_pivots(column);
-          dim_opt::swap_dimension(column);
+          Chain_opt::swap_pivots(column);
+          Dim_opt::swap_dimension(column);
         }
       }
     } else {
       if (_multiply_source_and_add(column, val)) {
-        chain_opt::swap_pivots(column);
-        dim_opt::swap_dimension(column);
+        Chain_opt::swap_pivots(column);
+        Dim_opt::swap_dimension(column);
       }
     }
   } else {
@@ -828,19 +806,19 @@ inline List_column<Master_matrix>& List_column<Master_matrix>::multiply_source_a
 }
 
 template <class Master_matrix>
-inline List_column<Master_matrix>& List_column<Master_matrix>::operator=(const List_column& other) 
+inline List_column<Master_matrix>& List_column<Master_matrix>::operator=(const List_column& other)
 {
   static_assert(!Master_matrix::Option_list::has_row_access, "= assignment not enabled with row access option.");
 
-  dim_opt::operator=(other);
-  chain_opt::operator=(other);
+  Dim_opt::operator=(other);
+  Chain_opt::operator=(other);
 
   auto tmpPool = cellPool_;
   cellPool_ = other.cellPool_;
 
   while (column_.size() > other.column_.size()) {
     if (column_.back() != nullptr) {
-      if constexpr (Master_matrix::Option_list::has_row_access) ra_opt::unlink(column_.back());
+      if constexpr (Master_matrix::Option_list::has_row_access) RA_opt::unlink(column_.back());
       tmpPool->destroy(column_.back());
     }
     column_.pop_back();
@@ -850,7 +828,7 @@ inline List_column<Master_matrix>& List_column<Master_matrix>::operator=(const L
   auto it = column_.begin();
   for (const Cell* cell : other.column_) {
     if (*it != nullptr) {
-      if constexpr (Master_matrix::Option_list::has_row_access) ra_opt::unlink(*it);
+      if constexpr (Master_matrix::Option_list::has_row_access) RA_opt::unlink(*it);
       tmpPool->destroy(*it);
     }
     if constexpr (Master_matrix::Option_list::is_z2) {
@@ -866,22 +844,22 @@ inline List_column<Master_matrix>& List_column<Master_matrix>::operator=(const L
 }
 
 template <class Master_matrix>
-inline void List_column<Master_matrix>::_delete_cell(typename Column_type::iterator& it) 
+inline void List_column<Master_matrix>::_delete_cell(typename Column::iterator& it)
 {
-  if constexpr (Master_matrix::Option_list::has_row_access) ra_opt::unlink(*it);
+  if constexpr (Master_matrix::Option_list::has_row_access) RA_opt::unlink(*it);
   cellPool_->destroy(*it);
   it = column_.erase(it);
 }
 
 template <class Master_matrix>
 inline typename List_column<Master_matrix>::Cell* List_column<Master_matrix>::_insert_cell(
-    const Field_element_type& value, id_index rowIndex, const typename Column_type::iterator& position)
+    const Field_element& value, ID_index rowIndex, const typename Column::iterator& position)
 {
   if constexpr (Master_matrix::Option_list::has_row_access) {
-    Cell* newCell = cellPool_->construct(ra_opt::columnIndex_, rowIndex);
+    Cell* newCell = cellPool_->construct(RA_opt::columnIndex_, rowIndex);
     newCell->set_element(value);
     column_.insert(position, newCell);
-    ra_opt::insert_cell(rowIndex, newCell);
+    RA_opt::insert_cell(rowIndex, newCell);
     return newCell;
   } else {
     Cell* newCell = cellPool_->construct(rowIndex);
@@ -892,13 +870,12 @@ inline typename List_column<Master_matrix>::Cell* List_column<Master_matrix>::_i
 }
 
 template <class Master_matrix>
-inline void List_column<Master_matrix>::_insert_cell(id_index rowIndex,
-                                                                       const typename Column_type::iterator& position) 
+inline void List_column<Master_matrix>::_insert_cell(ID_index rowIndex, const typename Column::iterator& position)
 {
   if constexpr (Master_matrix::Option_list::has_row_access) {
-    Cell* newCell = cellPool_->construct(ra_opt::columnIndex_, rowIndex);
+    Cell* newCell = cellPool_->construct(RA_opt::columnIndex_, rowIndex);
     column_.insert(position, newCell);
-    ra_opt::insert_cell(rowIndex, newCell);
+    RA_opt::insert_cell(rowIndex, newCell);
   } else {
     Cell* newCell = cellPool_->construct(rowIndex);
     column_.insert(position, newCell);
@@ -906,14 +883,14 @@ inline void List_column<Master_matrix>::_insert_cell(id_index rowIndex,
 }
 
 template <class Master_matrix>
-inline void List_column<Master_matrix>::_update_cell(const Field_element_type& value,
-                                                                       id_index rowIndex,
-                                                                       const typename Column_type::iterator& position) 
+inline void List_column<Master_matrix>::_update_cell(const Field_element& value,
+                                                     ID_index rowIndex,
+                                                     const typename Column::iterator& position)
 {
   if constexpr (Master_matrix::Option_list::has_row_access) {
-    *position = cellPool_->construct(ra_opt::columnIndex_, rowIndex);
+    *position = cellPool_->construct(RA_opt::columnIndex_, rowIndex);
     (*position)->set_element(value);
-    ra_opt::insert_cell(rowIndex, *position);
+    RA_opt::insert_cell(rowIndex, *position);
   } else {
     *position = cellPool_->construct(rowIndex);
     (*position)->set_element(value);
@@ -921,12 +898,11 @@ inline void List_column<Master_matrix>::_update_cell(const Field_element_type& v
 }
 
 template <class Master_matrix>
-inline void List_column<Master_matrix>::_update_cell(id_index rowIndex,
-                                                                       const typename Column_type::iterator& position) 
+inline void List_column<Master_matrix>::_update_cell(ID_index rowIndex, const typename Column::iterator& position)
 {
   if constexpr (Master_matrix::Option_list::has_row_access) {
-    *position = cellPool_->construct(ra_opt::columnIndex_, rowIndex);
-    ra_opt::insert_cell(rowIndex, *position);
+    *position = cellPool_->construct(RA_opt::columnIndex_, rowIndex);
+    RA_opt::insert_cell(rowIndex, *position);
   } else {
     *position = cellPool_->construct(rowIndex);
   }
@@ -934,7 +910,7 @@ inline void List_column<Master_matrix>::_update_cell(id_index rowIndex,
 
 template <class Master_matrix>
 template <class Cell_range>
-inline bool List_column<Master_matrix>::_add(const Cell_range& column) 
+inline bool List_column<Master_matrix>::_add(const Cell_range& column)
 {
   if (column.begin() == column.end()) return false;
   if (column_.empty()) {  // chain should never enter here.
@@ -955,16 +931,14 @@ inline bool List_column<Master_matrix>::_add(const Cell_range& column)
 
 template <class Master_matrix>
 template <class Cell_range>
-inline bool List_column<Master_matrix>::_multiply_target_and_add(const Field_element_type& val,
-                                                                            const Cell_range& column) 
+inline bool List_column<Master_matrix>::_multiply_target_and_add(const Field_element& val, const Cell_range& column)
 {
   return _multiply_target_and_add_to_column(val, column, *this);
 }
 
 template <class Master_matrix>
 template <class Cell_range>
-inline bool List_column<Master_matrix>::_multiply_source_and_add(const Cell_range& column,
-                                                                            const Field_element_type& val) 
+inline bool List_column<Master_matrix>::_multiply_source_and_add(const Cell_range& column, const Field_element& val)
 {
   return _multiply_source_and_add_to_column(val, column, *this);
 }
@@ -976,13 +950,12 @@ inline bool List_column<Master_matrix>::_multiply_source_and_add(const Cell_rang
  * @ingroup persistence_matrix
  *
  * @brief Hash method for @ref Gudhi::persistence_matrix::List_column.
- * 
+ *
  * @tparam Master_matrix Template parameter of @ref Gudhi::persistence_matrix::List_column.
  * @tparam Cell_constructor Template parameter of @ref Gudhi::persistence_matrix::List_column.
  */
 template <class Master_matrix>
-struct std::hash<Gudhi::persistence_matrix::List_column<Master_matrix> > 
-{
+struct std::hash<Gudhi::persistence_matrix::List_column<Master_matrix> > {
   std::size_t operator()(const Gudhi::persistence_matrix::List_column<Master_matrix>& column) const {
     return Gudhi::persistence_matrix::hash_column(column);
   }

--- a/src/Persistence_matrix/include/gudhi/Persistence_matrix/columns/naive_vector_column.h
+++ b/src/Persistence_matrix/include/gudhi/Persistence_matrix/columns/naive_vector_column.h
@@ -21,8 +21,8 @@
 #include <vector>
 #include <stdexcept>
 #include <type_traits>
-#include <algorithm>    //binary_search
-#include <utility>      //std::swap, std::move & std::exchange
+#include <algorithm>  //binary_search
+#include <utility>    //std::swap, std::move & std::exchange
 
 #include <boost/iterator/indirect_iterator.hpp>
 
@@ -40,76 +40,72 @@ namespace persistence_matrix {
  *
  * Column based on a vector structure. The cells are always ordered by row index and only non-zero values
  * are stored uniquely in the underlying container.
- * 
+ *
  * @tparam Master_matrix An instantiation of @ref Matrix from which all types and options are deduced.
  * @tparam Cell_constructor Factory of @ref Cell classes.
  */
 template <class Master_matrix>
 class Naive_vector_column : public Master_matrix::Row_access_option,
                             public Master_matrix::Column_dimension_option,
-                            public Master_matrix::Chain_column_option 
+                            public Master_matrix::Chain_column_option
 {
  public:
   using Master = Master_matrix;
-  using index = typename Master_matrix::index;
-  using id_index = typename Master_matrix::id_index;
-  using dimension_type = typename Master_matrix::dimension_type;
-  using Field_element_type = typename Master_matrix::element_type;
-  using Cell = typename Master_matrix::Cell_type;
+  using Index = typename Master_matrix::Index;
+  using ID_index = typename Master_matrix::ID_index;
+  using Dimension = typename Master_matrix::Dimension;
+  using Field_element = typename Master_matrix::Element;
+  using Cell = typename Master_matrix::Matrix_cell;
   using Column_settings = typename Master_matrix::Column_settings;
 
  private:
   using Field_operators = typename Master_matrix::Field_operators;
-  using Column_type = std::vector<Cell*>;
+  using Column = std::vector<Cell*>;
   using Cell_constructor = typename Master_matrix::Cell_constructor;
 
  public:
-  using iterator = boost::indirect_iterator<typename Column_type::iterator>;
-  using const_iterator = boost::indirect_iterator<typename Column_type::const_iterator>;
-  using reverse_iterator = boost::indirect_iterator<typename Column_type::reverse_iterator>;
-  using const_reverse_iterator = boost::indirect_iterator<typename Column_type::const_reverse_iterator>;
+  using iterator = boost::indirect_iterator<typename Column::iterator>;
+  using const_iterator = boost::indirect_iterator<typename Column::const_iterator>;
+  using reverse_iterator = boost::indirect_iterator<typename Column::reverse_iterator>;
+  using const_reverse_iterator = boost::indirect_iterator<typename Column::const_reverse_iterator>;
 
   Naive_vector_column(Column_settings* colSettings = nullptr);
-  template <class Container_type = typename Master_matrix::boundary_type>
-  Naive_vector_column(const Container_type& nonZeroRowIndices, 
+  template <class Container = typename Master_matrix::Boundary>
+  Naive_vector_column(const Container& nonZeroRowIndices, Column_settings* colSettings);
+  template <class Container = typename Master_matrix::Boundary, class Row_container>
+  Naive_vector_column(Index columnIndex,
+                      const Container& nonZeroRowIndices,
+                      Row_container* rowContainer,
                       Column_settings* colSettings);
-  template <class Container_type = typename Master_matrix::boundary_type, class Row_container_type>
-  Naive_vector_column(index columnIndex, 
-                      const Container_type& nonZeroRowIndices, 
-                      Row_container_type* rowContainer,
+  template <class Container = typename Master_matrix::Boundary>
+  Naive_vector_column(const Container& nonZeroChainRowIndices, Dimension dimension, Column_settings* colSettings);
+  template <class Container = typename Master_matrix::Boundary, class Row_container>
+  Naive_vector_column(Index columnIndex,
+                      const Container& nonZeroChainRowIndices,
+                      Dimension dimension,
+                      Row_container* rowContainer,
                       Column_settings* colSettings);
-  template <class Container_type = typename Master_matrix::boundary_type>
-  Naive_vector_column(const Container_type& nonZeroChainRowIndices, 
-                      dimension_type dimension,
-                      Column_settings* colSettings);
-  template <class Container_type = typename Master_matrix::boundary_type, class Row_container_type>
-  Naive_vector_column(index columnIndex, 
-                      const Container_type& nonZeroChainRowIndices, 
-                      dimension_type dimension,
-                      Row_container_type* rowContainer, 
-                      Column_settings* colSettings);
-  Naive_vector_column(const Naive_vector_column& column, 
-                      Column_settings* colSettings = nullptr);
-  template <class Row_container_type>
-  Naive_vector_column(const Naive_vector_column& column, 
-                      index columnIndex, 
-                      Row_container_type* rowContainer,
+  Naive_vector_column(const Naive_vector_column& column, Column_settings* colSettings = nullptr);
+  template <class Row_container>
+  Naive_vector_column(const Naive_vector_column& column,
+                      Index columnIndex,
+                      Row_container* rowContainer,
                       Column_settings* colSettings = nullptr);
   Naive_vector_column(Naive_vector_column&& column) noexcept;
   ~Naive_vector_column();
 
-  std::vector<Field_element_type> get_content(int columnLength = -1) const;
-  bool is_non_zero(id_index rowIndex) const;
+  std::vector<Field_element> get_content(int columnLength = -1) const;
+  bool is_non_zero(ID_index rowIndex) const;
   bool is_empty() const;
   std::size_t size() const;
 
-  template <class Map_type>
-  void reorder(const Map_type& valueMap, [[maybe_unused]] index columnIndex = -1);
+  template <class Row_index_map>
+  void reorder(const Row_index_map& valueMap, [[maybe_unused]] Index columnIndex = -1);
   void clear();
-  void clear(id_index rowIndex);
+  void clear(ID_index rowIndex);
 
-  id_index get_pivot() const;
-  Field_element_type get_pivot_value() const;
+  ID_index get_pivot() const;
+  Field_element get_pivot_value() const;
 
   iterator begin() noexcept;
   const_iterator begin() const noexcept;
@@ -128,12 +124,12 @@ class Naive_vector_column : public Master_matrix::Row_access_option,
 
   // this = v * this + column
   template <class Cell_range>
-  Naive_vector_column& multiply_target_and_add(const Field_element_type& val, const Cell_range& column);
-  Naive_vector_column& multiply_target_and_add(const Field_element_type& val, Naive_vector_column& column);
+  Naive_vector_column& multiply_target_and_add(const Field_element& val, const Cell_range& column);
+  Naive_vector_column& multiply_target_and_add(const Field_element& val, Naive_vector_column& column);
   // this = this + column * v
   template <class Cell_range>
-  Naive_vector_column& multiply_source_and_add(const Cell_range& column, const Field_element_type& val);
-  Naive_vector_column& multiply_source_and_add(Naive_vector_column& column, const Field_element_type& val);
+  Naive_vector_column& multiply_source_and_add(const Cell_range& column, const Field_element& val);
+  Naive_vector_column& multiply_source_and_add(Naive_vector_column& column, const Field_element& val);
 
   friend bool operator==(const Naive_vector_column& c1, const Naive_vector_column& c2) {
     if (&c1 == &c2) return true;
@@ -185,26 +181,26 @@ class Naive_vector_column : public Master_matrix::Row_access_option,
   }
 
  private:
-  using ra_opt = typename Master_matrix::Row_access_option;
-  using dim_opt = typename Master_matrix::Column_dimension_option;
-  using chain_opt = typename Master_matrix::Chain_column_option;
+  using RA_opt = typename Master_matrix::Row_access_option;
+  using Dim_opt = typename Master_matrix::Column_dimension_option;
+  using Chain_opt = typename Master_matrix::Chain_column_option;
 
-  Column_type column_;
+  Column column_;
   Field_operators* operators_;
   Cell_constructor* cellPool_;
 
-  template <class Column_type, class Cell_iterator, typename F1, typename F2, typename F3, typename F4>
-  friend void _generic_merge_cell_to_column(Column_type& targetColumn,
+  template <class Column, class Cell_iterator, typename F1, typename F2, typename F3, typename F4>
+  friend void _generic_merge_cell_to_column(Column& targetColumn,
                                             Cell_iterator& itSource,
-                                            typename Column_type::Column_type::iterator& itTarget,
+                                            typename Column::Column::iterator& itTarget,
                                             F1&& process_target,
                                             F2&& process_source,
                                             F3&& update_target1,
                                             F4&& update_target2,
                                             bool& pivotIsZeroed);
-  template <class Column_type, class Cell_range, typename F1, typename F2, typename F3, typename F4, typename F5>
+  template <class Column, class Cell_range, typename F1, typename F2, typename F3, typename F4, typename F5>
   friend bool _generic_add_to_column(const Cell_range& source,
-                                     Column_type& targetColumn,
+                                     Column& targetColumn,
                                      F1&& process_target,
                                      F2&& process_source,
                                      F3&& update_target1,
@@ -212,40 +208,40 @@ class Naive_vector_column : public Master_matrix::Row_access_option,
                                      F5&& finish_target);
 
   void _delete_cell(Cell* cell);
-  void _delete_cell(typename Column_type::iterator& it);
-  Cell* _insert_cell(const Field_element_type& value, id_index rowIndex, Column_type& column);
-  void _insert_cell(id_index rowIndex, Column_type& column);
-  void _update_cell(const Field_element_type& value, id_index rowIndex, index position);
-  void _update_cell(id_index rowIndex, index position);
+  void _delete_cell(typename Column::iterator& it);
+  Cell* _insert_cell(const Field_element& value, ID_index rowIndex, Column& column);
+  void _insert_cell(ID_index rowIndex, Column& column);
+  void _update_cell(const Field_element& value, ID_index rowIndex, Index position);
+  void _update_cell(ID_index rowIndex, Index position);
   template <class Cell_range>
   bool _add(const Cell_range& column);
   template <class Cell_range>
-  bool _multiply_target_and_add(const Field_element_type& val, const Cell_range& column);
+  bool _multiply_target_and_add(const Field_element& val, const Cell_range& column);
   template <class Cell_range>
-  bool _multiply_source_and_add(const Cell_range& column, const Field_element_type& val);
+  bool _multiply_source_and_add(const Cell_range& column, const Field_element& val);
 };
 
 template <class Master_matrix>
 inline Naive_vector_column<Master_matrix>::Naive_vector_column(Column_settings* colSettings)
-    : ra_opt(),
-      dim_opt(),
-      chain_opt(),
+    : RA_opt(),
+      Dim_opt(),
+      Chain_opt(),
       operators_(nullptr),
       cellPool_(colSettings == nullptr ? nullptr : &(colSettings->cellConstructor))
 {
-  if (operators_ == nullptr && cellPool_ == nullptr) return; // to allow default constructor which gives a dummy column
+  if (operators_ == nullptr && cellPool_ == nullptr) return;  // to allow default constructor which gives a dummy column
   if constexpr (!Master_matrix::Option_list::is_z2) {
     operators_ = &(colSettings->operators);
   }
 }
 
 template <class Master_matrix>
-template <class Container_type>
-inline Naive_vector_column<Master_matrix>::Naive_vector_column(
-    const Container_type& nonZeroRowIndices, Column_settings* colSettings)
-    : ra_opt(),
-      dim_opt(nonZeroRowIndices.size() == 0 ? 0 : nonZeroRowIndices.size() - 1),
-      chain_opt(),
+template <class Container>
+inline Naive_vector_column<Master_matrix>::Naive_vector_column(const Container& nonZeroRowIndices,
+                                                               Column_settings* colSettings)
+    : RA_opt(),
+      Dim_opt(nonZeroRowIndices.size() == 0 ? 0 : nonZeroRowIndices.size() - 1),
+      Chain_opt(),
       column_(nonZeroRowIndices.size(), nullptr),
       operators_(nullptr),
       cellPool_(&(colSettings->cellConstructor))
@@ -253,9 +249,9 @@ inline Naive_vector_column<Master_matrix>::Naive_vector_column(
   static_assert(!Master_matrix::isNonBasic || Master_matrix::Option_list::is_of_boundary_type,
                 "Constructor not available for chain columns, please specify the dimension of the chain.");
 
-  index i = 0;
+  Index i = 0;
   if constexpr (Master_matrix::Option_list::is_z2) {
-    for (id_index id : nonZeroRowIndices) {
+    for (ID_index id : nonZeroRowIndices) {
       _update_cell(id, i++);
     }
   } else {
@@ -267,15 +263,14 @@ inline Naive_vector_column<Master_matrix>::Naive_vector_column(
 }
 
 template <class Master_matrix>
-template <class Container_type, class Row_container_type>
-inline Naive_vector_column<Master_matrix>::Naive_vector_column(
-    index columnIndex, 
-    const Container_type& nonZeroRowIndices, 
-    Row_container_type* rowContainer,
-    Column_settings* colSettings)
-    : ra_opt(columnIndex, rowContainer),
-      dim_opt(nonZeroRowIndices.size() == 0 ? 0 : nonZeroRowIndices.size() - 1),
-      chain_opt([&] {
+template <class Container, class Row_container>
+inline Naive_vector_column<Master_matrix>::Naive_vector_column(Index columnIndex,
+                                                               const Container& nonZeroRowIndices,
+                                                               Row_container* rowContainer,
+                                                               Column_settings* colSettings)
+    : RA_opt(columnIndex, rowContainer),
+      Dim_opt(nonZeroRowIndices.size() == 0 ? 0 : nonZeroRowIndices.size() - 1),
+      Chain_opt([&] {
         if constexpr (Master_matrix::Option_list::is_z2) {
           return nonZeroRowIndices.begin() == nonZeroRowIndices.end() ? -1 : *std::prev(nonZeroRowIndices.end());
         } else {
@@ -289,9 +284,9 @@ inline Naive_vector_column<Master_matrix>::Naive_vector_column(
   static_assert(!Master_matrix::isNonBasic || Master_matrix::Option_list::is_of_boundary_type,
                 "Constructor not available for chain columns, please specify the dimension of the chain.");
 
-  index i = 0;
+  Index i = 0;
   if constexpr (Master_matrix::Option_list::is_z2) {
-    for (id_index id : nonZeroRowIndices) {
+    for (ID_index id : nonZeroRowIndices) {
       _update_cell(id, i++);
     }
   } else {
@@ -303,14 +298,13 @@ inline Naive_vector_column<Master_matrix>::Naive_vector_column(
 }
 
 template <class Master_matrix>
-template <class Container_type>
-inline Naive_vector_column<Master_matrix>::Naive_vector_column(
-    const Container_type& nonZeroRowIndices, 
-    dimension_type dimension, 
-    Column_settings* colSettings)
-    : ra_opt(),
-      dim_opt(dimension),
-      chain_opt([&] {
+template <class Container>
+inline Naive_vector_column<Master_matrix>::Naive_vector_column(const Container& nonZeroRowIndices,
+                                                               Dimension dimension,
+                                                               Column_settings* colSettings)
+    : RA_opt(),
+      Dim_opt(dimension),
+      Chain_opt([&] {
         if constexpr (Master_matrix::Option_list::is_z2) {
           return nonZeroRowIndices.begin() == nonZeroRowIndices.end() ? -1 : *std::prev(nonZeroRowIndices.end());
         } else {
@@ -321,9 +315,9 @@ inline Naive_vector_column<Master_matrix>::Naive_vector_column(
       operators_(nullptr),
       cellPool_(&(colSettings->cellConstructor))
 {
-  index i = 0;
+  Index i = 0;
   if constexpr (Master_matrix::Option_list::is_z2) {
-    for (id_index id : nonZeroRowIndices) {
+    for (ID_index id : nonZeroRowIndices) {
       _update_cell(id, i++);
     }
   } else {
@@ -335,16 +329,15 @@ inline Naive_vector_column<Master_matrix>::Naive_vector_column(
 }
 
 template <class Master_matrix>
-template <class Container_type, class Row_container_type>
-inline Naive_vector_column<Master_matrix>::Naive_vector_column(
-    index columnIndex, 
-    const Container_type& nonZeroRowIndices, 
-    dimension_type dimension,
-    Row_container_type* rowContainer, 
-    Column_settings* colSettings)
-    : ra_opt(columnIndex, rowContainer),
-      dim_opt(dimension),
-      chain_opt([&] {
+template <class Container, class Row_container>
+inline Naive_vector_column<Master_matrix>::Naive_vector_column(Index columnIndex,
+                                                               const Container& nonZeroRowIndices,
+                                                               Dimension dimension,
+                                                               Row_container* rowContainer,
+                                                               Column_settings* colSettings)
+    : RA_opt(columnIndex, rowContainer),
+      Dim_opt(dimension),
+      Chain_opt([&] {
         if constexpr (Master_matrix::Option_list::is_z2) {
           return nonZeroRowIndices.begin() == nonZeroRowIndices.end() ? -1 : *std::prev(nonZeroRowIndices.end());
         } else {
@@ -355,9 +348,9 @@ inline Naive_vector_column<Master_matrix>::Naive_vector_column(
       operators_(nullptr),
       cellPool_(&(colSettings->cellConstructor))
 {
-  index i = 0;
+  Index i = 0;
   if constexpr (Master_matrix::Option_list::is_z2) {
-    for (id_index id : nonZeroRowIndices) {
+    for (ID_index id : nonZeroRowIndices) {
       _update_cell(id, i++);
     }
   } else {
@@ -370,10 +363,10 @@ inline Naive_vector_column<Master_matrix>::Naive_vector_column(
 
 template <class Master_matrix>
 inline Naive_vector_column<Master_matrix>::Naive_vector_column(const Naive_vector_column& column,
-                                                                                 Column_settings* colSettings)
-    : ra_opt(),
-      dim_opt(static_cast<const dim_opt&>(column)),
-      chain_opt(static_cast<const chain_opt&>(column)),
+                                                               Column_settings* colSettings)
+    : RA_opt(),
+      Dim_opt(static_cast<const Dim_opt&>(column)),
+      Chain_opt(static_cast<const Chain_opt&>(column)),
       column_(column.column_.size(), nullptr),
       operators_(colSettings == nullptr ? column.operators_ : nullptr),
       cellPool_(colSettings == nullptr ? column.cellPool_ : &(colSettings->cellConstructor))
@@ -382,11 +375,11 @@ inline Naive_vector_column<Master_matrix>::Naive_vector_column(const Naive_vecto
                 "Simple copy constructor not available when row access option enabled. Please specify the new column "
                 "index and the row container.");
 
-  if constexpr (!Master_matrix::Option_list::is_z2){
+  if constexpr (!Master_matrix::Option_list::is_z2) {
     if (colSettings != nullptr) operators_ = &(colSettings->operators);
   }
 
-  index i = 0;
+  Index i = 0;
   for (const Cell* cell : column.column_) {
     if constexpr (Master_matrix::Option_list::is_z2) {
       _update_cell(cell->get_row_index(), i++);
@@ -397,23 +390,23 @@ inline Naive_vector_column<Master_matrix>::Naive_vector_column(const Naive_vecto
 }
 
 template <class Master_matrix>
-template <class Row_container_type>
+template <class Row_container>
 inline Naive_vector_column<Master_matrix>::Naive_vector_column(const Naive_vector_column& column,
-                                                                                 index columnIndex,
-                                                                                 Row_container_type* rowContainer,
-                                                                                 Column_settings* colSettings)
-    : ra_opt(columnIndex, rowContainer),
-      dim_opt(static_cast<const dim_opt&>(column)),
-      chain_opt(static_cast<const chain_opt&>(column)),
+                                                               Index columnIndex,
+                                                               Row_container* rowContainer,
+                                                               Column_settings* colSettings)
+    : RA_opt(columnIndex, rowContainer),
+      Dim_opt(static_cast<const Dim_opt&>(column)),
+      Chain_opt(static_cast<const Chain_opt&>(column)),
       column_(column.column_.size(), nullptr),
       operators_(colSettings == nullptr ? column.operators_ : nullptr),
       cellPool_(colSettings == nullptr ? column.cellPool_ : &(colSettings->cellConstructor))
 {
-  if constexpr (!Master_matrix::Option_list::is_z2){
+  if constexpr (!Master_matrix::Option_list::is_z2) {
     if (colSettings != nullptr) operators_ = &(colSettings->operators);
   }
 
-  index i = 0;
+  Index i = 0;
   for (const Cell* cell : column.column_) {
     if constexpr (Master_matrix::Option_list::is_z2) {
       _update_cell(cell->get_row_index(), i++);
@@ -425,16 +418,16 @@ inline Naive_vector_column<Master_matrix>::Naive_vector_column(const Naive_vecto
 
 template <class Master_matrix>
 inline Naive_vector_column<Master_matrix>::Naive_vector_column(Naive_vector_column&& column) noexcept
-    : ra_opt(std::move(static_cast<ra_opt&>(column))),
-      dim_opt(std::move(static_cast<dim_opt&>(column))),
-      chain_opt(std::move(static_cast<chain_opt&>(column))),
+    : RA_opt(std::move(static_cast<RA_opt&>(column))),
+      Dim_opt(std::move(static_cast<Dim_opt&>(column))),
+      Chain_opt(std::move(static_cast<Chain_opt&>(column))),
       column_(std::move(column.column_)),
       operators_(std::exchange(column.operators_, nullptr)),
-      cellPool_(std::exchange(column.cellPool_, nullptr)) 
+      cellPool_(std::exchange(column.cellPool_, nullptr))
 {}
 
 template <class Master_matrix>
-inline Naive_vector_column<Master_matrix>::~Naive_vector_column() 
+inline Naive_vector_column<Master_matrix>::~Naive_vector_column()
 {
   for (auto* cell : column_) {
     _delete_cell(cell);
@@ -442,16 +435,16 @@ inline Naive_vector_column<Master_matrix>::~Naive_vector_column()
 }
 
 template <class Master_matrix>
-inline std::vector<typename Naive_vector_column<Master_matrix>::Field_element_type>
-Naive_vector_column<Master_matrix>::get_content(int columnLength) const 
+inline std::vector<typename Naive_vector_column<Master_matrix>::Field_element>
+Naive_vector_column<Master_matrix>::get_content(int columnLength) const
 {
   if (columnLength < 0 && column_.size() > 0)
     columnLength = column_.back()->get_row_index() + 1;
   else if (columnLength < 0)
-    return std::vector<Field_element_type>();
+    return std::vector<Field_element>();
 
-  std::vector<Field_element_type> container(columnLength, 0);
-  for (auto it = column_.begin(); it != column_.end() && (*it)->get_row_index() < static_cast<id_index>(columnLength);
+  std::vector<Field_element> container(columnLength, 0);
+  for (auto it = column_.begin(); it != column_.end() && (*it)->get_row_index() < static_cast<ID_index>(columnLength);
        ++it) {
     if constexpr (Master_matrix::Option_list::is_z2) {
       container[(*it)->get_row_index()] = 1;
@@ -463,7 +456,7 @@ Naive_vector_column<Master_matrix>::get_content(int columnLength) const
 }
 
 template <class Master_matrix>
-inline bool Naive_vector_column<Master_matrix>::is_non_zero(id_index rowIndex) const 
+inline bool Naive_vector_column<Master_matrix>::is_non_zero(ID_index rowIndex) const
 {
   Cell cell(rowIndex);
   return std::binary_search(column_.begin(), column_.end(), &cell,
@@ -471,39 +464,39 @@ inline bool Naive_vector_column<Master_matrix>::is_non_zero(id_index rowIndex) c
 }
 
 template <class Master_matrix>
-inline bool Naive_vector_column<Master_matrix>::is_empty() const 
+inline bool Naive_vector_column<Master_matrix>::is_empty() const
 {
   return column_.empty();
 }
 
 template <class Master_matrix>
-inline std::size_t Naive_vector_column<Master_matrix>::size() const 
+inline std::size_t Naive_vector_column<Master_matrix>::size() const
 {
   return column_.size();
 }
 
 template <class Master_matrix>
-template <class Map_type>
-inline void Naive_vector_column<Master_matrix>::reorder(const Map_type& valueMap,
-                                                                          [[maybe_unused]] index columnIndex) 
+template <class Row_index_map>
+inline void Naive_vector_column<Master_matrix>::reorder(const Row_index_map& valueMap,
+                                                        [[maybe_unused]] Index columnIndex)
 {
   static_assert(!Master_matrix::isNonBasic || Master_matrix::Option_list::is_of_boundary_type,
                 "Method not available for chain columns.");
 
   for (Cell* cell : column_) {
     if constexpr (Master_matrix::Option_list::has_row_access) {
-      ra_opt::unlink(cell);
-      if (columnIndex != static_cast<index>(-1)) cell->set_column_index(columnIndex);
+      RA_opt::unlink(cell);
+      if (columnIndex != static_cast<Index>(-1)) cell->set_column_index(columnIndex);
     }
     cell->set_row_index(valueMap.at(cell->get_row_index()));
     if constexpr (Master_matrix::Option_list::has_intrusive_rows && Master_matrix::Option_list::has_row_access)
-      ra_opt::insert_cell(cell->get_row_index(), cell);
+      RA_opt::insert_cell(cell->get_row_index(), cell);
   }
 
   // all cells have to be deleted first, to avoid problem with insertion when row is a set
   if constexpr (!Master_matrix::Option_list::has_intrusive_rows && Master_matrix::Option_list::has_row_access) {
     for (Cell* cell : column_) {
-      ra_opt::insert_cell(cell->get_row_index(), cell);
+      RA_opt::insert_cell(cell->get_row_index(), cell);
     }
   }
 
@@ -511,13 +504,13 @@ inline void Naive_vector_column<Master_matrix>::reorder(const Map_type& valueMap
 }
 
 template <class Master_matrix>
-inline void Naive_vector_column<Master_matrix>::clear() 
+inline void Naive_vector_column<Master_matrix>::clear()
 {
   static_assert(!Master_matrix::isNonBasic || Master_matrix::Option_list::is_of_boundary_type,
                 "Method not available for chain columns as a base element should not be empty.");
 
   for (auto* cell : column_) {
-    if constexpr (Master_matrix::Option_list::has_row_access) ra_opt::unlink(cell);
+    if constexpr (Master_matrix::Option_list::has_row_access) RA_opt::unlink(cell);
     cellPool_->destroy(cell);
   }
 
@@ -525,7 +518,7 @@ inline void Naive_vector_column<Master_matrix>::clear()
 }
 
 template <class Master_matrix>
-inline void Naive_vector_column<Master_matrix>::clear(id_index rowIndex) 
+inline void Naive_vector_column<Master_matrix>::clear(ID_index rowIndex)
 {
   static_assert(!Master_matrix::isNonBasic || Master_matrix::Option_list::is_of_boundary_type,
                 "Method not available for chain columns.");
@@ -539,8 +532,7 @@ inline void Naive_vector_column<Master_matrix>::clear(id_index rowIndex)
 }
 
 template <class Master_matrix>
-inline typename Naive_vector_column<Master_matrix>::id_index
-Naive_vector_column<Master_matrix>::get_pivot() const 
+inline typename Naive_vector_column<Master_matrix>::ID_index Naive_vector_column<Master_matrix>::get_pivot() const
 {
   static_assert(Master_matrix::isNonBasic,
                 "Method not available for base columns.");  // could technically be, but is the notion useful then?
@@ -548,13 +540,13 @@ Naive_vector_column<Master_matrix>::get_pivot() const
   if constexpr (Master_matrix::Option_list::is_of_boundary_type) {
     return column_.empty() ? -1 : column_.back()->get_row_index();
   } else {
-    return chain_opt::get_pivot();
+    return Chain_opt::get_pivot();
   }
 }
 
 template <class Master_matrix>
-inline typename Naive_vector_column<Master_matrix>::Field_element_type
-Naive_vector_column<Master_matrix>::get_pivot_value() const 
+inline typename Naive_vector_column<Master_matrix>::Field_element Naive_vector_column<Master_matrix>::get_pivot_value()
+    const
 {
   static_assert(Master_matrix::isNonBasic,
                 "Method not available for base columns.");  // could technically be, but is the notion useful then?
@@ -563,77 +555,74 @@ Naive_vector_column<Master_matrix>::get_pivot_value() const
     return 1;
   } else {
     if constexpr (Master_matrix::Option_list::is_of_boundary_type) {
-      return column_.empty() ? Field_element_type() : column_.back()->get_element();
+      return column_.empty() ? Field_element() : column_.back()->get_element();
     } else {
-      if (chain_opt::get_pivot() == static_cast<id_index>(-1)) return Field_element_type();
+      if (Chain_opt::get_pivot() == static_cast<ID_index>(-1)) return Field_element();
       for (const Cell* cell : column_) {
-        if (cell->get_row_index() == chain_opt::get_pivot()) return cell->get_element();
+        if (cell->get_row_index() == Chain_opt::get_pivot()) return cell->get_element();
       }
-      return Field_element_type();  // should never happen if chain column is used properly
+      return Field_element();  // should never happen if chain column is used properly
     }
   }
 }
 
 template <class Master_matrix>
-inline typename Naive_vector_column<Master_matrix>::iterator
-Naive_vector_column<Master_matrix>::begin() noexcept 
+inline typename Naive_vector_column<Master_matrix>::iterator Naive_vector_column<Master_matrix>::begin() noexcept
 {
   return column_.begin();
 }
 
 template <class Master_matrix>
-inline typename Naive_vector_column<Master_matrix>::const_iterator
-Naive_vector_column<Master_matrix>::begin() const noexcept 
+inline typename Naive_vector_column<Master_matrix>::const_iterator Naive_vector_column<Master_matrix>::begin()
+    const noexcept
 {
   return column_.begin();
 }
 
 template <class Master_matrix>
-inline typename Naive_vector_column<Master_matrix>::iterator
-Naive_vector_column<Master_matrix>::end() noexcept 
+inline typename Naive_vector_column<Master_matrix>::iterator Naive_vector_column<Master_matrix>::end() noexcept
 {
   return column_.end();
 }
 
 template <class Master_matrix>
-inline typename Naive_vector_column<Master_matrix>::const_iterator
-Naive_vector_column<Master_matrix>::end() const noexcept 
+inline typename Naive_vector_column<Master_matrix>::const_iterator Naive_vector_column<Master_matrix>::end()
+    const noexcept
 {
   return column_.end();
 }
 
 template <class Master_matrix>
 inline typename Naive_vector_column<Master_matrix>::reverse_iterator
-Naive_vector_column<Master_matrix>::rbegin() noexcept 
+Naive_vector_column<Master_matrix>::rbegin() noexcept
 {
   return column_.rbegin();
 }
 
 template <class Master_matrix>
-inline typename Naive_vector_column<Master_matrix>::const_reverse_iterator
-Naive_vector_column<Master_matrix>::rbegin() const noexcept 
+inline typename Naive_vector_column<Master_matrix>::const_reverse_iterator Naive_vector_column<Master_matrix>::rbegin()
+    const noexcept
 {
   return column_.rbegin();
 }
 
 template <class Master_matrix>
 inline typename Naive_vector_column<Master_matrix>::reverse_iterator
-Naive_vector_column<Master_matrix>::rend() noexcept 
+Naive_vector_column<Master_matrix>::rend() noexcept
 {
   return column_.rend();
 }
 
 template <class Master_matrix>
-inline typename Naive_vector_column<Master_matrix>::const_reverse_iterator
-Naive_vector_column<Master_matrix>::rend() const noexcept 
+inline typename Naive_vector_column<Master_matrix>::const_reverse_iterator Naive_vector_column<Master_matrix>::rend()
+    const noexcept
 {
   return column_.rend();
 }
 
 template <class Master_matrix>
 template <class Cell_range>
-inline Naive_vector_column<Master_matrix>&
-Naive_vector_column<Master_matrix>::operator+=(const Cell_range& column) 
+inline Naive_vector_column<Master_matrix>& Naive_vector_column<Master_matrix>::operator+=(const Cell_range& column)
 {
   static_assert((!Master_matrix::isNonBasic || std::is_same_v<Cell_range, Naive_vector_column>),
                 "For boundary columns, the range has to be a column of same type to help ensure the validity of the "
@@ -647,14 +636,13 @@ Naive_vector_column<Master_matrix>::operator+=(const Cell_range& column)
 }
 
 template <class Master_matrix>
-inline Naive_vector_column<Master_matrix>&
-Naive_vector_column<Master_matrix>::operator+=(Naive_vector_column& column) 
+inline Naive_vector_column<Master_matrix>& Naive_vector_column<Master_matrix>::operator+=(Naive_vector_column& column)
 {
   if constexpr (Master_matrix::isNonBasic && !Master_matrix::Option_list::is_of_boundary_type) {
     // assumes that the addition never zeros out this column.
     if (_add(column)) {
-      chain_opt::swap_pivots(column);
-      dim_opt::swap_dimension(column);
+      Chain_opt::swap_pivots(column);
+      Dim_opt::swap_dimension(column);
     }
   } else {
     _add(column);
@@ -664,8 +652,7 @@ Naive_vector_column<Master_matrix>::operator+=(Naive_vector_column& column)
 }
 
 template <class Master_matrix>
-inline Naive_vector_column<Master_matrix>&
-Naive_vector_column<Master_matrix>::operator*=(unsigned int v) 
+inline Naive_vector_column<Master_matrix>& Naive_vector_column<Master_matrix>::operator*=(unsigned int v)
 {
   if constexpr (Master_matrix::Option_list::is_z2) {
     if (v % 2 == 0) {
@@ -676,7 +663,7 @@ Naive_vector_column<Master_matrix>::operator*=(unsigned int v)
       }
     }
   } else {
-    Field_element_type val = operators_->get_value(v);
+    Field_element val = operators_->get_value(v);
 
     if (val == Field_operators::get_additive_identity()) {
       if constexpr (Master_matrix::isNonBasic && !Master_matrix::Option_list::is_of_boundary_type) {
@@ -691,7 +678,7 @@ Naive_vector_column<Master_matrix>::operator*=(unsigned int v)
 
     for (Cell* cell : column_) {
       operators_->multiply_inplace(cell->get_element(), val);
-      if constexpr (Master_matrix::Option_list::has_row_access) ra_opt::update_cell(*cell);
+      if constexpr (Master_matrix::Option_list::has_row_access) RA_opt::update_cell(*cell);
     }
   }
 
@@ -700,9 +687,8 @@ Naive_vector_column<Master_matrix>::operator*=(unsigned int v)
 
 template <class Master_matrix>
 template <class Cell_range>
-inline Naive_vector_column<Master_matrix>&
-Naive_vector_column<Master_matrix>::multiply_target_and_add(const Field_element_type& val,
-                                                                       const Cell_range& column) 
+inline Naive_vector_column<Master_matrix>& Naive_vector_column<Master_matrix>::multiply_target_and_add(
+    const Field_element& val, const Cell_range& column)
 {
   static_assert((!Master_matrix::isNonBasic || std::is_same_v<Cell_range, Naive_vector_column>),
                 "For boundary columns, the range has to be a column of same type to help ensure the validity of the "
@@ -725,25 +711,24 @@ Naive_vector_column<Master_matrix>::multiply_target_and_add(const Field_element_
 }
 
 template <class Master_matrix>
-inline Naive_vector_column<Master_matrix>&
-Naive_vector_column<Master_matrix>::multiply_target_and_add(const Field_element_type& val,
-                                                                       Naive_vector_column& column) 
+inline Naive_vector_column<Master_matrix>& Naive_vector_column<Master_matrix>::multiply_target_and_add(
+    const Field_element& val, Naive_vector_column& column)
 {
   if constexpr (Master_matrix::isNonBasic && !Master_matrix::Option_list::is_of_boundary_type) {
     // assumes that the addition never zeros out this column.
     if constexpr (Master_matrix::Option_list::is_z2) {
       if (val) {
         if (_add(column)) {
-          chain_opt::swap_pivots(column);
-          dim_opt::swap_dimension(column);
+          Chain_opt::swap_pivots(column);
+          Dim_opt::swap_dimension(column);
         }
       } else {
         throw std::invalid_argument("A chain column should not be multiplied by 0.");
       }
     } else {
       if (_multiply_target_and_add(val, column)) {
-        chain_opt::swap_pivots(column);
-        dim_opt::swap_dimension(column);
+        Chain_opt::swap_pivots(column);
+        Dim_opt::swap_dimension(column);
       }
     }
   } else {
@@ -764,9 +749,8 @@ Naive_vector_column<Master_matrix>::multiply_target_and_add(const Field_element_
 
 template <class Master_matrix>
 template <class Cell_range>
-inline Naive_vector_column<Master_matrix>&
-Naive_vector_column<Master_matrix>::multiply_source_and_add(const Cell_range& column,
-                                                                       const Field_element_type& val) 
+inline Naive_vector_column<Master_matrix>& Naive_vector_column<Master_matrix>::multiply_source_and_add(
+    const Cell_range& column, const Field_element& val)
 {
   static_assert((!Master_matrix::isNonBasic || std::is_same_v<Cell_range, Naive_vector_column>),
                 "For boundary columns, the range has to be a column of same type to help ensure the validity of the "
@@ -786,23 +770,22 @@ Naive_vector_column<Master_matrix>::multiply_source_and_add(const Cell_range& co
 }
 
 template <class Master_matrix>
-inline Naive_vector_column<Master_matrix>&
-Naive_vector_column<Master_matrix>::multiply_source_and_add(Naive_vector_column& column,
-                                                                       const Field_element_type& val) 
+inline Naive_vector_column<Master_matrix>& Naive_vector_column<Master_matrix>::multiply_source_and_add(
+    Naive_vector_column& column, const Field_element& val)
 {
   if constexpr (Master_matrix::isNonBasic && !Master_matrix::Option_list::is_of_boundary_type) {
     // assumes that the addition never zeros out this column.
     if constexpr (Master_matrix::Option_list::is_z2) {
       if (val) {
         if (_add(column)) {
-          chain_opt::swap_pivots(column);
-          dim_opt::swap_dimension(column);
+          Chain_opt::swap_pivots(column);
+          Dim_opt::swap_dimension(column);
         }
       }
     } else {
       if (_multiply_source_and_add(column, val)) {
-        chain_opt::swap_pivots(column);
-        dim_opt::swap_dimension(column);
+        Chain_opt::swap_pivots(column);
+        Dim_opt::swap_dimension(column);
       }
     }
   } else {
@@ -819,30 +802,30 @@ Naive_vector_column<Master_matrix>::multiply_source_and_add(Naive_vector_column&
 }
 
 template <class Master_matrix>
-inline Naive_vector_column<Master_matrix>&
-Naive_vector_column<Master_matrix>::operator=(const Naive_vector_column& other) 
+inline Naive_vector_column<Master_matrix>& Naive_vector_column<Master_matrix>::operator=(
+    const Naive_vector_column& other)
 {
   static_assert(!Master_matrix::Option_list::has_row_access, "= assignment not enabled with row access option.");
 
-  dim_opt::operator=(other);
-  chain_opt::operator=(other);
+  Dim_opt::operator=(other);
+  Chain_opt::operator=(other);
 
   auto tmpPool = cellPool_;
   cellPool_ = other.cellPool_;
 
   while (column_.size() > other.column_.size()) {
     if (column_.back() == nullptr) {
-      if constexpr (Master_matrix::Option_list::has_row_access) ra_opt::unlink(column_.back());
+      if constexpr (Master_matrix::Option_list::has_row_access) RA_opt::unlink(column_.back());
       tmpPool->destroy(column_.back());
     }
     column_.pop_back();
   }
 
   column_.resize(other.column_.size(), nullptr);
-  index i = 0;
+  Index i = 0;
   for (const Cell* cell : other.column_) {
     if (column_[i] != nullptr) {
-      if constexpr (Master_matrix::Option_list::has_row_access) ra_opt::unlink(column_[i]);
+      if constexpr (Master_matrix::Option_list::has_row_access) RA_opt::unlink(column_[i]);
       tmpPool->destroy(column_[i]);
     }
     if constexpr (Master_matrix::Option_list::is_z2) {
@@ -858,14 +841,14 @@ Naive_vector_column<Master_matrix>::operator=(const Naive_vector_column& other)
 }
 
 template <class Master_matrix>
-inline void Naive_vector_column<Master_matrix>::_delete_cell(Cell* cell) 
+inline void Naive_vector_column<Master_matrix>::_delete_cell(Cell* cell)
 {
-  if constexpr (Master_matrix::Option_list::has_row_access) ra_opt::unlink(cell);
+  if constexpr (Master_matrix::Option_list::has_row_access) RA_opt::unlink(cell);
   cellPool_->destroy(cell);
 }
 
 template <class Master_matrix>
-inline void Naive_vector_column<Master_matrix>::_delete_cell(typename Column_type::iterator& it)
+inline void Naive_vector_column<Master_matrix>::_delete_cell(typename Column::iterator& it)
 {
   _delete_cell(*it);
   ++it;
@@ -873,13 +856,13 @@ inline void Naive_vector_column<Master_matrix>::_delete_cell(typename Column_typ
 
 template <class Master_matrix>
 inline typename Naive_vector_column<Master_matrix>::Cell* Naive_vector_column<Master_matrix>::_insert_cell(
-    const Field_element_type& value, id_index rowIndex, Column_type& column)
+    const Field_element& value, ID_index rowIndex, Column& column)
 {
   if constexpr (Master_matrix::Option_list::has_row_access) {
-    Cell* newCell = cellPool_->construct(ra_opt::columnIndex_, rowIndex);
+    Cell* newCell = cellPool_->construct(RA_opt::columnIndex_, rowIndex);
     newCell->set_element(value);
     column.push_back(newCell);
-    ra_opt::insert_cell(rowIndex, newCell);
+    RA_opt::insert_cell(rowIndex, newCell);
     return newCell;
   } else {
     Cell* newCell = cellPool_->construct(rowIndex);
@@ -890,27 +873,27 @@ inline typename Naive_vector_column<Master_matrix>::Cell* Naive_vector_column<Ma
 }
 
 template <class Master_matrix>
-inline void Naive_vector_column<Master_matrix>::_insert_cell(id_index rowIndex, Column_type& column) 
+inline void Naive_vector_column<Master_matrix>::_insert_cell(ID_index rowIndex, Column& column)
 {
   if constexpr (Master_matrix::Option_list::has_row_access) {
-    Cell* newCell = cellPool_->construct(ra_opt::columnIndex_, rowIndex);
+    Cell* newCell = cellPool_->construct(RA_opt::columnIndex_, rowIndex);
     column.push_back(newCell);
-    ra_opt::insert_cell(rowIndex, newCell);
+    RA_opt::insert_cell(rowIndex, newCell);
   } else {
     column.push_back(cellPool_->construct(rowIndex));
   }
 }
 
 template <class Master_matrix>
-inline void Naive_vector_column<Master_matrix>::_update_cell(const Field_element_type& value,
-                                                                               id_index rowIndex, 
-                                                                               index position) 
+inline void Naive_vector_column<Master_matrix>::_update_cell(const Field_element& value,
+                                                             ID_index rowIndex,
+                                                             Index position)
 {
   if constexpr (Master_matrix::Option_list::has_row_access) {
-    Cell* newCell = cellPool_->construct(ra_opt::columnIndex_, rowIndex);
+    Cell* newCell = cellPool_->construct(RA_opt::columnIndex_, rowIndex);
     newCell->set_element(value);
     column_[position] = newCell;
-    ra_opt::insert_cell(rowIndex, newCell);
+    RA_opt::insert_cell(rowIndex, newCell);
   } else {
     column_[position] = cellPool_->construct(rowIndex);
     column_[position]->set_element(value);
@@ -918,12 +901,12 @@ inline void Naive_vector_column<Master_matrix>::_update_cell(const Field_element
 }
 
 template <class Master_matrix>
-inline void Naive_vector_column<Master_matrix>::_update_cell(id_index rowIndex, index position) 
+inline void Naive_vector_column<Master_matrix>::_update_cell(ID_index rowIndex, Index position)
 {
   if constexpr (Master_matrix::Option_list::has_row_access) {
-    Cell* newCell = cellPool_->construct(ra_opt::columnIndex_, rowIndex);
+    Cell* newCell = cellPool_->construct(RA_opt::columnIndex_, rowIndex);
     column_[position] = newCell;
-    ra_opt::insert_cell(rowIndex, newCell);
+    RA_opt::insert_cell(rowIndex, newCell);
   } else {
     column_[position] = cellPool_->construct(rowIndex);
   }
@@ -931,12 +914,12 @@ inline void Naive_vector_column<Master_matrix>::_update_cell(id_index rowIndex, 
 
 template <class Master_matrix>
 template <class Cell_range>
-inline bool Naive_vector_column<Master_matrix>::_add(const Cell_range& column) 
+inline bool Naive_vector_column<Master_matrix>::_add(const Cell_range& column)
 {
   if (column.begin() == column.end()) return false;
   if (column_.empty()) {  // chain should never enter here.
     column_.resize(column.size());
-    index i = 0;
+    Index i = 0;
     for (const Cell& cell : column) {
       if constexpr (Master_matrix::Option_list::is_z2) {
         _update_cell(cell.get_row_index(), i++);
@@ -947,27 +930,24 @@ inline bool Naive_vector_column<Master_matrix>::_add(const Cell_range& column)
     return true;
   }
 
-  Column_type newColumn;
+  Column newColumn;
   newColumn.reserve(column_.size() + column.size());  // safe upper bound
 
   auto pivotIsZeroed = _generic_add_to_column(
-      column,
-      *this,
-      [&](Cell* cellTarget) { newColumn.push_back(cellTarget); },
-      [&](typename Cell_range::const_iterator& itSource,
-          [[maybe_unused]] const typename Column_type::iterator& itTarget) {
+      column, *this, [&](Cell* cellTarget) { newColumn.push_back(cellTarget); },
+      [&](typename Cell_range::const_iterator& itSource, [[maybe_unused]] const typename Column::iterator& itTarget) {
         if constexpr (Master_matrix::Option_list::is_z2) {
           _insert_cell(itSource->get_row_index(), newColumn);
         } else {
           _insert_cell(itSource->get_element(), itSource->get_row_index(), newColumn);
         }
       },
-      [&](Field_element_type& targetElement, typename Cell_range::const_iterator& itSource) {
+      [&](Field_element& targetElement, typename Cell_range::const_iterator& itSource) {
         if constexpr (!Master_matrix::Option_list::is_z2)
           operators_->add_inplace(targetElement, itSource->get_element());
       },
       [&](Cell* cellTarget) { newColumn.push_back(cellTarget); },
-      [&](typename Column_type::iterator& itTarget) {
+      [&](typename Column::iterator& itTarget) {
         while (itTarget != column_.end()) {
           newColumn.push_back(*itTarget);
           itTarget++;
@@ -981,8 +961,8 @@ inline bool Naive_vector_column<Master_matrix>::_add(const Cell_range& column)
 
 template <class Master_matrix>
 template <class Cell_range>
-inline bool Naive_vector_column<Master_matrix>::_multiply_target_and_add(const Field_element_type& val,
-                                                                                    const Cell_range& column) 
+inline bool Naive_vector_column<Master_matrix>::_multiply_target_and_add(const Field_element& val,
+                                                                         const Cell_range& column)
 {
   if (val == 0u) {
     if constexpr (Master_matrix::isNonBasic && !Master_matrix::Option_list::is_of_boundary_type) {
@@ -994,7 +974,7 @@ inline bool Naive_vector_column<Master_matrix>::_multiply_target_and_add(const F
   }
   if (column_.empty()) {  // chain should never enter here.
     column_.resize(column.size());
-    index i = 0;
+    Index i = 0;
     for (const Cell& cell : column) {
       if constexpr (Master_matrix::Option_list::is_z2) {
         _update_cell(cell.get_row_index(), i++);
@@ -1005,28 +985,27 @@ inline bool Naive_vector_column<Master_matrix>::_multiply_target_and_add(const F
     return true;
   }
 
-  Column_type newColumn;
+  Column newColumn;
   newColumn.reserve(column_.size() + column.size());  // safe upper bound
 
   auto pivotIsZeroed = _generic_add_to_column(
-      column,
-      *this,
+      column, *this,
       [&](Cell* cellTarget) {
         operators_->multiply_inplace(cellTarget->get_element(), val);
-        if constexpr (Master_matrix::Option_list::has_row_access) ra_opt::update_cell(*cellTarget);
+        if constexpr (Master_matrix::Option_list::has_row_access) RA_opt::update_cell(*cellTarget);
         newColumn.push_back(cellTarget);
       },
-      [&](typename Cell_range::const_iterator& itSource, const typename Column_type::iterator& itTarget) {
+      [&](typename Cell_range::const_iterator& itSource, const typename Column::iterator& itTarget) {
         _insert_cell(itSource->get_element(), itSource->get_row_index(), newColumn);
       },
-      [&](Field_element_type& targetElement, typename Cell_range::const_iterator& itSource) {
+      [&](Field_element& targetElement, typename Cell_range::const_iterator& itSource) {
         operators_->multiply_and_add_inplace_front(targetElement, val, itSource->get_element());
       },
       [&](Cell* cellTarget) { newColumn.push_back(cellTarget); },
-      [&](typename Column_type::iterator& itTarget) {
+      [&](typename Column::iterator& itTarget) {
         while (itTarget != column_.end()) {
           operators_->multiply_inplace((*itTarget)->get_element(), val);
-          if constexpr (Master_matrix::Option_list::has_row_access) ra_opt::update_cell(**itTarget);
+          if constexpr (Master_matrix::Option_list::has_row_access) RA_opt::update_cell(**itTarget);
           newColumn.push_back(*itTarget);
           itTarget++;
         }
@@ -1040,28 +1019,27 @@ inline bool Naive_vector_column<Master_matrix>::_multiply_target_and_add(const F
 template <class Master_matrix>
 template <class Cell_range>
 inline bool Naive_vector_column<Master_matrix>::_multiply_source_and_add(const Cell_range& column,
-                                                                                    const Field_element_type& val) 
+                                                                         const Field_element& val)
 {
   if (val == 0u || column.begin() == column.end()) {
     return false;
   }
 
-  Column_type newColumn;
+  Column newColumn;
   newColumn.reserve(column_.size() + column.size());  // safe upper bound
 
   auto pivotIsZeroed = _generic_add_to_column(
-      column, *this,
-      [&](Cell* cellTarget) { newColumn.push_back(cellTarget); },
-      [&](typename Cell_range::const_iterator& itSource, const typename Column_type::iterator& itTarget) {
+      column, *this, [&](Cell* cellTarget) { newColumn.push_back(cellTarget); },
+      [&](typename Cell_range::const_iterator& itSource, const typename Column::iterator& itTarget) {
         Cell* newCell = _insert_cell(itSource->get_element(), itSource->get_row_index(), newColumn);
         operators_->multiply_inplace(newCell->get_element(), val);
-        if constexpr (Master_matrix::Option_list::has_row_access) ra_opt::update_cell(*newCell);
+        if constexpr (Master_matrix::Option_list::has_row_access) RA_opt::update_cell(*newCell);
       },
-      [&](Field_element_type& targetElement, typename Cell_range::const_iterator& itSource) {
+      [&](Field_element& targetElement, typename Cell_range::const_iterator& itSource) {
         operators_->multiply_and_add_inplace_back(itSource->get_element(), val, targetElement);
       },
       [&](Cell* cellTarget) { newColumn.push_back(cellTarget); },
-      [&](typename Column_type::iterator& itTarget) {
+      [&](typename Column::iterator& itTarget) {
         while (itTarget != column_.end()) {
           newColumn.push_back(*itTarget);
           itTarget++;
@@ -1080,13 +1058,12 @@ inline bool Naive_vector_column<Master_matrix>::_multiply_source_and_add(const C
  * @ingroup persistence_matrix
  *
  * @brief Hash method for @ref Gudhi::persistence_matrix::Naive_vector_column.
- * 
+ *
  * @tparam Master_matrix Template parameter of @ref Gudhi::persistence_matrix::Naive_vector_column.
  * @tparam Cell_constructor Template parameter of @ref Gudhi::persistence_matrix::Naive_vector_column.
  */
 template <class Master_matrix>
-struct std::hash<Gudhi::persistence_matrix::Naive_vector_column<Master_matrix> > 
-{
+struct std::hash<Gudhi::persistence_matrix::Naive_vector_column<Master_matrix> > {
   std::size_t operator()(const Gudhi::persistence_matrix::Naive_vector_column<Master_matrix>& column) const {
     return Gudhi::persistence_matrix::hash_column(column);
   }

--- a/src/Persistence_matrix/include/gudhi/Persistence_matrix/columns/set_column.h
+++ b/src/Persistence_matrix/include/gudhi/Persistence_matrix/columns/set_column.h
@@ -40,22 +40,22 @@ namespace persistence_matrix {
  *
  * Column based on a set structure. The cells are always ordered by row index and only non-zero values
  * are stored uniquely in the underlying container.
- * 
+ *
  * @tparam Master_matrix An instantiation of @ref Matrix from which all types and options are deduced.
  * @tparam Cell_constructor Factory of @ref Cell classes.
  */
 template <class Master_matrix>
 class Set_column : public Master_matrix::Row_access_option,
                    public Master_matrix::Column_dimension_option,
-                   public Master_matrix::Chain_column_option 
+                   public Master_matrix::Chain_column_option
 {
  public:
   using Master = Master_matrix;
-  using index = typename Master_matrix::index;
-  using id_index = typename Master_matrix::id_index;
-  using dimension_type = typename Master_matrix::dimension_type;
-  using Field_element_type = typename Master_matrix::element_type;
-  using Cell = typename Master_matrix::Cell_type;
+  using Index = typename Master_matrix::Index;
+  using ID_index = typename Master_matrix::ID_index;
+  using Dimension = typename Master_matrix::Dimension;
+  using Field_element = typename Master_matrix::Element;
+  using Cell = typename Master_matrix::Matrix_cell;
   using Column_settings = typename Master_matrix::Column_settings;
 
  private:
@@ -65,55 +65,52 @@ class Set_column : public Master_matrix::Row_access_option,
     bool operator()(const Cell* c1, const Cell* c2) const { return *c1 < *c2; }
   };
 
-  using Column_type = std::set<Cell*, CellPointerComp>;
+  using Column = std::set<Cell*, CellPointerComp>;
   using Cell_constructor = typename Master_matrix::Cell_constructor;
 
  public:
-  using iterator = boost::indirect_iterator<typename Column_type::iterator>;
-  using const_iterator = boost::indirect_iterator<typename Column_type::const_iterator>;
-  using reverse_iterator = boost::indirect_iterator<typename Column_type::reverse_iterator>;
-  using const_reverse_iterator = boost::indirect_iterator<typename Column_type::const_reverse_iterator>;
+  using iterator = boost::indirect_iterator<typename Column::iterator>;
+  using const_iterator = boost::indirect_iterator<typename Column::const_iterator>;
+  using reverse_iterator = boost::indirect_iterator<typename Column::reverse_iterator>;
+  using const_reverse_iterator = boost::indirect_iterator<typename Column::const_reverse_iterator>;
 
   Set_column(Column_settings* colSettings = nullptr);
-  template <class Container_type = typename Master_matrix::boundary_type>
-  Set_column(const Container_type& nonZeroRowIndices, Column_settings* colSettings);
-  template <class Container_type = typename Master_matrix::boundary_type, class Row_container_type>
-  Set_column(index columnIndex, 
-             const Container_type& nonZeroRowIndices, 
-             Row_container_type* rowContainer,
+  template <class Container = typename Master_matrix::Boundary>
+  Set_column(const Container& nonZeroRowIndices, Column_settings* colSettings);
+  template <class Container = typename Master_matrix::Boundary, class Row_container>
+  Set_column(Index columnIndex,
+             const Container& nonZeroRowIndices,
+             Row_container* rowContainer,
              Column_settings* colSettings);
-  template <class Container_type = typename Master_matrix::boundary_type>
-  Set_column(const Container_type& nonZeroChainRowIndices, 
-             dimension_type dimension, 
+  template <class Container = typename Master_matrix::Boundary>
+  Set_column(const Container& nonZeroChainRowIndices, Dimension dimension, Column_settings* colSettings);
+  template <class Container = typename Master_matrix::Boundary, class Row_container>
+  Set_column(Index columnIndex,
+             const Container& nonZeroChainRowIndices,
+             Dimension dimension,
+             Row_container* rowContainer,
              Column_settings* colSettings);
-  template <class Container_type = typename Master_matrix::boundary_type, class Row_container_type>
-  Set_column(index columnIndex, 
-             const Container_type& nonZeroChainRowIndices, 
-             dimension_type dimension,
-             Row_container_type* rowContainer, 
-             Column_settings* colSettings);
-  Set_column(const Set_column& column, 
-             Column_settings* colSettings = nullptr);
-  template <class Row_container_type>
-  Set_column(const Set_column& column, 
-             index columnIndex, 
-             Row_container_type* rowContainer,
+  Set_column(const Set_column& column, Column_settings* colSettings = nullptr);
+  template <class Row_container>
+  Set_column(const Set_column& column,
+             Index columnIndex,
+             Row_container* rowContainer,
              Column_settings* colSettings = nullptr);
   Set_column(Set_column&& column) noexcept;
   ~Set_column();
 
-  std::vector<Field_element_type> get_content(int columnLength = -1) const;
-  bool is_non_zero(id_index rowIndex) const;
+  std::vector<Field_element> get_content(int columnLength = -1) const;
+  bool is_non_zero(ID_index rowIndex) const;
   bool is_empty() const;
   std::size_t size() const;
 
-  template <class Map_type>
-  void reorder(const Map_type& valueMap, [[maybe_unused]] index columnIndex = -1);
+  template <class Row_index_map>
+  void reorder(const Row_index_map& valueMap, [[maybe_unused]] Index columnIndex = -1);
   void clear();
-  void clear(id_index rowIndex);
+  void clear(ID_index rowIndex);
 
-  id_index get_pivot() const;
-  Field_element_type get_pivot_value() const;
+  ID_index get_pivot() const;
+  Field_element get_pivot_value() const;
 
   iterator begin() noexcept;
   const_iterator begin() const noexcept;
@@ -132,12 +129,12 @@ class Set_column : public Master_matrix::Row_access_option,
 
   // this = v * this + column
   template <class Cell_range>
-  Set_column& multiply_target_and_add(const Field_element_type& val, const Cell_range& column);
-  Set_column& multiply_target_and_add(const Field_element_type& val, Set_column& column);
+  Set_column& multiply_target_and_add(const Field_element& val, const Cell_range& column);
+  Set_column& multiply_target_and_add(const Field_element& val, Set_column& column);
   // this = this + column * v
   template <class Cell_range>
-  Set_column& multiply_source_and_add(const Cell_range& column, const Field_element_type& val);
-  Set_column& multiply_source_and_add(Set_column& column, const Field_element_type& val);
+  Set_column& multiply_source_and_add(const Cell_range& column, const Field_element& val);
+  Set_column& multiply_source_and_add(Set_column& column, const Field_element& val);
 
   friend bool operator==(const Set_column& c1, const Set_column& c2) {
     if (&c1 == &c2) return true;
@@ -189,76 +186,73 @@ class Set_column : public Master_matrix::Row_access_option,
   }
 
  private:
-  using ra_opt = typename Master_matrix::Row_access_option;
-  using dim_opt = typename Master_matrix::Column_dimension_option;
-  using chain_opt = typename Master_matrix::Chain_column_option;
+  using RA_opt = typename Master_matrix::Row_access_option;
+  using Dim_opt = typename Master_matrix::Column_dimension_option;
+  using Chain_opt = typename Master_matrix::Chain_column_option;
 
-  Column_type column_;
+  Column column_;
   Field_operators* operators_;
   Cell_constructor* cellPool_;
 
-  template <class Column_type, class Cell_iterator, typename F1, typename F2, typename F3, typename F4>
-  friend void _generic_merge_cell_to_column(Column_type& targetColumn,
+  template <class Column, class Cell_iterator, typename F1, typename F2, typename F3, typename F4>
+  friend void _generic_merge_cell_to_column(Column& targetColumn,
                                             Cell_iterator& itSource,
-                                            typename Column_type::Column_type::iterator& itTarget,
+                                            typename Column::Column::iterator& itTarget,
                                             F1&& process_target,
                                             F2&& process_source,
                                             F3&& update_target1,
                                             F4&& update_target2,
                                             bool& pivotIsZeroed);
-  template <class Column_type, class Cell_range, typename F1, typename F2, typename F3, typename F4, typename F5>
+  template <class Column, class Cell_range, typename F1, typename F2, typename F3, typename F4, typename F5>
   friend bool _generic_add_to_column(const Cell_range& source,
-                                     Column_type& targetColumn,
+                                     Column& targetColumn,
                                      F1&& process_target,
                                      F2&& process_source,
                                      F3&& update_target1,
                                      F4&& update_target2,
                                      F5&& finish_target);
-  template <class Column_type, class Cell_range>
-  friend bool _add_to_column(const Cell_range& source, Column_type& targetColumn);
-  template <class Column_type, class Cell_range>
-  friend bool _multiply_target_and_add_to_column(const typename Column_type::Field_element_type& val,
+  template <class Column, class Cell_range>
+  friend bool _add_to_column(const Cell_range& source, Column& targetColumn);
+  template <class Column, class Cell_range>
+  friend bool _multiply_target_and_add_to_column(const typename Column::Field_element& val,
                                                  const Cell_range& source,
-                                                 Column_type& targetColumn);
-  template <class Column_type, class Cell_range>
-  friend bool _multiply_source_and_add_to_column(const typename Column_type::Field_element_type& val,
+                                                 Column& targetColumn);
+  template <class Column, class Cell_range>
+  friend bool _multiply_source_and_add_to_column(const typename Column::Field_element& val,
                                                  const Cell_range& source,
-                                                 Column_type& targetColumn);
+                                                 Column& targetColumn);
 
-  void _delete_cell(typename Column_type::iterator& it);
-  Cell* _insert_cell(const Field_element_type& value,
-                     id_index rowIndex,
-                     const typename Column_type::iterator& position);
-  void _insert_cell(id_index rowIndex, const typename Column_type::iterator& position);
+  void _delete_cell(typename Column::iterator& it);
+  Cell* _insert_cell(const Field_element& value, ID_index rowIndex, const typename Column::iterator& position);
+  void _insert_cell(ID_index rowIndex, const typename Column::iterator& position);
   template <class Cell_range>
   bool _add(const Cell_range& column);
   template <class Cell_range>
-  bool _multiply_target_and_add(const Field_element_type& val, const Cell_range& column);
+  bool _multiply_target_and_add(const Field_element& val, const Cell_range& column);
   template <class Cell_range>
-  bool _multiply_source_and_add(const Cell_range& column, const Field_element_type& val);
+  bool _multiply_source_and_add(const Cell_range& column, const Field_element& val);
 };
 
 template <class Master_matrix>
 inline Set_column<Master_matrix>::Set_column(Column_settings* colSettings)
-    : ra_opt(),
-      dim_opt(),
-      chain_opt(),
+    : RA_opt(),
+      Dim_opt(),
+      Chain_opt(),
       operators_(nullptr),
       cellPool_(colSettings == nullptr ? nullptr : &(colSettings->cellConstructor))
 {
-  if (operators_ == nullptr && cellPool_ == nullptr) return; // to allow default constructor which gives a dummy column
+  if (operators_ == nullptr && cellPool_ == nullptr) return;  // to allow default constructor which gives a dummy column
   if constexpr (!Master_matrix::Option_list::is_z2) {
     operators_ = &(colSettings->operators);
   }
 }
 
 template <class Master_matrix>
-template <class Container_type>
-inline Set_column<Master_matrix>::Set_column(const Container_type& nonZeroRowIndices,
-                                                               Column_settings* colSettings)
-    : ra_opt(),
-      dim_opt(nonZeroRowIndices.size() == 0 ? 0 : nonZeroRowIndices.size() - 1),
-      chain_opt(),
+template <class Container>
+inline Set_column<Master_matrix>::Set_column(const Container& nonZeroRowIndices, Column_settings* colSettings)
+    : RA_opt(),
+      Dim_opt(nonZeroRowIndices.size() == 0 ? 0 : nonZeroRowIndices.size() - 1),
+      Chain_opt(),
       operators_(nullptr),
       cellPool_(&(colSettings->cellConstructor))
 {
@@ -266,7 +260,7 @@ inline Set_column<Master_matrix>::Set_column(const Container_type& nonZeroRowInd
                 "Constructor not available for chain columns, please specify the dimension of the chain.");
 
   if constexpr (Master_matrix::Option_list::is_z2) {
-    for (id_index id : nonZeroRowIndices) {
+    for (ID_index id : nonZeroRowIndices) {
       _insert_cell(id, column_.end());
     }
   } else {
@@ -278,14 +272,14 @@ inline Set_column<Master_matrix>::Set_column(const Container_type& nonZeroRowInd
 }
 
 template <class Master_matrix>
-template <class Container_type, class Row_container_type>
-inline Set_column<Master_matrix>::Set_column(index columnIndex,
-                                                               const Container_type& nonZeroRowIndices,
-                                                               Row_container_type* rowContainer,
-                                                               Column_settings* colSettings)
-    : ra_opt(columnIndex, rowContainer),
-      dim_opt(nonZeroRowIndices.size() == 0 ? 0 : nonZeroRowIndices.size() - 1),
-      chain_opt([&] {
+template <class Container, class Row_container>
+inline Set_column<Master_matrix>::Set_column(Index columnIndex,
+                                             const Container& nonZeroRowIndices,
+                                             Row_container* rowContainer,
+                                             Column_settings* colSettings)
+    : RA_opt(columnIndex, rowContainer),
+      Dim_opt(nonZeroRowIndices.size() == 0 ? 0 : nonZeroRowIndices.size() - 1),
+      Chain_opt([&] {
         if constexpr (Master_matrix::Option_list::is_z2) {
           return nonZeroRowIndices.begin() == nonZeroRowIndices.end() ? -1 : *std::prev(nonZeroRowIndices.end());
         } else {
@@ -299,7 +293,7 @@ inline Set_column<Master_matrix>::Set_column(index columnIndex,
                 "Constructor not available for chain columns, please specify the dimension of the chain.");
 
   if constexpr (Master_matrix::Option_list::is_z2) {
-    for (id_index id : nonZeroRowIndices) {
+    for (ID_index id : nonZeroRowIndices) {
       _insert_cell(id, column_.end());
     }
   } else {
@@ -311,13 +305,13 @@ inline Set_column<Master_matrix>::Set_column(index columnIndex,
 }
 
 template <class Master_matrix>
-template <class Container_type>
-inline Set_column<Master_matrix>::Set_column(const Container_type& nonZeroRowIndices,
-                                                               dimension_type dimension, 
-                                                               Column_settings* colSettings)
-    : ra_opt(),
-      dim_opt(dimension),
-      chain_opt([&] {
+template <class Container>
+inline Set_column<Master_matrix>::Set_column(const Container& nonZeroRowIndices,
+                                             Dimension dimension,
+                                             Column_settings* colSettings)
+    : RA_opt(),
+      Dim_opt(dimension),
+      Chain_opt([&] {
         if constexpr (Master_matrix::Option_list::is_z2) {
           return nonZeroRowIndices.begin() == nonZeroRowIndices.end() ? -1 : *std::prev(nonZeroRowIndices.end());
         } else {
@@ -328,7 +322,7 @@ inline Set_column<Master_matrix>::Set_column(const Container_type& nonZeroRowInd
       cellPool_(&(colSettings->cellConstructor))
 {
   if constexpr (Master_matrix::Option_list::is_z2) {
-    for (id_index id : nonZeroRowIndices) {
+    for (ID_index id : nonZeroRowIndices) {
       _insert_cell(id, column_.end());
     }
   } else {
@@ -340,16 +334,15 @@ inline Set_column<Master_matrix>::Set_column(const Container_type& nonZeroRowInd
 }
 
 template <class Master_matrix>
-template <class Container_type, class Row_container_type>
-inline Set_column<Master_matrix>::Set_column(
-    index columnIndex, 
-    const Container_type& nonZeroRowIndices, 
-    dimension_type dimension,
-    Row_container_type* rowContainer, 
-    Column_settings* colSettings)
-    : ra_opt(columnIndex, rowContainer),
-      dim_opt(dimension),
-      chain_opt([&] {
+template <class Container, class Row_container>
+inline Set_column<Master_matrix>::Set_column(Index columnIndex,
+                                             const Container& nonZeroRowIndices,
+                                             Dimension dimension,
+                                             Row_container* rowContainer,
+                                             Column_settings* colSettings)
+    : RA_opt(columnIndex, rowContainer),
+      Dim_opt(dimension),
+      Chain_opt([&] {
         if constexpr (Master_matrix::Option_list::is_z2) {
           return nonZeroRowIndices.begin() == nonZeroRowIndices.end() ? -1 : *std::prev(nonZeroRowIndices.end());
         } else {
@@ -360,7 +353,7 @@ inline Set_column<Master_matrix>::Set_column(
       cellPool_(&(colSettings->cellConstructor))
 {
   if constexpr (Master_matrix::Option_list::is_z2) {
-    for (id_index id : nonZeroRowIndices) {
+    for (ID_index id : nonZeroRowIndices) {
       _insert_cell(id, column_.end());
     }
   } else {
@@ -372,11 +365,10 @@ inline Set_column<Master_matrix>::Set_column(
 }
 
 template <class Master_matrix>
-inline Set_column<Master_matrix>::Set_column(const Set_column& column, 
-                                                               Column_settings* colSettings)
-    : ra_opt(),
-      dim_opt(static_cast<const dim_opt&>(column)),
-      chain_opt(static_cast<const chain_opt&>(column)),
+inline Set_column<Master_matrix>::Set_column(const Set_column& column, Column_settings* colSettings)
+    : RA_opt(),
+      Dim_opt(static_cast<const Dim_opt&>(column)),
+      Chain_opt(static_cast<const Chain_opt&>(column)),
       operators_(colSettings == nullptr ? column.operators_ : nullptr),
       cellPool_(colSettings == nullptr ? column.cellPool_ : &(colSettings->cellConstructor))
 {
@@ -384,7 +376,7 @@ inline Set_column<Master_matrix>::Set_column(const Set_column& column,
                 "Simple copy constructor not available when row access option enabled. Please specify the new column "
                 "index and the row container.");
 
-  if constexpr (!Master_matrix::Option_list::is_z2){
+  if constexpr (!Master_matrix::Option_list::is_z2) {
     if (colSettings != nullptr) operators_ = &(colSettings->operators);
   }
 
@@ -398,17 +390,18 @@ inline Set_column<Master_matrix>::Set_column(const Set_column& column,
 }
 
 template <class Master_matrix>
-template <class Row_container_type>
-inline Set_column<Master_matrix>::Set_column(const Set_column& column, index columnIndex,
-                                                               Row_container_type* rowContainer,
-                                                               Column_settings* colSettings)
-    : ra_opt(columnIndex, rowContainer),
-      dim_opt(static_cast<const dim_opt&>(column)),
-      chain_opt(static_cast<const chain_opt&>(column)),
+template <class Row_container>
+inline Set_column<Master_matrix>::Set_column(const Set_column& column,
+                                             Index columnIndex,
+                                             Row_container* rowContainer,
+                                             Column_settings* colSettings)
+    : RA_opt(columnIndex, rowContainer),
+      Dim_opt(static_cast<const Dim_opt&>(column)),
+      Chain_opt(static_cast<const Chain_opt&>(column)),
       operators_(colSettings == nullptr ? column.operators_ : nullptr),
       cellPool_(colSettings == nullptr ? column.cellPool_ : &(colSettings->cellConstructor))
 {
-  if constexpr (!Master_matrix::Option_list::is_z2){
+  if constexpr (!Master_matrix::Option_list::is_z2) {
     if (colSettings != nullptr) operators_ = &(colSettings->operators);
   }
 
@@ -423,34 +416,34 @@ inline Set_column<Master_matrix>::Set_column(const Set_column& column, index col
 
 template <class Master_matrix>
 inline Set_column<Master_matrix>::Set_column(Set_column&& column) noexcept
-    : ra_opt(std::move(static_cast<ra_opt&>(column))),
-      dim_opt(std::move(static_cast<dim_opt&>(column))),
-      chain_opt(std::move(static_cast<chain_opt&>(column))),
+    : RA_opt(std::move(static_cast<RA_opt&>(column))),
+      Dim_opt(std::move(static_cast<Dim_opt&>(column))),
+      Chain_opt(std::move(static_cast<Chain_opt&>(column))),
       column_(std::move(column.column_)),
       operators_(std::exchange(column.operators_, nullptr)),
-      cellPool_(std::exchange(column.cellPool_, nullptr)) 
+      cellPool_(std::exchange(column.cellPool_, nullptr))
 {}
 
 template <class Master_matrix>
-inline Set_column<Master_matrix>::~Set_column() 
+inline Set_column<Master_matrix>::~Set_column()
 {
   for (auto* cell : column_) {
-    if constexpr (Master_matrix::Option_list::has_row_access) ra_opt::unlink(cell);
+    if constexpr (Master_matrix::Option_list::has_row_access) RA_opt::unlink(cell);
     cellPool_->destroy(cell);
   }
 }
 
 template <class Master_matrix>
-inline std::vector<typename Set_column<Master_matrix>::Field_element_type>
-Set_column<Master_matrix>::get_content(int columnLength) const 
+inline std::vector<typename Set_column<Master_matrix>::Field_element> Set_column<Master_matrix>::get_content(
+    int columnLength) const
 {
   if (columnLength < 0 && column_.size() > 0)
     columnLength = (*column_.rbegin())->get_row_index() + 1;
   else if (columnLength < 0)
-    return std::vector<Field_element_type>();
+    return std::vector<Field_element>();
 
-  std::vector<Field_element_type> container(columnLength, 0);
-  for (auto it = column_.begin(); it != column_.end() && (*it)->get_row_index() < static_cast<id_index>(columnLength);
+  std::vector<Field_element> container(columnLength, 0);
+  for (auto it = column_.begin(); it != column_.end() && (*it)->get_row_index() < static_cast<ID_index>(columnLength);
        ++it) {
     if constexpr (Master_matrix::Option_list::is_z2) {
       container[(*it)->get_row_index()] = 1;
@@ -462,50 +455,49 @@ Set_column<Master_matrix>::get_content(int columnLength) const
 }
 
 template <class Master_matrix>
-inline bool Set_column<Master_matrix>::is_non_zero(id_index rowIndex) const 
+inline bool Set_column<Master_matrix>::is_non_zero(ID_index rowIndex) const
 {
   Cell cell(rowIndex);
   return column_.find(&cell) != column_.end();
 }
 
 template <class Master_matrix>
-inline bool Set_column<Master_matrix>::is_empty() const 
+inline bool Set_column<Master_matrix>::is_empty() const
 {
   return column_.empty();
 }
 
 template <class Master_matrix>
-inline std::size_t Set_column<Master_matrix>::size() const 
+inline std::size_t Set_column<Master_matrix>::size() const
 {
   return column_.size();
 }
 
 template <class Master_matrix>
-template <class Map_type>
-inline void Set_column<Master_matrix>::reorder(const Map_type& valueMap,
-                                                                 [[maybe_unused]] index columnIndex) 
+template <class Row_index_map>
+inline void Set_column<Master_matrix>::reorder(const Row_index_map& valueMap, [[maybe_unused]] Index columnIndex)
 {
   static_assert(!Master_matrix::isNonBasic || Master_matrix::Option_list::is_of_boundary_type,
                 "Method not available for chain columns.");
 
-  Column_type newSet;
+  Column newSet;
 
   for (Cell* cell : column_) {
     if constexpr (Master_matrix::Option_list::has_row_access) {
-      ra_opt::unlink(cell);
-      if (columnIndex != static_cast<index>(-1)) cell->set_column_index(columnIndex);
+      RA_opt::unlink(cell);
+      if (columnIndex != static_cast<Index>(-1)) cell->set_column_index(columnIndex);
     }
     cell->set_row_index(valueMap.at(cell->get_row_index()));
     newSet.insert(cell);
     if constexpr (Master_matrix::Option_list::has_row_access &&
                   Master_matrix::Option_list::has_intrusive_rows)  // intrusive list
-      ra_opt::insert_cell(cell->get_row_index(), cell);
+      RA_opt::insert_cell(cell->get_row_index(), cell);
   }
 
   // when row is a set, all cells have to be deleted first, to avoid colliding when inserting
-  if constexpr (Master_matrix::Option_list::has_row_access && !Master_matrix::Option_list::has_intrusive_rows) { // set
+  if constexpr (Master_matrix::Option_list::has_row_access && !Master_matrix::Option_list::has_intrusive_rows) {  // set
     for (Cell* cell : newSet) {
-      ra_opt::insert_cell(cell->get_row_index(), cell);
+      RA_opt::insert_cell(cell->get_row_index(), cell);
     }
   }
 
@@ -513,13 +505,13 @@ inline void Set_column<Master_matrix>::reorder(const Map_type& valueMap,
 }
 
 template <class Master_matrix>
-inline void Set_column<Master_matrix>::clear() 
+inline void Set_column<Master_matrix>::clear()
 {
   static_assert(!Master_matrix::isNonBasic || Master_matrix::Option_list::is_of_boundary_type,
                 "Method not available for chain columns as a base element should not be empty.");
 
   for (auto* cell : column_) {
-    if constexpr (Master_matrix::Option_list::has_row_access) ra_opt::unlink(cell);
+    if constexpr (Master_matrix::Option_list::has_row_access) RA_opt::unlink(cell);
     cellPool_->destroy(cell);
   }
 
@@ -527,7 +519,7 @@ inline void Set_column<Master_matrix>::clear()
 }
 
 template <class Master_matrix>
-inline void Set_column<Master_matrix>::clear(id_index rowIndex) 
+inline void Set_column<Master_matrix>::clear(ID_index rowIndex)
 {
   static_assert(!Master_matrix::isNonBasic || Master_matrix::Option_list::is_of_boundary_type,
                 "Method not available for chain columns.");
@@ -541,8 +533,7 @@ inline void Set_column<Master_matrix>::clear(id_index rowIndex)
 }
 
 template <class Master_matrix>
-inline typename Set_column<Master_matrix>::id_index
-Set_column<Master_matrix>::get_pivot() const 
+inline typename Set_column<Master_matrix>::ID_index Set_column<Master_matrix>::get_pivot() const
 {
   static_assert(Master_matrix::isNonBasic,
                 "Method not available for base columns.");  // could technically be, but is the notion useful then?
@@ -551,13 +542,12 @@ Set_column<Master_matrix>::get_pivot() const
     if (column_.empty()) return -1;
     return (*column_.rbegin())->get_row_index();
   } else {
-    return chain_opt::get_pivot();
+    return Chain_opt::get_pivot();
   }
 }
 
 template <class Master_matrix>
-inline typename Set_column<Master_matrix>::Field_element_type
-Set_column<Master_matrix>::get_pivot_value() const 
+inline typename Set_column<Master_matrix>::Field_element Set_column<Master_matrix>::get_pivot_value() const
 {
   static_assert(Master_matrix::isNonBasic,
                 "Method not available for base columns.");  // could technically be, but is the notion useful then?
@@ -569,75 +559,66 @@ Set_column<Master_matrix>::get_pivot_value() const
       if (column_.empty()) return 0;
       return (*column_.rbegin())->get_element();
     } else {
-      if (chain_opt::get_pivot() == static_cast<id_index>(-1)) return Field_element_type();
+      if (Chain_opt::get_pivot() == static_cast<ID_index>(-1)) return Field_element();
       for (const Cell* cell : column_) {
-        if (cell->get_row_index() == chain_opt::get_pivot()) return cell->get_element();
+        if (cell->get_row_index() == Chain_opt::get_pivot()) return cell->get_element();
       }
-      return Field_element_type();  // should never happen if chain column is used properly
+      return Field_element();  // should never happen if chain column is used properly
     }
   }
 }
 
 template <class Master_matrix>
-inline typename Set_column<Master_matrix>::iterator
-Set_column<Master_matrix>::begin() noexcept 
+inline typename Set_column<Master_matrix>::iterator Set_column<Master_matrix>::begin() noexcept
 {
   return column_.begin();
 }
 
 template <class Master_matrix>
-inline typename Set_column<Master_matrix>::const_iterator
-Set_column<Master_matrix>::begin() const noexcept 
+inline typename Set_column<Master_matrix>::const_iterator Set_column<Master_matrix>::begin() const noexcept
 {
   return column_.begin();
 }
 
 template <class Master_matrix>
-inline typename Set_column<Master_matrix>::iterator
-Set_column<Master_matrix>::end() noexcept 
+inline typename Set_column<Master_matrix>::iterator Set_column<Master_matrix>::end() noexcept
 {
   return column_.end();
 }
 
 template <class Master_matrix>
-inline typename Set_column<Master_matrix>::const_iterator
-Set_column<Master_matrix>::end() const noexcept 
+inline typename Set_column<Master_matrix>::const_iterator Set_column<Master_matrix>::end() const noexcept
 {
   return column_.end();
 }
 
 template <class Master_matrix>
-inline typename Set_column<Master_matrix>::reverse_iterator
-Set_column<Master_matrix>::rbegin() noexcept 
+inline typename Set_column<Master_matrix>::reverse_iterator Set_column<Master_matrix>::rbegin() noexcept
 {
   return column_.rbegin();
 }
 
 template <class Master_matrix>
-inline typename Set_column<Master_matrix>::const_reverse_iterator
-Set_column<Master_matrix>::rbegin() const noexcept 
+inline typename Set_column<Master_matrix>::const_reverse_iterator Set_column<Master_matrix>::rbegin() const noexcept
 {
   return column_.rbegin();
 }
 
 template <class Master_matrix>
-inline typename Set_column<Master_matrix>::reverse_iterator
-Set_column<Master_matrix>::rend() noexcept 
+inline typename Set_column<Master_matrix>::reverse_iterator Set_column<Master_matrix>::rend() noexcept
 {
   return column_.rend();
 }
 
 template <class Master_matrix>
-inline typename Set_column<Master_matrix>::const_reverse_iterator
-Set_column<Master_matrix>::rend() const noexcept 
+inline typename Set_column<Master_matrix>::const_reverse_iterator Set_column<Master_matrix>::rend() const noexcept
 {
   return column_.rend();
 }
 
 template <class Master_matrix>
 template <class Cell_range>
-inline Set_column<Master_matrix>& Set_column<Master_matrix>::operator+=(
-    const Cell_range& column) 
+inline Set_column<Master_matrix>& Set_column<Master_matrix>::operator+=(const Cell_range& column)
 {
   static_assert((!Master_matrix::isNonBasic || std::is_same_v<Cell_range, Set_column>),
                 "For boundary columns, the range has to be a column of same type to help ensure the validity of the "
@@ -651,14 +632,13 @@ inline Set_column<Master_matrix>& Set_column<Master_matrix>::operator+=(
 }
 
 template <class Master_matrix>
-inline Set_column<Master_matrix>& Set_column<Master_matrix>::operator+=(
-    Set_column& column) 
+inline Set_column<Master_matrix>& Set_column<Master_matrix>::operator+=(Set_column& column)
 {
   if constexpr (Master_matrix::isNonBasic && !Master_matrix::Option_list::is_of_boundary_type) {
     // assumes that the addition never zeros out this column.
     if (_add(column)) {
-      chain_opt::swap_pivots(column);
-      dim_opt::swap_dimension(column);
+      Chain_opt::swap_pivots(column);
+      Dim_opt::swap_dimension(column);
     }
   } else {
     _add(column);
@@ -668,8 +648,7 @@ inline Set_column<Master_matrix>& Set_column<Master_matrix>::operator+=(
 }
 
 template <class Master_matrix>
-inline Set_column<Master_matrix>& Set_column<Master_matrix>::operator*=(
-    unsigned int v) 
+inline Set_column<Master_matrix>& Set_column<Master_matrix>::operator*=(unsigned int v)
 {
   if constexpr (Master_matrix::Option_list::is_z2) {
     if (v % 2 == 0) {
@@ -680,7 +659,7 @@ inline Set_column<Master_matrix>& Set_column<Master_matrix>::operator*=(
       }
     }
   } else {
-    Field_element_type val = operators_->get_value(v);
+    Field_element val = operators_->get_value(v);
 
     if (val == Field_operators::get_additive_identity()) {
       if constexpr (Master_matrix::isNonBasic && !Master_matrix::Option_list::is_of_boundary_type) {
@@ -695,7 +674,7 @@ inline Set_column<Master_matrix>& Set_column<Master_matrix>::operator*=(
 
     for (Cell* cell : column_) {
       operators_->multiply_inplace(cell->get_element(), val);
-      if constexpr (Master_matrix::Option_list::has_row_access) ra_opt::update_cell(*cell);
+      if constexpr (Master_matrix::Option_list::has_row_access) RA_opt::update_cell(*cell);
     }
   }
 
@@ -704,8 +683,8 @@ inline Set_column<Master_matrix>& Set_column<Master_matrix>::operator*=(
 
 template <class Master_matrix>
 template <class Cell_range>
-inline Set_column<Master_matrix>& Set_column<Master_matrix>::multiply_target_and_add(
-    const Field_element_type& val, const Cell_range& column) 
+inline Set_column<Master_matrix>& Set_column<Master_matrix>::multiply_target_and_add(const Field_element& val,
+                                                                                     const Cell_range& column)
 {
   static_assert((!Master_matrix::isNonBasic || std::is_same_v<Cell_range, Set_column>),
                 "For boundary columns, the range has to be a column of same type to help ensure the validity of the "
@@ -728,24 +707,24 @@ inline Set_column<Master_matrix>& Set_column<Master_matrix>::multiply_target_and
 }
 
 template <class Master_matrix>
-inline Set_column<Master_matrix>& Set_column<Master_matrix>::multiply_target_and_add(
-    const Field_element_type& val, Set_column& column) 
+inline Set_column<Master_matrix>& Set_column<Master_matrix>::multiply_target_and_add(const Field_element& val,
+                                                                                     Set_column& column)
 {
   if constexpr (Master_matrix::isNonBasic && !Master_matrix::Option_list::is_of_boundary_type) {
     // assumes that the addition never zeros out this column.
     if constexpr (Master_matrix::Option_list::is_z2) {
       if (val) {
         if (_add(column)) {
-          chain_opt::swap_pivots(column);
-          dim_opt::swap_dimension(column);
+          Chain_opt::swap_pivots(column);
+          Dim_opt::swap_dimension(column);
         }
       } else {
         throw std::invalid_argument("A chain column should not be multiplied by 0.");
       }
     } else {
       if (_multiply_target_and_add(val, column)) {
-        chain_opt::swap_pivots(column);
-        dim_opt::swap_dimension(column);
+        Chain_opt::swap_pivots(column);
+        Dim_opt::swap_dimension(column);
       }
     }
   } else {
@@ -766,8 +745,8 @@ inline Set_column<Master_matrix>& Set_column<Master_matrix>::multiply_target_and
 
 template <class Master_matrix>
 template <class Cell_range>
-inline Set_column<Master_matrix>& Set_column<Master_matrix>::multiply_source_and_add(
-    const Cell_range& column, const Field_element_type& val) 
+inline Set_column<Master_matrix>& Set_column<Master_matrix>::multiply_source_and_add(const Cell_range& column,
+                                                                                     const Field_element& val)
 {
   static_assert((!Master_matrix::isNonBasic || std::is_same_v<Cell_range, Set_column>),
                 "For boundary columns, the range has to be a column of same type to help ensure the validity of the "
@@ -787,22 +766,22 @@ inline Set_column<Master_matrix>& Set_column<Master_matrix>::multiply_source_and
 }
 
 template <class Master_matrix>
-inline Set_column<Master_matrix>& Set_column<Master_matrix>::multiply_source_and_add(
-    Set_column& column, const Field_element_type& val) 
+inline Set_column<Master_matrix>& Set_column<Master_matrix>::multiply_source_and_add(Set_column& column,
+                                                                                     const Field_element& val)
 {
   if constexpr (Master_matrix::isNonBasic && !Master_matrix::Option_list::is_of_boundary_type) {
     // assumes that the addition never zeros out this column.
     if constexpr (Master_matrix::Option_list::is_z2) {
       if (val) {
         if (_add(column)) {
-          chain_opt::swap_pivots(column);
-          dim_opt::swap_dimension(column);
+          Chain_opt::swap_pivots(column);
+          Dim_opt::swap_dimension(column);
         }
       }
     } else {
       if (_multiply_source_and_add(column, val)) {
-        chain_opt::swap_pivots(column);
-        dim_opt::swap_dimension(column);
+        Chain_opt::swap_pivots(column);
+        Dim_opt::swap_dimension(column);
       }
     }
   } else {
@@ -819,16 +798,15 @@ inline Set_column<Master_matrix>& Set_column<Master_matrix>::multiply_source_and
 }
 
 template <class Master_matrix>
-inline Set_column<Master_matrix>& Set_column<Master_matrix>::operator=(
-    const Set_column& other) 
+inline Set_column<Master_matrix>& Set_column<Master_matrix>::operator=(const Set_column& other)
 {
   static_assert(!Master_matrix::Option_list::has_row_access, "= assignment not enabled with row access option.");
 
-  dim_opt::operator=(other);
-  chain_opt::operator=(other);
+  Dim_opt::operator=(other);
+  Chain_opt::operator=(other);
 
   for (auto* cell : column_) {
-    if constexpr (Master_matrix::Option_list::has_row_access) ra_opt::unlink(cell);
+    if constexpr (Master_matrix::Option_list::has_row_access) RA_opt::unlink(cell);
     cellPool_->destroy(cell);
   }
   column_.clear();
@@ -848,22 +826,22 @@ inline Set_column<Master_matrix>& Set_column<Master_matrix>::operator=(
 }
 
 template <class Master_matrix>
-inline void Set_column<Master_matrix>::_delete_cell(typename Column_type::iterator& it) 
+inline void Set_column<Master_matrix>::_delete_cell(typename Column::iterator& it)
 {
-  if constexpr (Master_matrix::Option_list::has_row_access) ra_opt::unlink(*it);
+  if constexpr (Master_matrix::Option_list::has_row_access) RA_opt::unlink(*it);
   cellPool_->destroy(*it);
   it = column_.erase(it);
 }
 
 template <class Master_matrix>
 inline typename Set_column<Master_matrix>::Cell* Set_column<Master_matrix>::_insert_cell(
-    const Field_element_type& value, id_index rowIndex, const typename Column_type::iterator& position)
+    const Field_element& value, ID_index rowIndex, const typename Column::iterator& position)
 {
   if constexpr (Master_matrix::Option_list::has_row_access) {
-    Cell* newCell = cellPool_->construct(ra_opt::columnIndex_, rowIndex);
+    Cell* newCell = cellPool_->construct(RA_opt::columnIndex_, rowIndex);
     newCell->set_element(value);
     column_.insert(position, newCell);
-    ra_opt::insert_cell(rowIndex, newCell);
+    RA_opt::insert_cell(rowIndex, newCell);
     return newCell;
   } else {
     Cell* newCell = cellPool_->construct(rowIndex);
@@ -874,13 +852,12 @@ inline typename Set_column<Master_matrix>::Cell* Set_column<Master_matrix>::_ins
 }
 
 template <class Master_matrix>
-inline void Set_column<Master_matrix>::_insert_cell(id_index rowIndex,
-                                                                      const typename Column_type::iterator& position) 
+inline void Set_column<Master_matrix>::_insert_cell(ID_index rowIndex, const typename Column::iterator& position)
 {
   if constexpr (Master_matrix::Option_list::has_row_access) {
-    Cell* newCell = cellPool_->construct(ra_opt::columnIndex_, rowIndex);
+    Cell* newCell = cellPool_->construct(RA_opt::columnIndex_, rowIndex);
     column_.insert(position, newCell);
-    ra_opt::insert_cell(rowIndex, newCell);
+    RA_opt::insert_cell(rowIndex, newCell);
   } else {
     Cell* newCell = cellPool_->construct(rowIndex);
     column_.insert(position, newCell);
@@ -889,23 +866,21 @@ inline void Set_column<Master_matrix>::_insert_cell(id_index rowIndex,
 
 template <class Master_matrix>
 template <class Cell_range>
-inline bool Set_column<Master_matrix>::_add(const Cell_range& column) 
+inline bool Set_column<Master_matrix>::_add(const Cell_range& column)
 {
   return _add_to_column(column, *this);
 }
 
 template <class Master_matrix>
 template <class Cell_range>
-inline bool Set_column<Master_matrix>::_multiply_target_and_add(const Field_element_type& val,
-                                                                           const Cell_range& column) 
+inline bool Set_column<Master_matrix>::_multiply_target_and_add(const Field_element& val, const Cell_range& column)
 {
   return _multiply_target_and_add_to_column(val, column, *this);
 }
 
 template <class Master_matrix>
 template <class Cell_range>
-inline bool Set_column<Master_matrix>::_multiply_source_and_add(const Cell_range& column,
-                                                                           const Field_element_type& val) 
+inline bool Set_column<Master_matrix>::_multiply_source_and_add(const Cell_range& column, const Field_element& val)
 {
   return _multiply_source_and_add_to_column(val, column, *this);
 }
@@ -917,13 +892,12 @@ inline bool Set_column<Master_matrix>::_multiply_source_and_add(const Cell_range
  * @ingroup persistence_matrix
  *
  * @brief Hash method for @ref Gudhi::persistence_matrix::Set_column.
- * 
+ *
  * @tparam Master_matrix Template parameter of @ref Gudhi::persistence_matrix::Set_column.
  * @tparam Cell_constructor Template parameter of @ref Gudhi::persistence_matrix::Set_column.
  */
 template <class Master_matrix>
-struct std::hash<Gudhi::persistence_matrix::Set_column<Master_matrix> > 
-{
+struct std::hash<Gudhi::persistence_matrix::Set_column<Master_matrix> > {
   std::size_t operator()(const Gudhi::persistence_matrix::Set_column<Master_matrix>& column) const {
     return Gudhi::persistence_matrix::hash_column(column);
   }

--- a/src/Persistence_matrix/include/gudhi/Persistence_matrix/columns/unordered_set_column.h
+++ b/src/Persistence_matrix/include/gudhi/Persistence_matrix/columns/unordered_set_column.h
@@ -36,14 +36,16 @@
 namespace Gudhi {
 namespace persistence_matrix {
 
-//For unordered_set container. Outside of Unordered_set_column because of a msvc bug who can't compile properly
-//unordered_flat_set if the hash method is nested.
+// For unordered_set container. Outside of Unordered_set_column because of a msvc bug who can't compile properly
+// unordered_flat_set if the hash method is nested.
 template <class Cell>
-struct CellPointerHash {
+struct CellPointerHash
+{
   size_t operator()(const Cell* c) const { return std::hash<Cell>()(*c); }
 };
 template <class Cell>
-struct CellPointerEq {
+struct CellPointerEq
+{
   bool operator()(const Cell* c1, const Cell* c2) const { return *c1 == *c2; }
 };
 
@@ -56,22 +58,22 @@ struct CellPointerEq {
  * Column based on an unordered set structure. The cells are not ordered, but only non-zero values
  * are stored uniquely in the underlying container. When adding a cell range into it, the given cell range
  * also does not need to be ordered (contrary to most other column types).
- * 
+ *
  * @tparam Master_matrix An instantiation of @ref Matrix from which all types and options are deduced.
  * @tparam Cell_constructor Factory of @ref Cell classes.
  */
 template <class Master_matrix>
 class Unordered_set_column : public Master_matrix::Row_access_option,
                              public Master_matrix::Column_dimension_option,
-                             public Master_matrix::Chain_column_option 
+                             public Master_matrix::Chain_column_option
 {
  public:
   using Master = Master_matrix;
-  using index = typename Master_matrix::index;
-  using id_index = typename Master_matrix::id_index;
-  using dimension_type = typename Master_matrix::dimension_type;
-  using Field_element_type = typename Master_matrix::element_type;
-  using Cell = typename Master_matrix::Cell_type;
+  using Index = typename Master_matrix::Index;
+  using ID_index = typename Master_matrix::ID_index;
+  using Dimension = typename Master_matrix::Dimension;
+  using Field_element = typename Master_matrix::Element;
+  using Cell = typename Master_matrix::Matrix_cell;
   using Column_settings = typename Master_matrix::Column_settings;
 
  private:
@@ -83,56 +85,52 @@ class Unordered_set_column : public Master_matrix::Row_access_option,
   };
 
 #if BOOST_VERSION >= 108100
-  using Column_type = boost::unordered_flat_set<Cell*, CellPointerHash<Cell>, CellPointerEq<Cell>>;
+  using Column = boost::unordered_flat_set<Cell*, CellPointerHash<Cell>, CellPointerEq<Cell>>;
 #else
-  using Column_type = std::unordered_set<Cell*, CellPointerHash<Cell>, CellPointerEq<Cell>>;
+  using Column = std::unordered_set<Cell*, CellPointerHash<Cell>, CellPointerEq<Cell>>;
 #endif
 
  public:
-  using iterator = boost::indirect_iterator<typename Column_type::iterator>;
-  using const_iterator = boost::indirect_iterator<typename Column_type::const_iterator>;
+  using iterator = boost::indirect_iterator<typename Column::iterator>;
+  using const_iterator = boost::indirect_iterator<typename Column::const_iterator>;
 
   Unordered_set_column(Column_settings* colSettings = nullptr);
-  template <class Container_type = typename Master_matrix::boundary_type>
-  Unordered_set_column(const Container_type& nonZeroRowIndices, 
+  template <class Container = typename Master_matrix::Boundary>
+  Unordered_set_column(const Container& nonZeroRowIndices, Column_settings* colSettings);
+  template <class Container = typename Master_matrix::Boundary, class Row_container>
+  Unordered_set_column(Index columnIndex,
+                       const Container& nonZeroRowIndices,
+                       Row_container* rowContainer,
                        Column_settings* colSettings);
-  template <class Container_type = typename Master_matrix::boundary_type, class Row_container_type>
-  Unordered_set_column(index columnIndex, 
-                       const Container_type& nonZeroRowIndices, 
-                       Row_container_type* rowContainer,
+  template <class Container = typename Master_matrix::Boundary>
+  Unordered_set_column(const Container& nonZeroChainRowIndices, Dimension dimension, Column_settings* colSettings);
+  template <class Container = typename Master_matrix::Boundary, class Row_container>
+  Unordered_set_column(Index columnIndex,
+                       const Container& nonZeroChainRowIndices,
+                       Dimension dimension,
+                       Row_container* rowContainer,
                        Column_settings* colSettings);
-  template <class Container_type = typename Master_matrix::boundary_type>
-  Unordered_set_column(const Container_type& nonZeroChainRowIndices, 
-                       dimension_type dimension,
-                       Column_settings* colSettings);
-  template <class Container_type = typename Master_matrix::boundary_type, class Row_container_type>
-  Unordered_set_column(index columnIndex, 
-                       const Container_type& nonZeroChainRowIndices, 
-                       dimension_type dimension,
-                       Row_container_type* rowContainer, 
-                       Column_settings* colSettings);
-  Unordered_set_column(const Unordered_set_column& column, 
-                       Column_settings* colSettings = nullptr);
-  template <class Row_container_type>
-  Unordered_set_column(const Unordered_set_column& column, 
-                       index columnIndex, 
-                       Row_container_type* rowContainer,
+  Unordered_set_column(const Unordered_set_column& column, Column_settings* colSettings = nullptr);
+  template <class Row_container>
+  Unordered_set_column(const Unordered_set_column& column,
+                       Index columnIndex,
+                       Row_container* rowContainer,
                        Column_settings* colSettings = nullptr);
   Unordered_set_column(Unordered_set_column&& column) noexcept;
   ~Unordered_set_column();
 
-  std::vector<Field_element_type> get_content(int columnLength = -1) const;
-  bool is_non_zero(id_index rowIndex) const;
+  std::vector<Field_element> get_content(int columnLength = -1) const;
+  bool is_non_zero(ID_index rowIndex) const;
   bool is_empty() const;
   std::size_t size() const;
 
-  template <class Map_type>
-  void reorder(const Map_type& valueMap, [[maybe_unused]] index columnIndex = -1);
+  template <class Row_index_map>
+  void reorder(const Row_index_map& valueMap, [[maybe_unused]] Index columnIndex = -1);
   void clear();
-  void clear(id_index rowIndex);
+  void clear(ID_index rowIndex);
 
-  id_index get_pivot() const;
-  Field_element_type get_pivot_value() const;
+  ID_index get_pivot() const;
+  Field_element get_pivot_value() const;
 
   iterator begin() noexcept;
   const_iterator begin() const noexcept;
@@ -147,18 +145,18 @@ class Unordered_set_column : public Master_matrix::Row_access_option,
 
   // this = v * this + column
   template <class Cell_range>
-  Unordered_set_column& multiply_target_and_add(const Field_element_type& val, const Cell_range& column);
-  Unordered_set_column& multiply_target_and_add(const Field_element_type& val, Unordered_set_column& column);
+  Unordered_set_column& multiply_target_and_add(const Field_element& val, const Cell_range& column);
+  Unordered_set_column& multiply_target_and_add(const Field_element& val, Unordered_set_column& column);
   // this = this + column * v
   template <class Cell_range>
-  Unordered_set_column& multiply_source_and_add(const Cell_range& column, const Field_element_type& val);
-  Unordered_set_column& multiply_source_and_add(Unordered_set_column& column, const Field_element_type& val);
+  Unordered_set_column& multiply_source_and_add(const Cell_range& column, const Field_element& val);
+  Unordered_set_column& multiply_source_and_add(Unordered_set_column& column, const Field_element& val);
 
   friend bool operator==(const Unordered_set_column& c1, const Unordered_set_column& c2) {
     if (&c1 == &c2) return true;
     if (c1.column_.size() != c2.column_.size()) return false;
 
-    for (Cell* cell : c1.column_){
+    for (Cell* cell : c1.column_) {
       auto it = c2.column_.find(cell);
       if (it == c2.column_.end()) return false;
       if constexpr (!Master_matrix::Option_list::is_z2)
@@ -169,15 +167,16 @@ class Unordered_set_column : public Master_matrix::Row_access_option,
   friend bool operator<(const Unordered_set_column& c1, const Unordered_set_column& c2) {
     if (&c1 == &c2) return false;
 
-    using id_index = Unordered_set_column<Master_matrix>::id_index;
-    using rep_type = typename std::conditional<Master_matrix::Option_list::is_z2,
-                                               id_index,
-                                               std::pair<id_index, unsigned int> 
-                                              >::type;
+    using ID_index = Unordered_set_column<Master_matrix>::ID_index;
+    using Cell_rep =
+        typename std::conditional<Master_matrix::Option_list::is_z2,
+                                  ID_index,
+                                  std::pair<ID_index, unsigned int>
+                                 >::type;
 
     auto it1 = c1.column_.begin();
     auto it2 = c2.column_.begin();
-    std::set<rep_type> cells1, cells2;
+    std::set<Cell_rep> cells1, cells2;
     while (it1 != c1.column_.end() && it2 != c2.column_.end()) {
       if constexpr (Master_matrix::Option_list::is_z2) {
         cells1.insert((*it1)->get_row_index());
@@ -224,48 +223,48 @@ class Unordered_set_column : public Master_matrix::Row_access_option,
   }
 
  private:
-  using ra_opt = typename Master_matrix::Row_access_option;
-  using dim_opt = typename Master_matrix::Column_dimension_option;
-  using chain_opt = typename Master_matrix::Chain_column_option;
+  using RA_opt = typename Master_matrix::Row_access_option;
+  using Dim_opt = typename Master_matrix::Column_dimension_option;
+  using Chain_opt = typename Master_matrix::Chain_column_option;
 
-  Column_type column_;
+  Column column_;
   Field_operators* operators_;
   Cell_constructor* cellPool_;
 
-  void _delete_cell(typename Column_type::iterator& it);
-  Cell* _insert_cell(const Field_element_type& value, id_index rowIndex);
-  void _insert_cell(id_index rowIndex);
+  void _delete_cell(typename Column::iterator& it);
+  Cell* _insert_cell(const Field_element& value, ID_index rowIndex);
+  void _insert_cell(ID_index rowIndex);
   template <class Cell_range>
   bool _add(const Cell_range& column);
   template <class Cell_range>
-  bool _multiply_target_and_add(const Field_element_type& val, const Cell_range& column);
+  bool _multiply_target_and_add(const Field_element& val, const Cell_range& column);
   template <class Cell_range>
-  bool _multiply_source_and_add(const Cell_range& column, const Field_element_type& val);
+  bool _multiply_source_and_add(const Cell_range& column, const Field_element& val);
   template <class Cell_range, typename F1, typename F2>
   bool _generic_add(const Cell_range& source, F1&& process_source, F2&& update_target);
 };
 
 template <class Master_matrix>
 inline Unordered_set_column<Master_matrix>::Unordered_set_column(Column_settings* colSettings)
-    : ra_opt(),
-      dim_opt(),
-      chain_opt(),
+    : RA_opt(),
+      Dim_opt(),
+      Chain_opt(),
       operators_(nullptr),
       cellPool_(colSettings == nullptr ? nullptr : &(colSettings->cellConstructor))
 {
-  if (operators_ == nullptr && cellPool_ == nullptr) return; // to allow default constructor which gives a dummy column
+  if (operators_ == nullptr && cellPool_ == nullptr) return;  // to allow default constructor which gives a dummy column
   if constexpr (!Master_matrix::Option_list::is_z2) {
     operators_ = &(colSettings->operators);
   }
 }
 
 template <class Master_matrix>
-template <class Container_type>
-inline Unordered_set_column<Master_matrix>::Unordered_set_column(
-    const Container_type& nonZeroRowIndices, Column_settings* colSettings)
-    : ra_opt(),
-      dim_opt(nonZeroRowIndices.size() == 0 ? 0 : nonZeroRowIndices.size() - 1),
-      chain_opt(),
+template <class Container>
+inline Unordered_set_column<Master_matrix>::Unordered_set_column(const Container& nonZeroRowIndices,
+                                                                 Column_settings* colSettings)
+    : RA_opt(),
+      Dim_opt(nonZeroRowIndices.size() == 0 ? 0 : nonZeroRowIndices.size() - 1),
+      Chain_opt(),
       column_(nonZeroRowIndices.size()),
       operators_(nullptr),
       cellPool_(&(colSettings->cellConstructor))
@@ -274,7 +273,7 @@ inline Unordered_set_column<Master_matrix>::Unordered_set_column(
                 "Constructor not available for chain columns, please specify the dimension of the chain.");
 
   if constexpr (Master_matrix::Option_list::is_z2) {
-    for (id_index id : nonZeroRowIndices) {
+    for (ID_index id : nonZeroRowIndices) {
       _insert_cell(id);
     }
   } else {
@@ -286,15 +285,14 @@ inline Unordered_set_column<Master_matrix>::Unordered_set_column(
 }
 
 template <class Master_matrix>
-template <class Container_type, class Row_container_type>
-inline Unordered_set_column<Master_matrix>::Unordered_set_column(
-    index columnIndex, 
-    const Container_type& nonZeroRowIndices, 
-    Row_container_type* rowContainer,
-    Column_settings* colSettings)
-    : ra_opt(columnIndex, rowContainer),
-      dim_opt(nonZeroRowIndices.size() == 0 ? 0 : nonZeroRowIndices.size() - 1),
-      chain_opt([&] {
+template <class Container, class Row_container>
+inline Unordered_set_column<Master_matrix>::Unordered_set_column(Index columnIndex,
+                                                                 const Container& nonZeroRowIndices,
+                                                                 Row_container* rowContainer,
+                                                                 Column_settings* colSettings)
+    : RA_opt(columnIndex, rowContainer),
+      Dim_opt(nonZeroRowIndices.size() == 0 ? 0 : nonZeroRowIndices.size() - 1),
+      Chain_opt([&] {
         if constexpr (Master_matrix::Option_list::is_z2) {
           return nonZeroRowIndices.begin() == nonZeroRowIndices.end() ? -1 : *std::prev(nonZeroRowIndices.end());
         } else {
@@ -309,7 +307,7 @@ inline Unordered_set_column<Master_matrix>::Unordered_set_column(
                 "Constructor not available for chain columns, please specify the dimension of the chain.");
 
   if constexpr (Master_matrix::Option_list::is_z2) {
-    for (id_index id : nonZeroRowIndices) {
+    for (ID_index id : nonZeroRowIndices) {
       _insert_cell(id);
     }
   } else {
@@ -321,14 +319,13 @@ inline Unordered_set_column<Master_matrix>::Unordered_set_column(
 }
 
 template <class Master_matrix>
-template <class Container_type>
-inline Unordered_set_column<Master_matrix>::Unordered_set_column(
-    const Container_type& nonZeroRowIndices, 
-    dimension_type dimension, 
-    Column_settings* colSettings)
-    : ra_opt(),
-      dim_opt(dimension),
-      chain_opt([&] {
+template <class Container>
+inline Unordered_set_column<Master_matrix>::Unordered_set_column(const Container& nonZeroRowIndices,
+                                                                 Dimension dimension,
+                                                                 Column_settings* colSettings)
+    : RA_opt(),
+      Dim_opt(dimension),
+      Chain_opt([&] {
         if constexpr (Master_matrix::Option_list::is_z2) {
           return nonZeroRowIndices.begin() == nonZeroRowIndices.end() ? -1 : *std::prev(nonZeroRowIndices.end());
         } else {
@@ -340,7 +337,7 @@ inline Unordered_set_column<Master_matrix>::Unordered_set_column(
       cellPool_(&(colSettings->cellConstructor))
 {
   if constexpr (Master_matrix::Option_list::is_z2) {
-    for (id_index id : nonZeroRowIndices) {
+    for (ID_index id : nonZeroRowIndices) {
       _insert_cell(id);
     }
   } else {
@@ -352,16 +349,15 @@ inline Unordered_set_column<Master_matrix>::Unordered_set_column(
 }
 
 template <class Master_matrix>
-template <class Container_type, class Row_container_type>
-inline Unordered_set_column<Master_matrix>::Unordered_set_column(
-    index columnIndex, 
-    const Container_type& nonZeroRowIndices, 
-    dimension_type dimension,
-    Row_container_type* rowContainer, 
-    Column_settings* colSettings)
-    : ra_opt(columnIndex, rowContainer),
-      dim_opt(dimension),
-      chain_opt([&] {
+template <class Container, class Row_container>
+inline Unordered_set_column<Master_matrix>::Unordered_set_column(Index columnIndex,
+                                                                 const Container& nonZeroRowIndices,
+                                                                 Dimension dimension,
+                                                                 Row_container* rowContainer,
+                                                                 Column_settings* colSettings)
+    : RA_opt(columnIndex, rowContainer),
+      Dim_opt(dimension),
+      Chain_opt([&] {
         if constexpr (Master_matrix::Option_list::is_z2) {
           return nonZeroRowIndices.begin() == nonZeroRowIndices.end() ? -1 : *std::prev(nonZeroRowIndices.end());
         } else {
@@ -373,7 +369,7 @@ inline Unordered_set_column<Master_matrix>::Unordered_set_column(
       cellPool_(&(colSettings->cellConstructor))
 {
   if constexpr (Master_matrix::Option_list::is_z2) {
-    for (id_index id : nonZeroRowIndices) {
+    for (ID_index id : nonZeroRowIndices) {
       _insert_cell(id);
     }
   } else {
@@ -386,10 +382,10 @@ inline Unordered_set_column<Master_matrix>::Unordered_set_column(
 
 template <class Master_matrix>
 inline Unordered_set_column<Master_matrix>::Unordered_set_column(const Unordered_set_column& column,
-                                                                                   Column_settings* colSettings)
-    : ra_opt(),
-      dim_opt(static_cast<const dim_opt&>(column)),
-      chain_opt(static_cast<const chain_opt&>(column)),
+                                                                 Column_settings* colSettings)
+    : RA_opt(),
+      Dim_opt(static_cast<const Dim_opt&>(column)),
+      Chain_opt(static_cast<const Chain_opt&>(column)),
       column_(column.column_.bucket_count()),
       operators_(colSettings == nullptr ? column.operators_ : nullptr),
       cellPool_(colSettings == nullptr ? column.cellPool_ : &(colSettings->cellConstructor))
@@ -398,7 +394,7 @@ inline Unordered_set_column<Master_matrix>::Unordered_set_column(const Unordered
                 "Simple copy constructor not available when row access option enabled. Please specify the new column "
                 "index and the row container.");
 
-  if constexpr (!Master_matrix::Option_list::is_z2){
+  if constexpr (!Master_matrix::Option_list::is_z2) {
     if (colSettings != nullptr) operators_ = &(colSettings->operators);
   }
 
@@ -412,19 +408,19 @@ inline Unordered_set_column<Master_matrix>::Unordered_set_column(const Unordered
 }
 
 template <class Master_matrix>
-template <class Row_container_type>
+template <class Row_container>
 inline Unordered_set_column<Master_matrix>::Unordered_set_column(const Unordered_set_column& column,
-                                                                                   index columnIndex,
-                                                                                   Row_container_type* rowContainer,
-                                                                                   Column_settings* colSettings)
-    : ra_opt(columnIndex, rowContainer),
-      dim_opt(static_cast<const dim_opt&>(column)),
-      chain_opt(static_cast<const chain_opt&>(column)),
+                                                                 Index columnIndex,
+                                                                 Row_container* rowContainer,
+                                                                 Column_settings* colSettings)
+    : RA_opt(columnIndex, rowContainer),
+      Dim_opt(static_cast<const Dim_opt&>(column)),
+      Chain_opt(static_cast<const Chain_opt&>(column)),
       column_(column.column_.bucket_count()),
       operators_(colSettings == nullptr ? column.operators_ : nullptr),
       cellPool_(colSettings == nullptr ? column.cellPool_ : &(colSettings->cellConstructor))
 {
-  if constexpr (!Master_matrix::Option_list::is_z2){
+  if constexpr (!Master_matrix::Option_list::is_z2) {
     if (colSettings != nullptr) operators_ = &(colSettings->operators);
   }
 
@@ -438,37 +434,36 @@ inline Unordered_set_column<Master_matrix>::Unordered_set_column(const Unordered
 }
 
 template <class Master_matrix>
-inline Unordered_set_column<Master_matrix>::Unordered_set_column(
-    Unordered_set_column&& column) noexcept
-    : ra_opt(std::move(static_cast<ra_opt&>(column))),
-      dim_opt(std::move(static_cast<dim_opt&>(column))),
-      chain_opt(std::move(static_cast<chain_opt&>(column))),
+inline Unordered_set_column<Master_matrix>::Unordered_set_column(Unordered_set_column&& column) noexcept
+    : RA_opt(std::move(static_cast<RA_opt&>(column))),
+      Dim_opt(std::move(static_cast<Dim_opt&>(column))),
+      Chain_opt(std::move(static_cast<Chain_opt&>(column))),
       column_(std::move(column.column_)),
       operators_(std::exchange(column.operators_, nullptr)),
-      cellPool_(std::exchange(column.cellPool_, nullptr)) 
+      cellPool_(std::exchange(column.cellPool_, nullptr))
 {}
 
 template <class Master_matrix>
-inline Unordered_set_column<Master_matrix>::~Unordered_set_column() 
+inline Unordered_set_column<Master_matrix>::~Unordered_set_column()
 {
   for (auto* cell : column_) {
-    if constexpr (Master_matrix::Option_list::has_row_access) ra_opt::unlink(cell);
+    if constexpr (Master_matrix::Option_list::has_row_access) RA_opt::unlink(cell);
     cellPool_->destroy(cell);
   }
 }
 
 template <class Master_matrix>
-inline std::vector<typename Unordered_set_column<Master_matrix>::Field_element_type>
-Unordered_set_column<Master_matrix>::get_content(int columnLength) const 
+inline std::vector<typename Unordered_set_column<Master_matrix>::Field_element>
+Unordered_set_column<Master_matrix>::get_content(int columnLength) const
 {
   if (columnLength < 0 && column_.size() > 0)
     columnLength = (*std::max_element(column_.begin(), column_.end(), CellPointerComp()))->get_row_index() + 1;
   else if (columnLength < 0)
-    return std::vector<Field_element_type>();
+    return std::vector<Field_element>();
 
-  std::vector<Field_element_type> container(columnLength, 0);
+  std::vector<Field_element> container(columnLength, 0);
   for (auto it = column_.begin(); it != column_.end(); ++it) {
-    if ((*it)->get_row_index() < static_cast<id_index>(columnLength)) {
+    if ((*it)->get_row_index() < static_cast<ID_index>(columnLength)) {
       if constexpr (Master_matrix::Option_list::is_z2) {
         container[(*it)->get_row_index()] = 1;
       } else {
@@ -480,50 +475,50 @@ Unordered_set_column<Master_matrix>::get_content(int columnLength) const
 }
 
 template <class Master_matrix>
-inline bool Unordered_set_column<Master_matrix>::is_non_zero(id_index rowIndex) const 
+inline bool Unordered_set_column<Master_matrix>::is_non_zero(ID_index rowIndex) const
 {
   Cell cell(rowIndex);
   return column_.find(&cell) != column_.end();
 }
 
 template <class Master_matrix>
-inline bool Unordered_set_column<Master_matrix>::is_empty() const 
+inline bool Unordered_set_column<Master_matrix>::is_empty() const
 {
   return column_.empty();
 }
 
 template <class Master_matrix>
-inline std::size_t Unordered_set_column<Master_matrix>::size() const 
+inline std::size_t Unordered_set_column<Master_matrix>::size() const
 {
   return column_.size();
 }
 
 template <class Master_matrix>
-template <class Map_type>
-inline void Unordered_set_column<Master_matrix>::reorder(const Map_type& valueMap,
-                                                                           [[maybe_unused]] index columnIndex) 
+template <class Row_index_map>
+inline void Unordered_set_column<Master_matrix>::reorder(const Row_index_map& valueMap,
+                                                         [[maybe_unused]] Index columnIndex)
 {
   static_assert(!Master_matrix::isNonBasic || Master_matrix::Option_list::is_of_boundary_type,
                 "Method not available for chain columns.");
 
-  Column_type newSet;
+  Column newSet;
 
   for (Cell* cell : column_) {
     if constexpr (Master_matrix::Option_list::has_row_access) {
-      ra_opt::unlink(cell);
-      if (columnIndex != static_cast<index>(-1)) cell->set_column_index(columnIndex);
+      RA_opt::unlink(cell);
+      if (columnIndex != static_cast<Index>(-1)) cell->set_column_index(columnIndex);
     }
     cell->set_row_index(valueMap.at(cell->get_row_index()));
     newSet.insert(cell);
     if constexpr (Master_matrix::Option_list::has_row_access &&
                   Master_matrix::Option_list::has_intrusive_rows)  // intrusive list
-      ra_opt::insert_cell(cell->get_row_index(), cell);
+      RA_opt::insert_cell(cell->get_row_index(), cell);
   }
 
   // when row is a set, all cells have to be deleted first, to avoid colliding when inserting
   if constexpr (Master_matrix::Option_list::has_row_access && !Master_matrix::Option_list::has_intrusive_rows) {  // set
     for (Cell* cell : newSet) {
-      ra_opt::insert_cell(cell->get_row_index(), cell);
+      RA_opt::insert_cell(cell->get_row_index(), cell);
     }
   }
 
@@ -531,13 +526,13 @@ inline void Unordered_set_column<Master_matrix>::reorder(const Map_type& valueMa
 }
 
 template <class Master_matrix>
-inline void Unordered_set_column<Master_matrix>::clear() 
+inline void Unordered_set_column<Master_matrix>::clear()
 {
   static_assert(!Master_matrix::isNonBasic || Master_matrix::Option_list::is_of_boundary_type,
                 "Method not available for chain columns as a base element should not be empty.");
 
   for (auto* cell : column_) {
-    if constexpr (Master_matrix::Option_list::has_row_access) ra_opt::unlink(cell);
+    if constexpr (Master_matrix::Option_list::has_row_access) RA_opt::unlink(cell);
     cellPool_->destroy(cell);
   }
 
@@ -545,7 +540,7 @@ inline void Unordered_set_column<Master_matrix>::clear()
 }
 
 template <class Master_matrix>
-inline void Unordered_set_column<Master_matrix>::clear(id_index rowIndex) 
+inline void Unordered_set_column<Master_matrix>::clear(ID_index rowIndex)
 {
   static_assert(!Master_matrix::isNonBasic || Master_matrix::Option_list::is_of_boundary_type,
                 "Method not available for chain columns.");
@@ -559,8 +554,7 @@ inline void Unordered_set_column<Master_matrix>::clear(id_index rowIndex)
 }
 
 template <class Master_matrix>
-inline typename Unordered_set_column<Master_matrix>::id_index
-Unordered_set_column<Master_matrix>::get_pivot() const 
+inline typename Unordered_set_column<Master_matrix>::ID_index Unordered_set_column<Master_matrix>::get_pivot() const
 {
   static_assert(Master_matrix::isNonBasic,
                 "Method not available for base columns.");  // could technically be, but is the notion useful then?
@@ -571,13 +565,13 @@ Unordered_set_column<Master_matrix>::get_pivot() const
     // the max, so not clear how much it is worth it.
     return (*std::max_element(column_.begin(), column_.end(), CellPointerComp()))->get_row_index();
   } else {
-    return chain_opt::get_pivot();
+    return Chain_opt::get_pivot();
   }
 }
 
 template <class Master_matrix>
-inline typename Unordered_set_column<Master_matrix>::Field_element_type
-Unordered_set_column<Master_matrix>::get_pivot_value() const 
+inline typename Unordered_set_column<Master_matrix>::Field_element
+Unordered_set_column<Master_matrix>::get_pivot_value() const
 {
   static_assert(Master_matrix::isNonBasic,
                 "Method not available for base columns.");  // could technically be, but is the notion useful then?
@@ -589,47 +583,44 @@ Unordered_set_column<Master_matrix>::get_pivot_value() const
       if (column_.empty()) return 0;
       return (*std::max_element(column_.begin(), column_.end(), CellPointerComp()))->get_element();
     } else {
-      if (chain_opt::get_pivot() == static_cast<id_index>(-1)) return Field_element_type();
+      if (Chain_opt::get_pivot() == static_cast<ID_index>(-1)) return Field_element();
       for (const Cell* cell : column_) {
-        if (cell->get_row_index() == chain_opt::get_pivot()) return cell->get_element();
+        if (cell->get_row_index() == Chain_opt::get_pivot()) return cell->get_element();
       }
-      return Field_element_type();  // should never happen if chain column is used properly
+      return Field_element();  // should never happen if chain column is used properly
     }
   }
 }
 
 template <class Master_matrix>
-inline typename Unordered_set_column<Master_matrix>::iterator
-Unordered_set_column<Master_matrix>::begin() noexcept 
+inline typename Unordered_set_column<Master_matrix>::iterator Unordered_set_column<Master_matrix>::begin() noexcept
 {
   return column_.begin();
 }
 
 template <class Master_matrix>
-inline typename Unordered_set_column<Master_matrix>::const_iterator
-Unordered_set_column<Master_matrix>::begin() const noexcept 
+inline typename Unordered_set_column<Master_matrix>::const_iterator Unordered_set_column<Master_matrix>::begin()
+    const noexcept
 {
   return column_.begin();
 }
 
 template <class Master_matrix>
-inline typename Unordered_set_column<Master_matrix>::iterator
-Unordered_set_column<Master_matrix>::end() noexcept 
+inline typename Unordered_set_column<Master_matrix>::iterator Unordered_set_column<Master_matrix>::end() noexcept
 {
   return column_.end();
 }
 
 template <class Master_matrix>
-inline typename Unordered_set_column<Master_matrix>::const_iterator
-Unordered_set_column<Master_matrix>::end() const noexcept 
+inline typename Unordered_set_column<Master_matrix>::const_iterator Unordered_set_column<Master_matrix>::end()
+    const noexcept
 {
   return column_.end();
 }
 
 template <class Master_matrix>
 template <class Cell_range>
-inline Unordered_set_column<Master_matrix>&
-Unordered_set_column<Master_matrix>::operator+=(const Cell_range& column) 
+inline Unordered_set_column<Master_matrix>& Unordered_set_column<Master_matrix>::operator+=(const Cell_range& column)
 {
   static_assert((!Master_matrix::isNonBasic || std::is_same_v<Cell_range, Unordered_set_column>),
                 "For boundary columns, the range has to be a column of same type to help ensure the validity of the "
@@ -643,14 +634,14 @@ Unordered_set_column<Master_matrix>::operator+=(const Cell_range& column)
 }
 
 template <class Master_matrix>
-inline Unordered_set_column<Master_matrix>&
-Unordered_set_column<Master_matrix>::operator+=(Unordered_set_column& column) 
+inline Unordered_set_column<Master_matrix>& Unordered_set_column<Master_matrix>::operator+=(
+    Unordered_set_column& column)
 {
   if constexpr (Master_matrix::isNonBasic && !Master_matrix::Option_list::is_of_boundary_type) {
     // assumes that the addition never zeros out this column.
     if (_add(column)) {
-      chain_opt::swap_pivots(column);
-      dim_opt::swap_dimension(column);
+      Chain_opt::swap_pivots(column);
+      Dim_opt::swap_dimension(column);
     }
   } else {
     _add(column);
@@ -660,8 +651,7 @@ Unordered_set_column<Master_matrix>::operator+=(Unordered_set_column& column)
 }
 
 template <class Master_matrix>
-inline Unordered_set_column<Master_matrix>&
-Unordered_set_column<Master_matrix>::operator*=(unsigned int v) 
+inline Unordered_set_column<Master_matrix>& Unordered_set_column<Master_matrix>::operator*=(unsigned int v)
 {
   if constexpr (Master_matrix::Option_list::is_z2) {
     if (v % 2 == 0) {
@@ -672,7 +662,7 @@ Unordered_set_column<Master_matrix>::operator*=(unsigned int v)
       }
     }
   } else {
-    Field_element_type val = operators_->get_value(v);
+    Field_element val = operators_->get_value(v);
 
     if (val == Field_operators::get_additive_identity()) {
       if constexpr (Master_matrix::isNonBasic && !Master_matrix::Option_list::is_of_boundary_type) {
@@ -687,7 +677,7 @@ Unordered_set_column<Master_matrix>::operator*=(unsigned int v)
 
     for (Cell* cell : column_) {
       operators_->multiply_inplace(cell->get_element(), val);
-      if constexpr (Master_matrix::Option_list::has_row_access) ra_opt::update_cell(*cell);
+      if constexpr (Master_matrix::Option_list::has_row_access) RA_opt::update_cell(*cell);
     }
   }
 
@@ -696,9 +686,8 @@ Unordered_set_column<Master_matrix>::operator*=(unsigned int v)
 
 template <class Master_matrix>
 template <class Cell_range>
-inline Unordered_set_column<Master_matrix>&
-Unordered_set_column<Master_matrix>::multiply_target_and_add(const Field_element_type& val,
-                                                                        const Cell_range& column) 
+inline Unordered_set_column<Master_matrix>& Unordered_set_column<Master_matrix>::multiply_target_and_add(
+    const Field_element& val, const Cell_range& column)
 {
   static_assert((!Master_matrix::isNonBasic || std::is_same_v<Cell_range, Unordered_set_column>),
                 "For boundary columns, the range has to be a column of same type to help ensure the validity of the "
@@ -721,25 +710,24 @@ Unordered_set_column<Master_matrix>::multiply_target_and_add(const Field_element
 }
 
 template <class Master_matrix>
-inline Unordered_set_column<Master_matrix>&
-Unordered_set_column<Master_matrix>::multiply_target_and_add(const Field_element_type& val,
-                                                                        Unordered_set_column& column) 
+inline Unordered_set_column<Master_matrix>& Unordered_set_column<Master_matrix>::multiply_target_and_add(
+    const Field_element& val, Unordered_set_column& column)
 {
   if constexpr (Master_matrix::isNonBasic && !Master_matrix::Option_list::is_of_boundary_type) {
     // assumes that the addition never zeros out this column.
     if constexpr (Master_matrix::Option_list::is_z2) {
       if (val) {
         if (_add(column)) {
-          chain_opt::swap_pivots(column);
-          dim_opt::swap_dimension(column);
+          Chain_opt::swap_pivots(column);
+          Dim_opt::swap_dimension(column);
         }
       } else {
         throw std::invalid_argument("A chain column should not be multiplied by 0.");
       }
     } else {
       if (_multiply_target_and_add(val, column)) {
-        chain_opt::swap_pivots(column);
-        dim_opt::swap_dimension(column);
+        Chain_opt::swap_pivots(column);
+        Dim_opt::swap_dimension(column);
       }
     }
   } else {
@@ -760,9 +748,8 @@ Unordered_set_column<Master_matrix>::multiply_target_and_add(const Field_element
 
 template <class Master_matrix>
 template <class Cell_range>
-inline Unordered_set_column<Master_matrix>&
-Unordered_set_column<Master_matrix>::multiply_source_and_add(const Cell_range& column,
-                                                                        const Field_element_type& val) 
+inline Unordered_set_column<Master_matrix>& Unordered_set_column<Master_matrix>::multiply_source_and_add(
+    const Cell_range& column, const Field_element& val)
 {
   static_assert((!Master_matrix::isNonBasic || std::is_same_v<Cell_range, Unordered_set_column>),
                 "For boundary columns, the range has to be a column of same type to help ensure the validity of the "
@@ -782,23 +769,22 @@ Unordered_set_column<Master_matrix>::multiply_source_and_add(const Cell_range& c
 }
 
 template <class Master_matrix>
-inline Unordered_set_column<Master_matrix>&
-Unordered_set_column<Master_matrix>::multiply_source_and_add(Unordered_set_column& column,
-                                                                        const Field_element_type& val) 
+inline Unordered_set_column<Master_matrix>& Unordered_set_column<Master_matrix>::multiply_source_and_add(
+    Unordered_set_column& column, const Field_element& val)
 {
   if constexpr (Master_matrix::isNonBasic && !Master_matrix::Option_list::is_of_boundary_type) {
     // assumes that the addition never zeros out this column.
     if constexpr (Master_matrix::Option_list::is_z2) {
       if (val) {
         if (_add(column)) {
-          chain_opt::swap_pivots(column);
-          dim_opt::swap_dimension(column);
+          Chain_opt::swap_pivots(column);
+          Dim_opt::swap_dimension(column);
         }
       }
     } else {
       if (_multiply_source_and_add(column, val)) {
-        chain_opt::swap_pivots(column);
-        dim_opt::swap_dimension(column);
+        Chain_opt::swap_pivots(column);
+        Dim_opt::swap_dimension(column);
       }
     }
   } else {
@@ -815,16 +801,16 @@ Unordered_set_column<Master_matrix>::multiply_source_and_add(Unordered_set_colum
 }
 
 template <class Master_matrix>
-inline Unordered_set_column<Master_matrix>&
-Unordered_set_column<Master_matrix>::operator=(const Unordered_set_column& other) 
+inline Unordered_set_column<Master_matrix>& Unordered_set_column<Master_matrix>::operator=(
+    const Unordered_set_column& other)
 {
   static_assert(!Master_matrix::Option_list::has_row_access, "= assignment not enabled with row access option.");
 
-  dim_opt::operator=(other);
-  chain_opt::operator=(other);
+  Dim_opt::operator=(other);
+  Chain_opt::operator=(other);
 
   for (auto* cell : column_) {
-    if constexpr (Master_matrix::Option_list::has_row_access) ra_opt::unlink(cell);
+    if constexpr (Master_matrix::Option_list::has_row_access) RA_opt::unlink(cell);
     cellPool_->destroy(cell);
   }
   column_.clear();
@@ -844,9 +830,9 @@ Unordered_set_column<Master_matrix>::operator=(const Unordered_set_column& other
 }
 
 template <class Master_matrix>
-inline void Unordered_set_column<Master_matrix>::_delete_cell(typename Column_type::iterator& it) 
+inline void Unordered_set_column<Master_matrix>::_delete_cell(typename Column::iterator& it)
 {
-  if constexpr (Master_matrix::Option_list::has_row_access) ra_opt::unlink(*it);
+  if constexpr (Master_matrix::Option_list::has_row_access) RA_opt::unlink(*it);
   cellPool_->destroy(*it);
   auto tmp = it++;
   // it = column_.erase(it);
@@ -855,13 +841,13 @@ inline void Unordered_set_column<Master_matrix>::_delete_cell(typename Column_ty
 
 template <class Master_matrix>
 inline typename Unordered_set_column<Master_matrix>::Cell* Unordered_set_column<Master_matrix>::_insert_cell(
-    const Field_element_type& value, id_index rowIndex)
+    const Field_element& value, ID_index rowIndex)
 {
   if constexpr (Master_matrix::Option_list::has_row_access) {
-    Cell* newCell = cellPool_->construct(ra_opt::columnIndex_, rowIndex);
+    Cell* newCell = cellPool_->construct(RA_opt::columnIndex_, rowIndex);
     newCell->set_element(value);
     column_.insert(newCell);
-    ra_opt::insert_cell(rowIndex, newCell);
+    RA_opt::insert_cell(rowIndex, newCell);
     return newCell;
   } else {
     Cell* newCell = cellPool_->construct(rowIndex);
@@ -872,12 +858,12 @@ inline typename Unordered_set_column<Master_matrix>::Cell* Unordered_set_column<
 }
 
 template <class Master_matrix>
-inline void Unordered_set_column<Master_matrix>::_insert_cell(id_index rowIndex) 
+inline void Unordered_set_column<Master_matrix>::_insert_cell(ID_index rowIndex)
 {
   if constexpr (Master_matrix::Option_list::has_row_access) {
-    Cell* newCell = cellPool_->construct(ra_opt::columnIndex_, rowIndex);
+    Cell* newCell = cellPool_->construct(RA_opt::columnIndex_, rowIndex);
     column_.insert(newCell);
-    ra_opt::insert_cell(rowIndex, newCell);
+    RA_opt::insert_cell(rowIndex, newCell);
   } else {
     Cell* newCell = cellPool_->construct(rowIndex);
     column_.insert(newCell);
@@ -886,7 +872,7 @@ inline void Unordered_set_column<Master_matrix>::_insert_cell(id_index rowIndex)
 
 template <class Master_matrix>
 template <class Cell_range>
-inline bool Unordered_set_column<Master_matrix>::_add(const Cell_range& column) 
+inline bool Unordered_set_column<Master_matrix>::_add(const Cell_range& column)
 {
   return _generic_add(
       column,
@@ -901,8 +887,8 @@ inline bool Unordered_set_column<Master_matrix>::_add(const Cell_range& column)
 
 template <class Master_matrix>
 template <class Cell_range>
-inline bool Unordered_set_column<Master_matrix>::_multiply_target_and_add(const Field_element_type& val,
-                                                                          const Cell_range& column) 
+inline bool Unordered_set_column<Master_matrix>::_multiply_target_and_add(const Field_element& val,
+                                                                          const Cell_range& column)
 {
   if (val == 0u) {
     if constexpr (Master_matrix::isNonBasic && !Master_matrix::Option_list::is_of_boundary_type) {
@@ -926,13 +912,14 @@ inline bool Unordered_set_column<Master_matrix>::_multiply_target_and_add(const 
 template <class Master_matrix>
 template <class Cell_range>
 inline bool Unordered_set_column<Master_matrix>::_multiply_source_and_add(const Cell_range& column,
-                                                                          const Field_element_type& val) 
+                                                                          const Field_element& val)
 {
   if (val == 0u) {
     return false;
   }
 
-  return _generic_add(column,
+  return _generic_add(
+      column,
       [&](const Cell& oldCell, Cell* newCell) {
         newCell->set_element(oldCell.get_element());
         operators_->multiply_inplace(newCell->get_element(), val);
@@ -953,30 +940,30 @@ inline bool Unordered_set_column<Master_matrix>::_generic_add(const Cell_range& 
   for (const Cell& cell : source) {
     Cell* newCell;
     if constexpr (Master_matrix::Option_list::has_row_access) {
-      newCell = cellPool_->construct(ra_opt::columnIndex_, cell.get_row_index());
+      newCell = cellPool_->construct(RA_opt::columnIndex_, cell.get_row_index());
     } else {
       newCell = cellPool_->construct(cell.get_row_index());
     }
     auto res = column_.insert(newCell);
-    if (res.second){
+    if (res.second) {
       process_source(cell, newCell);
-      if constexpr (Master_matrix::Option_list::has_row_access) ra_opt::insert_cell(cell.get_row_index(), newCell);
+      if constexpr (Master_matrix::Option_list::has_row_access) RA_opt::insert_cell(cell.get_row_index(), newCell);
     } else {
       cellPool_->destroy(newCell);
       if constexpr (Master_matrix::Option_list::is_z2) {
         if constexpr (Master_matrix::isNonBasic && !Master_matrix::Option_list::is_of_boundary_type) {
-          if (cell.get_row_index() == chain_opt::get_pivot()) pivotIsZeroed = true;
+          if (cell.get_row_index() == Chain_opt::get_pivot()) pivotIsZeroed = true;
         }
         _delete_cell(res.first);
       } else {
         update_target(*res.first, cell);
         if ((*res.first)->get_element() == Field_operators::get_additive_identity()) {
           if constexpr (Master_matrix::isNonBasic && !Master_matrix::Option_list::is_of_boundary_type) {
-            if ((*res.first)->get_row_index() == chain_opt::get_pivot()) pivotIsZeroed = true;
+            if ((*res.first)->get_row_index() == Chain_opt::get_pivot()) pivotIsZeroed = true;
           }
           _delete_cell(res.first);
         } else {
-          if constexpr (Master_matrix::Option_list::has_row_access) ra_opt::update_cell(**res.first);
+          if constexpr (Master_matrix::Option_list::has_row_access) RA_opt::update_cell(**res.first);
         }
       }
     }
@@ -992,15 +979,14 @@ inline bool Unordered_set_column<Master_matrix>::_generic_add(const Cell_range& 
  * @ingroup persistence_matrix
  *
  * @brief Hash method for @ref Gudhi::persistence_matrix::Unordered_set_column.
- * 
+ *
  * @tparam Master_matrix Template parameter of @ref Gudhi::persistence_matrix::Unordered_set_column.
  * @tparam Cell_constructor Template parameter of @ref Gudhi::persistence_matrix::Unordered_set_column.
  */
 template <class Master_matrix>
-struct std::hash<Gudhi::persistence_matrix::Unordered_set_column<Master_matrix> > 
-{
+struct std::hash<Gudhi::persistence_matrix::Unordered_set_column<Master_matrix>> {
   std::size_t operator()(const Gudhi::persistence_matrix::Unordered_set_column<Master_matrix>& column) const {
-    //can't use Gudhi::persistence_matrix::hash_column because unordered
+    // can't use Gudhi::persistence_matrix::hash_column because unordered
     std::size_t seed = 0;
     for (const auto& cell : column) {
       seed ^= std::hash<unsigned int>()(cell.get_row_index() * static_cast<unsigned int>(cell.get_element()));

--- a/src/Persistence_matrix/include/gudhi/Persistence_matrix/columns/vector_column.h
+++ b/src/Persistence_matrix/include/gudhi/Persistence_matrix/columns/vector_column.h
@@ -22,9 +22,9 @@
 #include <vector>
 #include <stdexcept>
 #include <type_traits>
-#include <algorithm>      //binary_search
+#include <algorithm>  //binary_search
 #include <unordered_set>
-#include <utility>        //std::swap, std::move & std::exchange
+#include <utility>  //std::swap, std::move & std::exchange
 
 #include <boost/iterator/indirect_iterator.hpp>
 #include <gudhi/Persistence_matrix/columns/column_utilities.h>
@@ -38,80 +38,77 @@ namespace persistence_matrix {
  *
  * @brief Column class following the @ref PersistenceMatrixColumn concept.
  *
- * Column based on a vector structure. The cells are always ordered by row index, but cells are removed by 
- * @ref PersistenceMatrixColumn::clear(PersistenceMatrixOptions::index_type rowIndex) "clear(index)" in a lazy way,
+ * Column based on a vector structure. The cells are always ordered by row index, but cells are removed by
+ * @ref PersistenceMatrixColumn::clear(PersistenceMatrixOptions::Index rowIndex) "clear(Index)" in a lazy way,
  * so erased values can still be in the underlying container.
  * On the other hand, two cells will never have the same row index.
- * 
+ *
  * @tparam Master_matrix An instantiation of @ref Matrix from which all types and options are deduced.
  * @tparam Cell_constructor Factory of @ref Cell classes.
  */
 template <class Master_matrix>
 class Vector_column : public Master_matrix::Row_access_option,
                       public Master_matrix::Column_dimension_option,
-                      public Master_matrix::Chain_column_option 
+                      public Master_matrix::Chain_column_option
 {
  public:
   using Master = Master_matrix;
-  using index = typename Master_matrix::index;
-  using id_index = typename Master_matrix::id_index;
-  using dimension_type = typename Master_matrix::dimension_type;
-  using Field_element_type = typename Master_matrix::element_type;
-  using Cell = typename Master_matrix::Cell_type;
+  using Index = typename Master_matrix::Index;
+  using ID_index = typename Master_matrix::ID_index;
+  using Dimension = typename Master_matrix::Dimension;
+  using Field_element = typename Master_matrix::Element;
+  using Cell = typename Master_matrix::Matrix_cell;
   using Column_settings = typename Master_matrix::Column_settings;
 
  private:
   using Field_operators = typename Master_matrix::Field_operators;
-  using Column_type = std::vector<Cell*>;
+  using Column = std::vector<Cell*>;
   using Cell_constructor = typename Master_matrix::Cell_constructor;
 
  public:
-  using iterator = boost::indirect_iterator<typename Column_type::iterator>;
-  using const_iterator = boost::indirect_iterator<typename Column_type::const_iterator>;
-  using reverse_iterator = boost::indirect_iterator<typename Column_type::reverse_iterator>;
-  using const_reverse_iterator = boost::indirect_iterator<typename Column_type::const_reverse_iterator>;
+  using iterator = boost::indirect_iterator<typename Column::iterator>;
+  using const_iterator = boost::indirect_iterator<typename Column::const_iterator>;
+  using reverse_iterator = boost::indirect_iterator<typename Column::reverse_iterator>;
+  using const_reverse_iterator = boost::indirect_iterator<typename Column::const_reverse_iterator>;
 
   Vector_column(Column_settings* colSettings = nullptr);
-  template <class Container_type = typename Master_matrix::boundary_type>
-  Vector_column(const Container_type& nonZeroRowIndices, Column_settings* colSettings);
-  template <class Container_type = typename Master_matrix::boundary_type, class Row_container_type>
-  Vector_column(index columnIndex, 
-                const Container_type& nonZeroRowIndices, 
-                Row_container_type* rowContainer,
+  template <class Container = typename Master_matrix::Boundary>
+  Vector_column(const Container& nonZeroRowIndices, Column_settings* colSettings);
+  template <class Container = typename Master_matrix::Boundary, class Row_container>
+  Vector_column(Index columnIndex,
+                const Container& nonZeroRowIndices,
+                Row_container* rowContainer,
                 Column_settings* colSettings);
-  template <class Container_type = typename Master_matrix::boundary_type>
-  Vector_column(const Container_type& nonZeroChainRowIndices, 
-                dimension_type dimension, 
+  template <class Container = typename Master_matrix::Boundary>
+  Vector_column(const Container& nonZeroChainRowIndices, Dimension dimension, Column_settings* colSettings);
+  template <class Container = typename Master_matrix::Boundary, class Row_container>
+  Vector_column(Index columnIndex,
+                const Container& nonZeroChainRowIndices,
+                Dimension dimension,
+                Row_container* rowContainer,
                 Column_settings* colSettings);
-  template <class Container_type = typename Master_matrix::boundary_type, class Row_container_type>
-  Vector_column(index columnIndex, 
-                const Container_type& nonZeroChainRowIndices, 
-                dimension_type dimension,
-                Row_container_type* rowContainer, 
-                Column_settings* colSettings);
-  Vector_column(const Vector_column& column, 
-                Column_settings* colSettings = nullptr);
-  template <class Row_container_type>
-  Vector_column(const Vector_column& column, 
-                index columnIndex, 
-                Row_container_type* rowContainer,
+  Vector_column(const Vector_column& column, Column_settings* colSettings = nullptr);
+  template <class Row_container>
+  Vector_column(const Vector_column& column,
+                Index columnIndex,
+                Row_container* rowContainer,
                 Column_settings* colSettings = nullptr);
   Vector_column(Vector_column&& column) noexcept;
   ~Vector_column();
 
-  std::vector<Field_element_type> get_content(int columnLength = -1) const;
-  bool is_non_zero(id_index rowIndex) const;
+  std::vector<Field_element> get_content(int columnLength = -1) const;
+  bool is_non_zero(ID_index rowIndex) const;
   bool is_empty() const;
   std::size_t size() const;
 
-  template <class Map_type>
-  void reorder(const Map_type& valueMap, [[maybe_unused]] index columnIndex = -1);
+  template <class Row_index_map>
+  void reorder(const Row_index_map& valueMap, [[maybe_unused]] Index columnIndex = -1);
   void clear();
   // do not clear a cell to 0 if the cell was already 0, otherwise size/is_empty will be wrong.
-  void clear(id_index rowIndex);
+  void clear(ID_index rowIndex);
 
-  id_index get_pivot();
-  Field_element_type get_pivot_value();
+  ID_index get_pivot();
+  Field_element get_pivot_value();
 
   iterator begin() noexcept;
   const_iterator begin() const noexcept;
@@ -130,12 +127,12 @@ class Vector_column : public Master_matrix::Row_access_option,
 
   // this = v * this + column
   template <class Cell_range>
-  Vector_column& multiply_target_and_add(const Field_element_type& val, const Cell_range& column);
-  Vector_column& multiply_target_and_add(const Field_element_type& val, Vector_column& column);
+  Vector_column& multiply_target_and_add(const Field_element& val, const Cell_range& column);
+  Vector_column& multiply_target_and_add(const Field_element& val, Vector_column& column);
   // this = this + column * v
   template <class Cell_range>
-  Vector_column& multiply_source_and_add(const Cell_range& column, const Field_element_type& val);
-  Vector_column& multiply_source_and_add(Vector_column& column, const Field_element_type& val);
+  Vector_column& multiply_source_and_add(const Cell_range& column, const Field_element& val);
+  Vector_column& multiply_source_and_add(Vector_column& column, const Field_element& val);
 
   std::size_t compute_hash_value();
 
@@ -216,20 +213,20 @@ class Vector_column : public Master_matrix::Row_access_option,
   }
 
  private:
-  using ra_opt = typename Master_matrix::Row_access_option;
-  using dim_opt = typename Master_matrix::Column_dimension_option;
-  using chain_opt = typename Master_matrix::Chain_column_option;
+  using RA_opt = typename Master_matrix::Row_access_option;
+  using Dim_opt = typename Master_matrix::Column_dimension_option;
+  using Chain_opt = typename Master_matrix::Chain_column_option;
 
-  Column_type column_;
-  std::unordered_set<id_index> erasedValues_;  // TODO: test other containers? Useless when clear(index) is never
+  Column column_;
+  std::unordered_set<ID_index> erasedValues_;  // TODO: test other containers? Useless when clear(Index) is never
                                                // called, how much is it worth it?
   Field_operators* operators_;
   Cell_constructor* cellPool_;
 
-  template <class Column_type, class Cell_iterator, typename F1, typename F2, typename F3, typename F4>
-  friend void _generic_merge_cell_to_column(Column_type& targetColumn,
+  template <class Column, class Cell_iterator, typename F1, typename F2, typename F3, typename F4>
+  friend void _generic_merge_cell_to_column(Column& targetColumn,
                                             Cell_iterator& itSource,
-                                            typename Column_type::Column_type::iterator& itTarget,
+                                            typename Column::Column::iterator& itTarget,
                                             F1&& process_target,
                                             F2&& process_source,
                                             F3&& update_target1,
@@ -237,17 +234,17 @@ class Vector_column : public Master_matrix::Row_access_option,
                                             bool& pivotIsZeroed);
 
   void _delete_cell(Cell* cell);
-  void _delete_cell(typename Column_type::iterator& it);
-  Cell* _insert_cell(const Field_element_type& value, id_index rowIndex, Column_type& column);
-  void _insert_cell(id_index rowIndex, Column_type& column);
-  void _update_cell(const Field_element_type& value, id_index rowIndex, index position);
-  void _update_cell(id_index rowIndex, index position);
+  void _delete_cell(typename Column::iterator& it);
+  Cell* _insert_cell(const Field_element& value, ID_index rowIndex, Column& column);
+  void _insert_cell(ID_index rowIndex, Column& column);
+  void _update_cell(const Field_element& value, ID_index rowIndex, Index position);
+  void _update_cell(ID_index rowIndex, Index position);
   template <class Cell_range>
   bool _add(const Cell_range& column);
   template <class Cell_range>
-  bool _multiply_target_and_add(const Field_element_type& val, const Cell_range& column);
+  bool _multiply_target_and_add(const Field_element& val, const Cell_range& column);
   template <class Cell_range>
-  bool _multiply_source_and_add(const Cell_range& column, const Field_element_type& val);
+  bool _multiply_source_and_add(const Cell_range& column, const Field_element& val);
   template <class Cell_range, typename F1, typename F2, typename F3, typename F4>
   bool _generic_add(const Cell_range& source,
                     F1&& process_target,
@@ -258,21 +255,24 @@ class Vector_column : public Master_matrix::Row_access_option,
 
 template <class Master_matrix>
 inline Vector_column<Master_matrix>::Vector_column(Column_settings* colSettings)
-    : ra_opt(), dim_opt(), chain_opt(), operators_(nullptr), cellPool_(colSettings == nullptr ? nullptr : &(colSettings->cellConstructor))
+    : RA_opt(),
+      Dim_opt(),
+      Chain_opt(),
+      operators_(nullptr),
+      cellPool_(colSettings == nullptr ? nullptr : &(colSettings->cellConstructor))
 {
-  if (operators_ == nullptr && cellPool_ == nullptr) return;  //to allow default constructor which gives a dummy column
-  if constexpr (!Master_matrix::Option_list::is_z2){
+  if (operators_ == nullptr && cellPool_ == nullptr) return;  // to allow default constructor which gives a dummy column
+  if constexpr (!Master_matrix::Option_list::is_z2) {
     operators_ = &(colSettings->operators);
   }
 }
 
 template <class Master_matrix>
-template <class Container_type>
-inline Vector_column<Master_matrix>::Vector_column(const Container_type& nonZeroRowIndices,
-                                                                     Column_settings* colSettings)
-    : ra_opt(),
-      dim_opt(nonZeroRowIndices.size() == 0 ? 0 : nonZeroRowIndices.size() - 1),
-      chain_opt(),
+template <class Container>
+inline Vector_column<Master_matrix>::Vector_column(const Container& nonZeroRowIndices, Column_settings* colSettings)
+    : RA_opt(),
+      Dim_opt(nonZeroRowIndices.size() == 0 ? 0 : nonZeroRowIndices.size() - 1),
+      Chain_opt(),
       column_(nonZeroRowIndices.size(), nullptr),
       operators_(nullptr),
       cellPool_(&(colSettings->cellConstructor))
@@ -280,13 +280,13 @@ inline Vector_column<Master_matrix>::Vector_column(const Container_type& nonZero
   static_assert(!Master_matrix::isNonBasic || Master_matrix::Option_list::is_of_boundary_type,
                 "Constructor not available for chain columns, please specify the dimension of the chain.");
 
-  if constexpr (!Master_matrix::Option_list::is_z2){
+  if constexpr (!Master_matrix::Option_list::is_z2) {
     operators_ = &(colSettings->operators);
   }
 
-  index i = 0;
+  Index i = 0;
   if constexpr (Master_matrix::Option_list::is_z2) {
-    for (id_index id : nonZeroRowIndices) {
+    for (ID_index id : nonZeroRowIndices) {
       _update_cell(id, i++);
     }
   } else {
@@ -297,14 +297,14 @@ inline Vector_column<Master_matrix>::Vector_column(const Container_type& nonZero
 }
 
 template <class Master_matrix>
-template <class Container_type, class Row_container_type>
-inline Vector_column<Master_matrix>::Vector_column(index columnIndex,
-                                                                     const Container_type& nonZeroRowIndices,
-                                                                     Row_container_type* rowContainer,
-                                                                     Column_settings* colSettings)
-    : ra_opt(columnIndex, rowContainer),
-      dim_opt(nonZeroRowIndices.size() == 0 ? 0 : nonZeroRowIndices.size() - 1),
-      chain_opt([&] {
+template <class Container, class Row_container>
+inline Vector_column<Master_matrix>::Vector_column(Index columnIndex,
+                                                   const Container& nonZeroRowIndices,
+                                                   Row_container* rowContainer,
+                                                   Column_settings* colSettings)
+    : RA_opt(columnIndex, rowContainer),
+      Dim_opt(nonZeroRowIndices.size() == 0 ? 0 : nonZeroRowIndices.size() - 1),
+      Chain_opt([&] {
         if constexpr (Master_matrix::Option_list::is_z2) {
           return nonZeroRowIndices.begin() == nonZeroRowIndices.end() ? -1 : *std::prev(nonZeroRowIndices.end());
         } else {
@@ -318,13 +318,13 @@ inline Vector_column<Master_matrix>::Vector_column(index columnIndex,
   static_assert(!Master_matrix::isNonBasic || Master_matrix::Option_list::is_of_boundary_type,
                 "Constructor not available for chain columns, please specify the dimension of the chain.");
 
-  if constexpr (!Master_matrix::Option_list::is_z2){
+  if constexpr (!Master_matrix::Option_list::is_z2) {
     operators_ = &(colSettings->operators);
   }
 
-  index i = 0;
+  Index i = 0;
   if constexpr (Master_matrix::Option_list::is_z2) {
-    for (id_index id : nonZeroRowIndices) {
+    for (ID_index id : nonZeroRowIndices) {
       _update_cell(id, i++);
     }
   } else {
@@ -335,13 +335,13 @@ inline Vector_column<Master_matrix>::Vector_column(index columnIndex,
 }
 
 template <class Master_matrix>
-template <class Container_type>
-inline Vector_column<Master_matrix>::Vector_column(const Container_type& nonZeroRowIndices,
-                                                                     dimension_type dimension,
-                                                                     Column_settings* colSettings)
-    : ra_opt(),
-      dim_opt(dimension),
-      chain_opt([&] {
+template <class Container>
+inline Vector_column<Master_matrix>::Vector_column(const Container& nonZeroRowIndices,
+                                                   Dimension dimension,
+                                                   Column_settings* colSettings)
+    : RA_opt(),
+      Dim_opt(dimension),
+      Chain_opt([&] {
         if constexpr (Master_matrix::Option_list::is_z2) {
           return nonZeroRowIndices.begin() == nonZeroRowIndices.end() ? -1 : *std::prev(nonZeroRowIndices.end());
         } else {
@@ -352,13 +352,13 @@ inline Vector_column<Master_matrix>::Vector_column(const Container_type& nonZero
       operators_(nullptr),
       cellPool_(&(colSettings->cellConstructor))
 {
-  if constexpr (!Master_matrix::Option_list::is_z2){
+  if constexpr (!Master_matrix::Option_list::is_z2) {
     operators_ = &(colSettings->operators);
   }
 
-  index i = 0;
+  Index i = 0;
   if constexpr (Master_matrix::Option_list::is_z2) {
-    for (id_index id : nonZeroRowIndices) {
+    for (ID_index id : nonZeroRowIndices) {
       _update_cell(id, i++);
     }
   } else {
@@ -369,16 +369,15 @@ inline Vector_column<Master_matrix>::Vector_column(const Container_type& nonZero
 }
 
 template <class Master_matrix>
-template <class Container_type, class Row_container_type>
-inline Vector_column<Master_matrix>::Vector_column(
-    index columnIndex, 
-    const Container_type& nonZeroRowIndices, 
-    dimension_type dimension,
-    Row_container_type* rowContainer, 
-    Column_settings* colSettings)
-    : ra_opt(columnIndex, rowContainer),
-      dim_opt(dimension),
-      chain_opt([&] {
+template <class Container, class Row_container>
+inline Vector_column<Master_matrix>::Vector_column(Index columnIndex,
+                                                   const Container& nonZeroRowIndices,
+                                                   Dimension dimension,
+                                                   Row_container* rowContainer,
+                                                   Column_settings* colSettings)
+    : RA_opt(columnIndex, rowContainer),
+      Dim_opt(dimension),
+      Chain_opt([&] {
         if constexpr (Master_matrix::Option_list::is_z2) {
           return nonZeroRowIndices.begin() == nonZeroRowIndices.end() ? -1 : *std::prev(nonZeroRowIndices.end());
         } else {
@@ -389,13 +388,13 @@ inline Vector_column<Master_matrix>::Vector_column(
       operators_(nullptr),
       cellPool_(&(colSettings->cellConstructor))
 {
-  if constexpr (!Master_matrix::Option_list::is_z2){
+  if constexpr (!Master_matrix::Option_list::is_z2) {
     operators_ = &(colSettings->operators);
   }
 
-  index i = 0;
+  Index i = 0;
   if constexpr (Master_matrix::Option_list::is_z2) {
-    for (id_index id : nonZeroRowIndices) {
+    for (ID_index id : nonZeroRowIndices) {
       _update_cell(id, i++);
     }
   } else {
@@ -406,11 +405,10 @@ inline Vector_column<Master_matrix>::Vector_column(
 }
 
 template <class Master_matrix>
-inline Vector_column<Master_matrix>::Vector_column(const Vector_column& column,
-                                                                     Column_settings* colSettings)
-    : ra_opt(),
-      dim_opt(static_cast<const dim_opt&>(column)),
-      chain_opt(static_cast<const chain_opt&>(column)),
+inline Vector_column<Master_matrix>::Vector_column(const Vector_column& column, Column_settings* colSettings)
+    : RA_opt(),
+      Dim_opt(static_cast<const Dim_opt&>(column)),
+      Chain_opt(static_cast<const Chain_opt&>(column)),
       column_(column.column_.size(), nullptr),
       erasedValues_(column.erasedValues_),
       operators_(colSettings == nullptr ? column.operators_ : nullptr),
@@ -420,11 +418,11 @@ inline Vector_column<Master_matrix>::Vector_column(const Vector_column& column,
                 "Simple copy constructor not available when row access option enabled. Please specify the new column "
                 "index and the row container.");
 
-  if constexpr (!Master_matrix::Option_list::is_z2){
+  if constexpr (!Master_matrix::Option_list::is_z2) {
     if (colSettings != nullptr) operators_ = &(colSettings->operators);
   }
 
-  index i = 0;
+  Index i = 0;
   for (const Cell* cell : column.column_) {
     if constexpr (Master_matrix::Option_list::is_z2) {
       _update_cell(cell->get_row_index(), i++);
@@ -435,23 +433,24 @@ inline Vector_column<Master_matrix>::Vector_column(const Vector_column& column,
 }
 
 template <class Master_matrix>
-template <class Row_container_type>
-inline Vector_column<Master_matrix>::Vector_column(const Vector_column& column, index columnIndex,
-                                                                     Row_container_type* rowContainer,
-                                                                     Column_settings* colSettings)
-    : ra_opt(columnIndex, rowContainer),
-      dim_opt(static_cast<const dim_opt&>(column)),
-      chain_opt(static_cast<const chain_opt&>(column)),
+template <class Row_container>
+inline Vector_column<Master_matrix>::Vector_column(const Vector_column& column,
+                                                   Index columnIndex,
+                                                   Row_container* rowContainer,
+                                                   Column_settings* colSettings)
+    : RA_opt(columnIndex, rowContainer),
+      Dim_opt(static_cast<const Dim_opt&>(column)),
+      Chain_opt(static_cast<const Chain_opt&>(column)),
       column_(column.column_.size(), nullptr),
       erasedValues_(column.erasedValues_),
       operators_(colSettings == nullptr ? column.operators_ : nullptr),
       cellPool_(colSettings == nullptr ? column.cellPool_ : &(colSettings->cellConstructor))
 {
-  if constexpr (!Master_matrix::Option_list::is_z2){
+  if constexpr (!Master_matrix::Option_list::is_z2) {
     if (colSettings != nullptr) operators_ = &(colSettings->operators);
   }
 
-  index i = 0;
+  Index i = 0;
   for (const Cell* cell : column.column_) {
     if constexpr (Master_matrix::Option_list::is_z2) {
       _update_cell(cell->get_row_index(), i++);
@@ -463,17 +462,17 @@ inline Vector_column<Master_matrix>::Vector_column(const Vector_column& column, 
 
 template <class Master_matrix>
 inline Vector_column<Master_matrix>::Vector_column(Vector_column&& column) noexcept
-    : ra_opt(std::move(static_cast<ra_opt&>(column))),
-      dim_opt(std::move(static_cast<dim_opt&>(column))),
-      chain_opt(std::move(static_cast<chain_opt&>(column))),
+    : RA_opt(std::move(static_cast<RA_opt&>(column))),
+      Dim_opt(std::move(static_cast<Dim_opt&>(column))),
+      Chain_opt(std::move(static_cast<Chain_opt&>(column))),
       column_(std::move(column.column_)),
       erasedValues_(std::move(column.erasedValues_)),
       operators_(std::exchange(column.operators_, nullptr)),
-      cellPool_(std::exchange(column.cellPool_, nullptr)) 
+      cellPool_(std::exchange(column.cellPool_, nullptr))
 {}
 
 template <class Master_matrix>
-inline Vector_column<Master_matrix>::~Vector_column() 
+inline Vector_column<Master_matrix>::~Vector_column()
 {
   for (auto* cell : column_) {
     _delete_cell(cell);
@@ -481,16 +480,16 @@ inline Vector_column<Master_matrix>::~Vector_column()
 }
 
 template <class Master_matrix>
-inline std::vector<typename Vector_column<Master_matrix>::Field_element_type>
-Vector_column<Master_matrix>::get_content(int columnLength) const 
+inline std::vector<typename Vector_column<Master_matrix>::Field_element> Vector_column<Master_matrix>::get_content(
+    int columnLength) const
 {
   if (columnLength < 0 && column_.size() > 0)
     columnLength = column_.back()->get_row_index() + 1;
   else if (columnLength < 0)
-    return std::vector<Field_element_type>();
+    return std::vector<Field_element>();
 
-  std::vector<Field_element_type> container(columnLength, 0);
-  for (auto it = column_.begin(); it != column_.end() && (*it)->get_row_index() < static_cast<id_index>(columnLength);
+  std::vector<Field_element> container(columnLength, 0);
+  for (auto it = column_.begin(); it != column_.end() && (*it)->get_row_index() < static_cast<ID_index>(columnLength);
        ++it) {
     if constexpr (!Master_matrix::isNonBasic || Master_matrix::Option_list::is_of_boundary_type) {
       if (erasedValues_.find((*it)->get_row_index()) != erasedValues_.end()) continue;
@@ -505,7 +504,7 @@ Vector_column<Master_matrix>::get_content(int columnLength) const
 }
 
 template <class Master_matrix>
-inline bool Vector_column<Master_matrix>::is_non_zero(id_index rowIndex) const 
+inline bool Vector_column<Master_matrix>::is_non_zero(ID_index rowIndex) const
 {
   if constexpr (!Master_matrix::isNonBasic || Master_matrix::Option_list::is_of_boundary_type)
     if (erasedValues_.find(rowIndex) != erasedValues_.end()) return false;
@@ -516,7 +515,7 @@ inline bool Vector_column<Master_matrix>::is_non_zero(id_index rowIndex) const
 }
 
 template <class Master_matrix>
-inline bool Vector_column<Master_matrix>::is_empty() const 
+inline bool Vector_column<Master_matrix>::is_empty() const
 {
   if constexpr (!Master_matrix::isNonBasic || Master_matrix::Option_list::is_of_boundary_type) {
     return column_.size() == erasedValues_.size();  // assumes that erasedValues is always a subset of column_, which is
@@ -527,7 +526,7 @@ inline bool Vector_column<Master_matrix>::is_empty() const
 }
 
 template <class Master_matrix>
-inline std::size_t Vector_column<Master_matrix>::size() const 
+inline std::size_t Vector_column<Master_matrix>::size() const
 {
   if constexpr (!Master_matrix::isNonBasic || Master_matrix::Option_list::is_of_boundary_type) {
     return column_.size() - erasedValues_.size();  // assumes that erasedValues is always a subset of column_, which is
@@ -538,9 +537,8 @@ inline std::size_t Vector_column<Master_matrix>::size() const
 }
 
 template <class Master_matrix>
-template <class Map_type>
-inline void Vector_column<Master_matrix>::reorder(const Map_type& valueMap,
-                                                                    [[maybe_unused]] index columnIndex) 
+template <class Row_index_map>
+inline void Vector_column<Master_matrix>::reorder(const Row_index_map& valueMap, [[maybe_unused]] Index columnIndex)
 {
   static_assert(!Master_matrix::isNonBasic || Master_matrix::Option_list::is_of_boundary_type,
                 "Method not available for chain columns.");
@@ -548,34 +546,34 @@ inline void Vector_column<Master_matrix>::reorder(const Map_type& valueMap,
   if (erasedValues_.empty()) {  // to avoid useless push_backs.
     for (Cell* cell : column_) {
       if constexpr (Master_matrix::Option_list::has_row_access) {
-        ra_opt::unlink(cell);
-        if (columnIndex != static_cast<index>(-1)) cell->set_column_index(columnIndex);
+        RA_opt::unlink(cell);
+        if (columnIndex != static_cast<Index>(-1)) cell->set_column_index(columnIndex);
       }
       cell->set_row_index(valueMap.at(cell->get_row_index()));
       if constexpr (Master_matrix::Option_list::has_intrusive_rows && Master_matrix::Option_list::has_row_access)
-        ra_opt::insert_cell(cell->get_row_index(), cell);
+        RA_opt::insert_cell(cell->get_row_index(), cell);
     }
 
     // all cells have to be deleted first, to avoid problem with insertion when row is a set
     if constexpr (!Master_matrix::Option_list::has_intrusive_rows && Master_matrix::Option_list::has_row_access) {
       for (Cell* cell : column_) {
-        ra_opt::insert_cell(cell->get_row_index(), cell);
+        RA_opt::insert_cell(cell->get_row_index(), cell);
       }
     }
 
     std::sort(column_.begin(), column_.end(), [](const Cell* c1, const Cell* c2) { return *c1 < *c2; });
   } else {
-    Column_type newColumn;
+    Column newColumn;
     for (Cell* cell : column_) {
       if (erasedValues_.find(cell->get_row_index()) == erasedValues_.end()) {
         if constexpr (Master_matrix::Option_list::has_row_access) {
-          ra_opt::unlink(cell);
-          if (columnIndex != static_cast<index>(-1)) cell->set_column_index(columnIndex);
+          RA_opt::unlink(cell);
+          if (columnIndex != static_cast<Index>(-1)) cell->set_column_index(columnIndex);
         }
         cell->set_row_index(valueMap.at(cell->get_row_index()));
         newColumn.push_back(cell);
         if constexpr (Master_matrix::Option_list::has_intrusive_rows && Master_matrix::Option_list::has_row_access)
-          ra_opt::insert_cell(cell->get_row_index(), cell);
+          RA_opt::insert_cell(cell->get_row_index(), cell);
       } else {
         _delete_cell(cell);
       }
@@ -583,7 +581,7 @@ inline void Vector_column<Master_matrix>::reorder(const Map_type& valueMap,
     // all cells have to be deleted first, to avoid problem with insertion when row is a set
     if constexpr (!Master_matrix::Option_list::has_intrusive_rows && Master_matrix::Option_list::has_row_access) {
       for (Cell* cell : column_) {
-        ra_opt::insert_cell(cell->get_row_index(), cell);
+        RA_opt::insert_cell(cell->get_row_index(), cell);
       }
     }
     std::sort(newColumn.begin(), newColumn.end(), [](const Cell* c1, const Cell* c2) { return *c1 < *c2; });
@@ -593,13 +591,13 @@ inline void Vector_column<Master_matrix>::reorder(const Map_type& valueMap,
 }
 
 template <class Master_matrix>
-inline void Vector_column<Master_matrix>::clear() 
+inline void Vector_column<Master_matrix>::clear()
 {
   static_assert(!Master_matrix::isNonBasic || Master_matrix::Option_list::is_of_boundary_type,
                 "Method not available for chain columns as a base element should not be empty.");
 
   for (auto* cell : column_) {
-    if constexpr (Master_matrix::Option_list::has_row_access) ra_opt::unlink(cell);
+    if constexpr (Master_matrix::Option_list::has_row_access) RA_opt::unlink(cell);
     cellPool_->destroy(cell);
   }
 
@@ -608,7 +606,7 @@ inline void Vector_column<Master_matrix>::clear()
 }
 
 template <class Master_matrix>
-inline void Vector_column<Master_matrix>::clear(id_index rowIndex) 
+inline void Vector_column<Master_matrix>::clear(ID_index rowIndex)
 {
   static_assert(!Master_matrix::isNonBasic || Master_matrix::Option_list::is_of_boundary_type,
                 "Method not available for chain columns.");
@@ -617,8 +615,7 @@ inline void Vector_column<Master_matrix>::clear(id_index rowIndex)
 }
 
 template <class Master_matrix>
-inline typename Vector_column<Master_matrix>::id_index
-Vector_column<Master_matrix>::get_pivot() 
+inline typename Vector_column<Master_matrix>::ID_index Vector_column<Master_matrix>::get_pivot()
 {
   static_assert(Master_matrix::isNonBasic,
                 "Method not available for base columns.");  // could technically be, but is the notion useful then?
@@ -638,13 +635,12 @@ Vector_column<Master_matrix>::get_pivot()
     if (column_.empty()) return -1;
     return column_.back()->get_row_index();
   } else {
-    return chain_opt::get_pivot();
+    return Chain_opt::get_pivot();
   }
 }
 
 template <class Master_matrix>
-inline typename Vector_column<Master_matrix>::Field_element_type
-Vector_column<Master_matrix>::get_pivot_value() 
+inline typename Vector_column<Master_matrix>::Field_element Vector_column<Master_matrix>::get_pivot_value()
 {
   static_assert(Master_matrix::isNonBasic,
                 "Method not available for base columns.");  // could technically be, but is the notion useful then?
@@ -667,75 +663,68 @@ Vector_column<Master_matrix>::get_pivot_value()
       if (column_.empty()) return 0;
       return column_.back()->get_element();
     } else {
-      if (chain_opt::get_pivot() == static_cast<id_index>(-1)) return Field_element_type();
+      if (Chain_opt::get_pivot() == static_cast<ID_index>(-1)) return Field_element();
       for (const Cell* cell : column_) {
-        if (cell->get_row_index() == chain_opt::get_pivot()) return cell->get_element();
+        if (cell->get_row_index() == Chain_opt::get_pivot()) return cell->get_element();
       }
-      return Field_element_type();  // should never happen if chain column is used properly
+      return Field_element();  // should never happen if chain column is used properly
     }
   }
 }
 
 template <class Master_matrix>
-inline typename Vector_column<Master_matrix>::iterator
-Vector_column<Master_matrix>::begin() noexcept 
+inline typename Vector_column<Master_matrix>::iterator Vector_column<Master_matrix>::begin() noexcept
 {
   return column_.begin();
 }
 
 template <class Master_matrix>
-inline typename Vector_column<Master_matrix>::const_iterator
-Vector_column<Master_matrix>::begin() const noexcept 
+inline typename Vector_column<Master_matrix>::const_iterator Vector_column<Master_matrix>::begin() const noexcept
 {
   return column_.begin();
 }
 
 template <class Master_matrix>
-inline typename Vector_column<Master_matrix>::iterator
-Vector_column<Master_matrix>::end() noexcept 
+inline typename Vector_column<Master_matrix>::iterator Vector_column<Master_matrix>::end() noexcept
 {
   return column_.end();
 }
 
 template <class Master_matrix>
-inline typename Vector_column<Master_matrix>::const_iterator
-Vector_column<Master_matrix>::end() const noexcept 
+inline typename Vector_column<Master_matrix>::const_iterator Vector_column<Master_matrix>::end() const noexcept
 {
   return column_.end();
 }
 
 template <class Master_matrix>
-inline typename Vector_column<Master_matrix>::reverse_iterator
-Vector_column<Master_matrix>::rbegin() noexcept 
+inline typename Vector_column<Master_matrix>::reverse_iterator Vector_column<Master_matrix>::rbegin() noexcept
 {
   return column_.rbegin();
 }
 
 template <class Master_matrix>
-inline typename Vector_column<Master_matrix>::const_reverse_iterator
-Vector_column<Master_matrix>::rbegin() const noexcept 
+inline typename Vector_column<Master_matrix>::const_reverse_iterator Vector_column<Master_matrix>::rbegin()
+    const noexcept
 {
   return column_.rbegin();
 }
 
 template <class Master_matrix>
-inline typename Vector_column<Master_matrix>::reverse_iterator
-Vector_column<Master_matrix>::rend() noexcept 
+inline typename Vector_column<Master_matrix>::reverse_iterator Vector_column<Master_matrix>::rend() noexcept
 {
   return column_.rend();
 }
 
 template <class Master_matrix>
-inline typename Vector_column<Master_matrix>::const_reverse_iterator
-Vector_column<Master_matrix>::rend() const noexcept 
+inline typename Vector_column<Master_matrix>::const_reverse_iterator Vector_column<Master_matrix>::rend()
+    const noexcept
 {
   return column_.rend();
 }
 
 template <class Master_matrix>
 template <class Cell_range>
-inline Vector_column<Master_matrix>& Vector_column<Master_matrix>::operator+=(
-    const Cell_range& column) 
+inline Vector_column<Master_matrix>& Vector_column<Master_matrix>::operator+=(const Cell_range& column)
 {
   static_assert((!Master_matrix::isNonBasic || std::is_same_v<Cell_range, Vector_column>),
                 "For boundary columns, the range has to be a column of same type to help ensure the validity of the "
@@ -749,14 +738,13 @@ inline Vector_column<Master_matrix>& Vector_column<Master_matrix>::operator+=(
 }
 
 template <class Master_matrix>
-inline Vector_column<Master_matrix>& Vector_column<Master_matrix>::operator+=(
-    Vector_column& column) 
+inline Vector_column<Master_matrix>& Vector_column<Master_matrix>::operator+=(Vector_column& column)
 {
   if constexpr (Master_matrix::isNonBasic && !Master_matrix::Option_list::is_of_boundary_type) {
     // assumes that the addition never zeros out this column.
     if (_add(column)) {
-      chain_opt::swap_pivots(column);
-      dim_opt::swap_dimension(column);
+      Chain_opt::swap_pivots(column);
+      Dim_opt::swap_dimension(column);
     }
   } else {
     _add(column);
@@ -766,8 +754,7 @@ inline Vector_column<Master_matrix>& Vector_column<Master_matrix>::operator+=(
 }
 
 template <class Master_matrix>
-inline Vector_column<Master_matrix>& Vector_column<Master_matrix>::operator*=(
-    unsigned int v) 
+inline Vector_column<Master_matrix>& Vector_column<Master_matrix>::operator*=(unsigned int v)
 {
   if constexpr (Master_matrix::Option_list::is_z2) {
     if (v % 2 == 0) {
@@ -778,7 +765,7 @@ inline Vector_column<Master_matrix>& Vector_column<Master_matrix>::operator*=(
       }
     }
   } else {
-    Field_element_type val = operators_->get_value(v);
+    Field_element val = operators_->get_value(v);
 
     if (val == Field_operators::get_additive_identity()) {
       if constexpr (Master_matrix::isNonBasic && !Master_matrix::Option_list::is_of_boundary_type) {
@@ -793,7 +780,7 @@ inline Vector_column<Master_matrix>& Vector_column<Master_matrix>::operator*=(
 
     for (Cell* cell : column_) {
       operators_->multiply_inplace(cell->get_element(), val);
-      if constexpr (Master_matrix::Option_list::has_row_access) ra_opt::update_cell(*cell);
+      if constexpr (Master_matrix::Option_list::has_row_access) RA_opt::update_cell(*cell);
     }
   }
 
@@ -802,8 +789,8 @@ inline Vector_column<Master_matrix>& Vector_column<Master_matrix>::operator*=(
 
 template <class Master_matrix>
 template <class Cell_range>
-inline Vector_column<Master_matrix>& Vector_column<Master_matrix>::multiply_target_and_add(
-    const Field_element_type& val, const Cell_range& column) 
+inline Vector_column<Master_matrix>& Vector_column<Master_matrix>::multiply_target_and_add(const Field_element& val,
+                                                                                           const Cell_range& column)
 {
   static_assert((!Master_matrix::isNonBasic || std::is_same_v<Cell_range, Vector_column>),
                 "For boundary columns, the range has to be a column of same type to help ensure the validity of the "
@@ -826,24 +813,24 @@ inline Vector_column<Master_matrix>& Vector_column<Master_matrix>::multiply_targ
 }
 
 template <class Master_matrix>
-inline Vector_column<Master_matrix>& Vector_column<Master_matrix>::multiply_target_and_add(
-    const Field_element_type& val, Vector_column& column) 
+inline Vector_column<Master_matrix>& Vector_column<Master_matrix>::multiply_target_and_add(const Field_element& val,
+                                                                                           Vector_column& column)
 {
   if constexpr (Master_matrix::isNonBasic && !Master_matrix::Option_list::is_of_boundary_type) {
     // assumes that the addition never zeros out this column.
     if constexpr (Master_matrix::Option_list::is_z2) {
       if (val) {
         if (_add(column)) {
-          chain_opt::swap_pivots(column);
-          dim_opt::swap_dimension(column);
+          Chain_opt::swap_pivots(column);
+          Dim_opt::swap_dimension(column);
         }
       } else {
         throw std::invalid_argument("A chain column should not be multiplied by 0.");
       }
     } else {
       if (_multiply_target_and_add(val, column)) {
-        chain_opt::swap_pivots(column);
-        dim_opt::swap_dimension(column);
+        Chain_opt::swap_pivots(column);
+        Dim_opt::swap_dimension(column);
       }
     }
   } else {
@@ -864,8 +851,8 @@ inline Vector_column<Master_matrix>& Vector_column<Master_matrix>::multiply_targ
 
 template <class Master_matrix>
 template <class Cell_range>
-inline Vector_column<Master_matrix>& Vector_column<Master_matrix>::multiply_source_and_add(
-    const Cell_range& column, const Field_element_type& val) 
+inline Vector_column<Master_matrix>& Vector_column<Master_matrix>::multiply_source_and_add(const Cell_range& column,
+                                                                                           const Field_element& val)
 {
   static_assert((!Master_matrix::isNonBasic || std::is_same_v<Cell_range, Vector_column>),
                 "For boundary columns, the range has to be a column of same type to help ensure the validity of the "
@@ -885,22 +872,22 @@ inline Vector_column<Master_matrix>& Vector_column<Master_matrix>::multiply_sour
 }
 
 template <class Master_matrix>
-inline Vector_column<Master_matrix>& Vector_column<Master_matrix>::multiply_source_and_add(
-    Vector_column& column, const Field_element_type& val) 
+inline Vector_column<Master_matrix>& Vector_column<Master_matrix>::multiply_source_and_add(Vector_column& column,
+                                                                                           const Field_element& val)
 {
   if constexpr (Master_matrix::isNonBasic && !Master_matrix::Option_list::is_of_boundary_type) {
     // assumes that the addition never zeros out this column.
     if constexpr (Master_matrix::Option_list::is_z2) {
       if (val) {
         if (_add(column)) {
-          chain_opt::swap_pivots(column);
-          dim_opt::swap_dimension(column);
+          Chain_opt::swap_pivots(column);
+          Dim_opt::swap_dimension(column);
         }
       }
     } else {
       if (_multiply_source_and_add(column, val)) {
-        chain_opt::swap_pivots(column);
-        dim_opt::swap_dimension(column);
+        Chain_opt::swap_pivots(column);
+        Dim_opt::swap_dimension(column);
       }
     }
   } else {
@@ -917,30 +904,29 @@ inline Vector_column<Master_matrix>& Vector_column<Master_matrix>::multiply_sour
 }
 
 template <class Master_matrix>
-inline Vector_column<Master_matrix>& Vector_column<Master_matrix>::operator=(
-    const Vector_column& other) 
+inline Vector_column<Master_matrix>& Vector_column<Master_matrix>::operator=(const Vector_column& other)
 {
   static_assert(!Master_matrix::Option_list::has_row_access, "= assignment not enabled with row access option.");
 
-  dim_opt::operator=(other);
-  chain_opt::operator=(other);
+  Dim_opt::operator=(other);
+  Chain_opt::operator=(other);
 
   auto tmpPool = cellPool_;
   cellPool_ = other.cellPool_;
 
   while (column_.size() > other.column_.size()) {
     if (column_.back() != nullptr) {
-      if constexpr (Master_matrix::Option_list::has_row_access) ra_opt::unlink(column_.back());
+      if constexpr (Master_matrix::Option_list::has_row_access) RA_opt::unlink(column_.back());
       tmpPool->destroy(column_.back());
     }
     column_.pop_back();
   }
 
   column_.resize(other.column_.size(), nullptr);
-  index i = 0;
+  Index i = 0;
   for (const Cell* cell : other.column_) {
     if (column_[i] != nullptr) {
-      if constexpr (Master_matrix::Option_list::has_row_access) ra_opt::unlink(column_[i]);
+      if constexpr (Master_matrix::Option_list::has_row_access) RA_opt::unlink(column_[i]);
       tmpPool->destroy(column_[i]);
     }
     if constexpr (Master_matrix::Option_list::is_z2) {
@@ -960,7 +946,7 @@ inline std::size_t Vector_column<Master_matrix>::compute_hash_value()
 {
   std::size_t seed = 0;
   for (Cell* cell : column_) {
-    if (erasedValues_.find(cell->get_row_index()) == erasedValues_.end()){
+    if (erasedValues_.find(cell->get_row_index()) == erasedValues_.end()) {
       seed ^= std::hash<unsigned int>()(cell->get_row_index() * static_cast<unsigned int>(cell->get_element())) +
               0x9e3779b9 + (seed << 6) + (seed >> 2);
     }
@@ -969,14 +955,14 @@ inline std::size_t Vector_column<Master_matrix>::compute_hash_value()
 }
 
 template <class Master_matrix>
-inline void Vector_column<Master_matrix>::_delete_cell(Cell* cell) 
+inline void Vector_column<Master_matrix>::_delete_cell(Cell* cell)
 {
-  if constexpr (Master_matrix::Option_list::has_row_access) ra_opt::unlink(cell);
+  if constexpr (Master_matrix::Option_list::has_row_access) RA_opt::unlink(cell);
   cellPool_->destroy(cell);
 }
 
 template <class Master_matrix>
-inline void Vector_column<Master_matrix>::_delete_cell(typename Column_type::iterator& it)
+inline void Vector_column<Master_matrix>::_delete_cell(typename Column::iterator& it)
 {
   _delete_cell(*it);
   ++it;
@@ -984,13 +970,13 @@ inline void Vector_column<Master_matrix>::_delete_cell(typename Column_type::ite
 
 template <class Master_matrix>
 inline typename Vector_column<Master_matrix>::Cell* Vector_column<Master_matrix>::_insert_cell(
-    const Field_element_type& value, id_index rowIndex, Column_type& column)
+    const Field_element& value, ID_index rowIndex, Column& column)
 {
   if constexpr (Master_matrix::Option_list::has_row_access) {
-    Cell* newCell = cellPool_->construct(ra_opt::columnIndex_, rowIndex);
+    Cell* newCell = cellPool_->construct(RA_opt::columnIndex_, rowIndex);
     newCell->set_element(value);
     column.push_back(newCell);
-    ra_opt::insert_cell(rowIndex, newCell);
+    RA_opt::insert_cell(rowIndex, newCell);
     return newCell;
   } else {
     Cell* newCell = cellPool_->construct(rowIndex);
@@ -1001,12 +987,12 @@ inline typename Vector_column<Master_matrix>::Cell* Vector_column<Master_matrix>
 }
 
 template <class Master_matrix>
-inline void Vector_column<Master_matrix>::_insert_cell(id_index rowIndex, Column_type& column) 
+inline void Vector_column<Master_matrix>::_insert_cell(ID_index rowIndex, Column& column)
 {
   if constexpr (Master_matrix::Option_list::has_row_access) {
-    Cell* newCell = cellPool_->construct(ra_opt::columnIndex_, rowIndex);
+    Cell* newCell = cellPool_->construct(RA_opt::columnIndex_, rowIndex);
     column.push_back(newCell);
-    ra_opt::insert_cell(rowIndex, newCell);
+    RA_opt::insert_cell(rowIndex, newCell);
   } else {
     Cell* newCell = cellPool_->construct(rowIndex);
     column.push_back(newCell);
@@ -1014,14 +1000,13 @@ inline void Vector_column<Master_matrix>::_insert_cell(id_index rowIndex, Column
 }
 
 template <class Master_matrix>
-inline void Vector_column<Master_matrix>::_update_cell(const Field_element_type& value,
-                                                                         id_index rowIndex, index position) 
+inline void Vector_column<Master_matrix>::_update_cell(const Field_element& value, ID_index rowIndex, Index position)
 {
   if constexpr (Master_matrix::Option_list::has_row_access) {
-    Cell* newCell = cellPool_->construct(ra_opt::columnIndex_, rowIndex);
+    Cell* newCell = cellPool_->construct(RA_opt::columnIndex_, rowIndex);
     newCell->set_element(value);
     column_[position] = newCell;
-    ra_opt::insert_cell(rowIndex, newCell);
+    RA_opt::insert_cell(rowIndex, newCell);
   } else {
     column_[position] = cellPool_->construct(rowIndex);
     column_[position]->set_element(value);
@@ -1029,12 +1014,12 @@ inline void Vector_column<Master_matrix>::_update_cell(const Field_element_type&
 }
 
 template <class Master_matrix>
-inline void Vector_column<Master_matrix>::_update_cell(id_index rowIndex, index position) 
+inline void Vector_column<Master_matrix>::_update_cell(ID_index rowIndex, Index position)
 {
   if constexpr (Master_matrix::Option_list::has_row_access) {
-    Cell* newCell = cellPool_->construct(ra_opt::columnIndex_, rowIndex);
+    Cell* newCell = cellPool_->construct(RA_opt::columnIndex_, rowIndex);
     column_[position] = newCell;
-    ra_opt::insert_cell(rowIndex, newCell);
+    RA_opt::insert_cell(rowIndex, newCell);
   } else {
     column_[position] = cellPool_->construct(rowIndex);
   }
@@ -1042,12 +1027,12 @@ inline void Vector_column<Master_matrix>::_update_cell(id_index rowIndex, index 
 
 template <class Master_matrix>
 template <class Cell_range>
-inline bool Vector_column<Master_matrix>::_add(const Cell_range& column) 
+inline bool Vector_column<Master_matrix>::_add(const Cell_range& column)
 {
   if (column.begin() == column.end()) return false;
   if (column_.empty()) {  // chain should never enter here.
     column_.resize(column.size());
-    index i = 0;
+    Index i = 0;
     for (const Cell& cell : column) {
       if constexpr (Master_matrix::Option_list::is_z2) {
         _update_cell(cell.get_row_index(), i++);
@@ -1058,21 +1043,20 @@ inline bool Vector_column<Master_matrix>::_add(const Cell_range& column)
     return true;
   }
 
-  Column_type newColumn;
+  Column newColumn;
   newColumn.reserve(column_.size() + column.size());  // safe upper bound
 
   auto pivotIsZeroed = _generic_add(
       column,
       [&](Cell* cellTarget) { newColumn.push_back(cellTarget); },
-      [&](typename Cell_range::const_iterator& itSource,
-          [[maybe_unused]] const typename Column_type::iterator& itTarget) {
+      [&](typename Cell_range::const_iterator& itSource, [[maybe_unused]] const typename Column::iterator& itTarget) {
         if constexpr (Master_matrix::Option_list::is_z2) {
           _insert_cell(itSource->get_row_index(), newColumn);
         } else {
           _insert_cell(itSource->get_element(), itSource->get_row_index(), newColumn);
         }
       },
-      [&](Field_element_type& targetElement, typename Cell_range::const_iterator& itSource) {
+      [&](Field_element& targetElement, typename Cell_range::const_iterator& itSource) {
         if constexpr (!Master_matrix::Option_list::is_z2)
           operators_->add_inplace(targetElement, itSource->get_element());
       },
@@ -1085,8 +1069,7 @@ inline bool Vector_column<Master_matrix>::_add(const Cell_range& column)
 
 template <class Master_matrix>
 template <class Cell_range>
-inline bool Vector_column<Master_matrix>::_multiply_target_and_add(const Field_element_type& val,
-                                                                              const Cell_range& column) 
+inline bool Vector_column<Master_matrix>::_multiply_target_and_add(const Field_element& val, const Cell_range& column)
 {
   if (val == 0u) {
     if constexpr (Master_matrix::isNonBasic && !Master_matrix::Option_list::is_of_boundary_type) {
@@ -1098,7 +1081,7 @@ inline bool Vector_column<Master_matrix>::_multiply_target_and_add(const Field_e
   }
   if (column_.empty()) {  // chain should never enter here.
     column_.resize(column.size());
-    index i = 0;
+    Index i = 0;
     for (const Cell& cell : column) {
       if constexpr (Master_matrix::Option_list::is_z2) {
         _update_cell(cell.get_row_index(), i++);
@@ -1110,20 +1093,20 @@ inline bool Vector_column<Master_matrix>::_multiply_target_and_add(const Field_e
     return true;
   }
 
-  Column_type newColumn;
+  Column newColumn;
   newColumn.reserve(column_.size() + column.size());  // safe upper bound
 
   auto pivotIsZeroed = _generic_add(
       column,
       [&](Cell* cellTarget) {
         operators_->multiply_inplace(cellTarget->get_element(), val);
-        if constexpr (Master_matrix::Option_list::has_row_access) ra_opt::update_cell(*cellTarget);
+        if constexpr (Master_matrix::Option_list::has_row_access) RA_opt::update_cell(*cellTarget);
         newColumn.push_back(cellTarget);
       },
-      [&](typename Cell_range::const_iterator& itSource, const typename Column_type::iterator& itTarget) {
+      [&](typename Cell_range::const_iterator& itSource, const typename Column::iterator& itTarget) {
         _insert_cell(itSource->get_element(), itSource->get_row_index(), newColumn);
       },
-      [&](Field_element_type& targetElement, typename Cell_range::const_iterator& itSource) {
+      [&](Field_element& targetElement, typename Cell_range::const_iterator& itSource) {
         operators_->multiply_and_add_inplace_front(targetElement, val, itSource->get_element());
       },
       [&](Cell* cellTarget) { newColumn.push_back(cellTarget); });
@@ -1135,25 +1118,24 @@ inline bool Vector_column<Master_matrix>::_multiply_target_and_add(const Field_e
 
 template <class Master_matrix>
 template <class Cell_range>
-inline bool Vector_column<Master_matrix>::_multiply_source_and_add(const Cell_range& column,
-                                                                              const Field_element_type& val) 
+inline bool Vector_column<Master_matrix>::_multiply_source_and_add(const Cell_range& column, const Field_element& val)
 {
   if (val == 0u || column.begin() == column.end()) {
     return false;
   }
 
-  Column_type newColumn;
+  Column newColumn;
   newColumn.reserve(column_.size() + column.size());  // safe upper bound
 
   auto pivotIsZeroed = _generic_add(
       column,
       [&](Cell* cellTarget) { newColumn.push_back(cellTarget); },
-      [&](typename Cell_range::const_iterator& itSource, const typename Column_type::iterator& itTarget) {
+      [&](typename Cell_range::const_iterator& itSource, const typename Column::iterator& itTarget) {
         Cell* newCell = _insert_cell(itSource->get_element(), itSource->get_row_index(), newColumn);
         operators_->multiply_inplace(newCell->get_element(), val);
-        if constexpr (Master_matrix::Option_list::has_row_access) ra_opt::update_cell(*newCell);
+        if constexpr (Master_matrix::Option_list::has_row_access) RA_opt::update_cell(*newCell);
       },
-      [&](Field_element_type& targetElement, typename Cell_range::const_iterator& itSource) {
+      [&](Field_element& targetElement, typename Cell_range::const_iterator& itSource) {
         operators_->multiply_and_add_inplace_back(itSource->get_element(), val, targetElement);
       },
       [&](Cell* cellTarget) { newColumn.push_back(cellTarget); });
@@ -1171,15 +1153,15 @@ inline bool Vector_column<Master_matrix>::_generic_add(const Cell_range& column,
                                                        F3&& update_target1,
                                                        F4&& update_target2)
 {
-  auto updateTargetIterator = [&](typename Column_type::iterator& itTarget){
-    if constexpr (!Master_matrix::isNonBasic || Master_matrix::Option_list::is_of_boundary_type){
+  auto updateTargetIterator = [&](typename Column::iterator& itTarget) {
+    if constexpr (!Master_matrix::isNonBasic || Master_matrix::Option_list::is_of_boundary_type) {
       while (itTarget != column_.end() && erasedValues_.find((*itTarget)->get_row_index()) != erasedValues_.end()) {
         _delete_cell(*itTarget);
         ++itTarget;
       }
     }
   };
-  auto updateSourceIterator = [&](typename Cell_range::const_iterator& itSource){
+  auto updateSourceIterator = [&](typename Cell_range::const_iterator& itSource) {
     if constexpr (std::is_same_v<Cell_range, Vector_column<Master_matrix> > &&
                   (!Master_matrix::isNonBasic || Master_matrix::Option_list::is_of_boundary_type)) {
       while (itSource != column.end() &&
@@ -1197,10 +1179,9 @@ inline bool Vector_column<Master_matrix>::_generic_add(const Cell_range& column,
     updateSourceIterator(itSource);
     if (itTarget == column_.end() || itSource == column.end()) break;
 
-    _generic_merge_cell_to_column(*this,
-                                   itSource, itTarget,
-                                   process_target, process_source, update_target1, update_target2,
-                                   pivotIsZeroed);
+    _generic_merge_cell_to_column(*this, itSource, itTarget,
+                                  process_target, process_source, update_target1, update_target2,
+                                  pivotIsZeroed);
   }
 
   while (itSource != column.end()) {
@@ -1231,13 +1212,12 @@ inline bool Vector_column<Master_matrix>::_generic_add(const Cell_range& column,
  * @ingroup persistence_matrix
  *
  * @brief Hash method for @ref Gudhi::persistence_matrix::Vector_column.
- * 
+ *
  * @tparam Master_matrix Template parameter of @ref Gudhi::persistence_matrix::Vector_column.
  * @tparam Cell_constructor Template parameter of @ref Gudhi::persistence_matrix::Vector_column.
  */
 template <class Master_matrix>
-struct std::hash<Gudhi::persistence_matrix::Vector_column<Master_matrix> > 
-{
+struct std::hash<Gudhi::persistence_matrix::Vector_column<Master_matrix> > {
   std::size_t operator()(const Gudhi::persistence_matrix::Vector_column<Master_matrix>& column) const {
     return column.compute_hash_value();
   }

--- a/src/Persistence_matrix/include/gudhi/Persistence_matrix/matrix_dimension_holders.h
+++ b/src/Persistence_matrix/include/gudhi/Persistence_matrix/matrix_dimension_holders.h
@@ -32,9 +32,10 @@ namespace persistence_matrix {
  * Inherited instead of @ref Matrix_max_dimension_holder or @ref Matrix_all_dimension_holder, when the maximal
  * dimension of a matrix is not stored.
  */
-struct Dummy_matrix_dimension_holder {
-  template <typename dimension_type>
-  Dummy_matrix_dimension_holder([[maybe_unused]] dimension_type maximalDimension) {}
+struct Dummy_matrix_dimension_holder
+{
+  template <typename Dimension>
+  Dummy_matrix_dimension_holder([[maybe_unused]] Dimension maximalDimension) {}
 
   friend void swap([[maybe_unused]] Dummy_matrix_dimension_holder& d1,
                    [[maybe_unused]] Dummy_matrix_dimension_holder& d2) {}
@@ -46,10 +47,10 @@ struct Dummy_matrix_dimension_holder {
  * @brief Class managing the maximal dimension of a face represented in the inheriting matrix, when the option of
  * face removal is not enabled.
  * 
- * @tparam dimension_type Dimension value type. Has to be an integer type.
+ * @tparam Dimension Dimension value type. Has to be an integer type.
  * If unsigned, the maximal value of the type should not be attained during a run.
  */
-template <typename dimension_type>
+template <typename Dimension>
 class Matrix_max_dimension_holder 
 {
  public:
@@ -58,7 +59,7 @@ class Matrix_max_dimension_holder
    * 
    * @param maximalDimension Value of the maximal dimension. Has to be either positive or -1. Default value: -1.
    */
-  Matrix_max_dimension_holder(dimension_type maximalDimension = -1) : maxDim_(maximalDimension){};
+  Matrix_max_dimension_holder(Dimension maximalDimension = -1) : maxDim_(maximalDimension){};
   /**
    * @brief Copy constructor.
    * 
@@ -78,7 +79,7 @@ class Matrix_max_dimension_holder
    * 
    * @return The maximal dimension.
    */
-  dimension_type get_max_dimension() const { return maxDim_; };
+  Dimension get_max_dimension() const { return maxDim_; };
 
   /**
    * @brief Assign operator.
@@ -95,9 +96,9 @@ class Matrix_max_dimension_holder
   }
 
  protected:
-  dimension_type maxDim_; /**< Current maximal dimension. */
+  Dimension maxDim_; /**< Current maximal dimension. */
 
-  void update_up(dimension_type dimension) {
+  void update_up(Dimension dimension) {
     if (maxDim_ == -1 || maxDim_ < dimension) maxDim_ = dimension;
   };
 };
@@ -108,10 +109,10 @@ class Matrix_max_dimension_holder
  * @brief Class managing the maximal dimension of a face represented in the inheriting matrix, when the option of
  * face removal is enabled.
  * 
- * @tparam dimension_type Dimension value type. Has to be an integer type.
+ * @tparam Dimension Dimension value type. Has to be an integer type.
  * If unsigned, the maximal value of the type should not be attained during a run.
  */
-template <typename dimension_type>
+template <typename Dimension>
 class Matrix_all_dimension_holder 
 {
  public:
@@ -120,7 +121,7 @@ class Matrix_all_dimension_holder
    * 
    * @param maximalDimension Value of the maximal dimension. Has to be either positive or -1. Default value: -1.
    */
-  Matrix_all_dimension_holder(dimension_type maximalDimension = -1)
+  Matrix_all_dimension_holder(Dimension maximalDimension = -1)
       : dimensions_(maximalDimension < 0 ? 0 : maximalDimension + 1, 0), maxDim_(maximalDimension) {
     if (maxDim_ != -1) dimensions_[maxDim_] = 1;
   };
@@ -144,7 +145,7 @@ class Matrix_all_dimension_holder
    * 
    * @return The maximal dimension.
    */
-  dimension_type get_max_dimension() const { return maxDim_; };
+  Dimension get_max_dimension() const { return maxDim_; };
 
   /**
    * @brief Assign operator.
@@ -164,7 +165,7 @@ class Matrix_all_dimension_holder
 
  protected:
   std::vector<unsigned int> dimensions_;   /**< Number of faces by dimension. */
-  dimension_type maxDim_;                  /**< Current maximal dimension. */
+  Dimension maxDim_;                  /**< Current maximal dimension. */
 
   void update_up(unsigned int dimension) {
     if (dimensions_.size() <= dimension) dimensions_.resize(dimension + 1, 0);

--- a/src/Persistence_matrix/include/gudhi/Persistence_matrix/matrix_row_access.h
+++ b/src/Persistence_matrix/include/gudhi/Persistence_matrix/matrix_row_access.h
@@ -29,7 +29,8 @@ namespace persistence_matrix {
  * @brief Empty structure.
  * Inherited instead of @ref Matrix_row_access, when the the row access is not enabled.
  */
-struct Dummy_matrix_row_access {
+struct Dummy_matrix_row_access
+{
   Dummy_matrix_row_access([[maybe_unused]] unsigned int numberOfRows = 0){};
 
   friend void swap([[maybe_unused]] Dummy_matrix_row_access& d1, [[maybe_unused]] Dummy_matrix_row_access& d2) {}
@@ -41,21 +42,21 @@ struct Dummy_matrix_row_access {
  *
  * @brief Class managing the row access for the inheriting matrix.
  * 
- * @tparam Row_type Either boost::intrusive::list<Cell_type,...> if @ref PersistenceMatrixOptions::has_intrusive_rows
- * is true, or std::set<Cell_type, RowCellComp> otherwise.
- * @tparam Row_container_type Either std::map<index,Row_type> if @ref PersistenceMatrixOptions::has_removable_rows is
- *  true, or std::vector<Row_type> otherwise.
+ * @tparam Row Either boost::intrusive::list<Matrix_cell,...> if @ref PersistenceMatrixOptions::has_intrusive_rows
+ * is true, or std::set<Matrix_cell, RowCellComp> otherwise.
+ * @tparam Row_container Either std::map<Index,Row> if @ref PersistenceMatrixOptions::has_removable_rows is
+ *  true, or std::vector<Row> otherwise.
  * @tparam has_removable_rows Value of @ref PersistenceMatrixOptions::has_removable_rows.
- * @tparam id_index @ref IDIdx index type.
+ * @tparam ID_index @ref IDIdx index type.
  */
-template <typename Row_type, typename Row_container_type, bool has_removable_rows, typename id_index>
+template <typename Row, typename Row_container, bool has_removable_rows, typename ID_index>
 class Matrix_row_access 
 {
  public:
   /**
    * @brief Default constructor.
    */
-  Matrix_row_access() : rows_(new Row_container_type()){};
+  Matrix_row_access() : rows_(new Row_container()){};
   /**
    * @brief Constructor reserving space for the given number of rows.
    *
@@ -63,7 +64,7 @@ class Matrix_row_access
    * 
    * @param numberOfRows Number of rows to reserve space for.
    */
-  Matrix_row_access(unsigned int numberOfRows) : rows_(new Row_container_type()) {
+  Matrix_row_access(unsigned int numberOfRows) : rows_(new Row_container()) {
     if constexpr (!has_removable_rows) {
       rows_->resize(numberOfRows);
     }
@@ -74,7 +75,7 @@ class Matrix_row_access
    * @param toCopy Matrix to copy.
    */
   Matrix_row_access(const Matrix_row_access& toCopy)
-      : rows_(new Row_container_type())  // as the matrix is rebuild, the rows should not be copied.
+      : rows_(new Row_container())  // as the matrix is rebuild, the rows should not be copied.
   {
     if constexpr (!has_removable_rows) {
       rows_->resize(toCopy.rows_->size());
@@ -99,7 +100,7 @@ class Matrix_row_access
    * or updated @ref IDIdx for @ref boundarymatrix "boundary matrices" if swaps occurred.
    * @return Reference to the row.
    */
-  Row_type& get_row(id_index rowIndex) {
+  Row& get_row(ID_index rowIndex) {
     if constexpr (has_removable_rows) {
       return rows_->at(rowIndex);
     } else {
@@ -114,7 +115,7 @@ class Matrix_row_access
    * or updated @ref IDIdx for @ref boundarymatrix "boundary matrices" if swaps occurred.
    * @return Const reference to the row.
    */
-  const Row_type& get_row(id_index rowIndex) const {
+  const Row& get_row(ID_index rowIndex) const {
     if constexpr (has_removable_rows) {
       return rows_->at(rowIndex);
     } else {
@@ -127,7 +128,7 @@ class Matrix_row_access
    * 
    * @param rowIndex @ref rowindex "Row index" of the row to remove.
    */
-  void erase_empty_row(id_index rowIndex) {
+  void erase_empty_row(ID_index rowIndex) {
     static_assert(has_removable_rows, "'erase_empty_row' is not implemented for the chosen options.");
 
     auto it = rows_->find(rowIndex);
@@ -154,7 +155,7 @@ class Matrix_row_access
    * @brief Row container. A pointer to facilitate column swaps when two matrices are swapped.
    * Has to be destroyed after matrix_, therefore has to be inherited.
    */
-  Row_container_type* rows_;
+  Row_container* rows_;
 };
 
 }  // namespace persistence_matrix

--- a/src/Persistence_matrix/include/gudhi/Persistence_matrix/overlay_ididx_to_matidx.h
+++ b/src/Persistence_matrix/include/gudhi/Persistence_matrix/overlay_ididx_to_matidx.h
@@ -34,32 +34,32 @@ namespace persistence_matrix {
  * @brief Overlay for @ref mp_matrices "non-basic matrices" replacing all input and output @ref MatIdx indices of
  * the original methods with @ref IDIdx indices.
  * 
- * @tparam Matrix_type %Matrix type taking the overlay.
- * @tparam Master_matrix_type An instantiation of @ref Matrix from which all types and options are deduced.
+ * @tparam Underlying_matrix %Matrix type taking the overlay.
+ * @tparam Master_matrix An instantiation of @ref Matrix from which all types and options are deduced.
  */
-template <class Matrix_type, class Master_matrix_type>
+template <class Underlying_matrix, class Master_matrix>
 class Id_to_index_overlay 
 {
  public:
-  using index = typename Master_matrix_type::index;                       /**< @ref MatIdx index type. */
-  using id_index = typename Master_matrix_type::id_index;                 /**< @ref IDIdx index type. */
-  using pos_index = typename Master_matrix_type::pos_index;               /**< @ref PosIdx index type. */
-  using dimension_type = typename Master_matrix_type::dimension_type;     /**< Dimension value type. */
+  using Index = typename Master_matrix::Index;                       /**< @ref MatIdx index type. */
+  using ID_index = typename Master_matrix::ID_index;                 /**< @ref IDIdx index type. */
+  using Pos_index = typename Master_matrix::Pos_index;               /**< @ref PosIdx index type. */
+  using Dimension = typename Master_matrix::Dimension;               /**< Dimension value type. */
   /**
    * @brief Field operators class. Necessary only if @ref PersistenceMatrixOptions::is_z2 is false.
    */
-  using Field_operators = typename Master_matrix_type::Field_operators;
-  using Field_element_type = typename Master_matrix_type::element_type;   /**< Type of an field element. */
-  using boundary_type = typename Master_matrix_type::boundary_type;       /**< Type of an input column. */
-  using Column_type = typename Master_matrix_type::Column_type;           /**< Column type. */
-  using Row_type = typename Master_matrix_type::Row_type;                 /**< Row type,
-                                                                               only necessary with row access option. */
-  using bar_type = typename Master_matrix_type::Bar;                      /**< Bar type. */
-  using barcode_type = typename Master_matrix_type::barcode_type;         /**< Barcode type. */
-  using cycle_type = typename Master_matrix_type::cycle_type;             /**< Cycle type. */
-  using Cell_constructor = typename Master_matrix_type::Cell_constructor; /**< Factory of @ref Cell classes. */
-  using Column_settings = typename Master_matrix_type::Column_settings;   /**< Structure giving access to the columns to
-                                                                               necessary external classes. */
+  using Field_operators = typename Master_matrix::Field_operators;
+  using Field_element = typename Master_matrix::Element;             /**< Type of an field element. */
+  using Boundary = typename Master_matrix::Boundary;                 /**< Type of an input column. */
+  using Column = typename Master_matrix::Column;                     /**< Column type. */
+  using Row = typename Master_matrix::Row;                           /**< Row type,
+                                                                          only necessary with row access option. */
+  using Bar = typename Master_matrix::Bar;                           /**< Bar type. */
+  using Barcode = typename Master_matrix::Barcode;                   /**< Barcode type. */
+  using Cycle = typename Master_matrix::Cycle;                       /**< Cycle type. */
+  using Cell_constructor = typename Master_matrix::Cell_constructor; /**< Factory of @ref Cell classes. */
+  using Column_settings = typename Master_matrix::Column_settings;   /**< Structure giving access to the columns to
+                                                                          necessary external classes. */
 
   /**
    * @brief Constructs an empty matrix.
@@ -69,11 +69,11 @@ class Id_to_index_overlay
    */
   Id_to_index_overlay(Column_settings* colSettings);
   /**
-   * @brief Constructs a new matrix from the given ranges of @ref Matrix::cell_rep_type. Each range corresponds to a
+   * @brief Constructs a new matrix from the given ranges of @ref Matrix::Cell_representative. Each range corresponds to a
    * column (the order of the ranges are preserved). The content of the ranges is assumed to be sorted by increasing
    * IDs. The IDs of the simplices are also assumed to be consecutive, ordered by filtration value, starting with 0.
    * 
-   * @tparam Boundary_type Range type for @ref Matrix::cell_rep_type ranges.
+   * @tparam Boundary_container Range type for @ref Matrix::Cell_representative ranges.
    * Assumed to have a begin(), end() and size() method.
    * @param orderedBoundaries Range of boundaries: @p orderedBoundaries is interpreted as a boundary matrix of a 
    * filtered **simplicial** complex, whose boundaries are ordered by filtration order. 
@@ -88,8 +88,8 @@ class Id_to_index_overlay
    * @param colSettings Pointer to an existing setting structure for the columns. The structure should contain all
    * the necessary external classes specifically necessary for the choosen column type, such as custom allocators.
    */
-  template <class Boundary_type = boundary_type>
-  Id_to_index_overlay(const std::vector<Boundary_type>& orderedBoundaries, 
+  template <class Boundary_container = Boundary>
+  Id_to_index_overlay(const std::vector<Boundary_container>& orderedBoundaries, 
                       Column_settings* colSettings);
   /**
    * @brief Constructs a new empty matrix and reserves space for the given number of columns.
@@ -108,8 +108,8 @@ class Id_to_index_overlay
    * @ref PersistenceMatrixOptions::has_column_pairings is also true, the comparators are ignored and
    * the current barcode is used to compare birth and deaths. Therefore it is useless to provide them in those cases.
    * 
-   * @tparam BirthComparatorFunction Type of the birth comparator: (@ref pos_index, @ref pos_index) -> bool
-   * @tparam DeathComparatorFunction Type of the death comparator: (@ref pos_index, @ref pos_index) -> bool
+   * @tparam BirthComparatorFunction Type of the birth comparator: (@ref Pos_index, @ref Pos_index) -> bool
+   * @tparam DeathComparatorFunction Type of the death comparator: (@ref Pos_index, @ref Pos_index) -> bool
    * @param colSettings Pointer to an existing setting structure for the columns. The structure should contain all
    * the necessary external classes specifically necessary for the choosen column type, such as custom allocators.
    * @param birthComparator Method taking two @ref PosIdx indices as input and returning true if and only if
@@ -127,7 +127,7 @@ class Id_to_index_overlay
                       const DeathComparatorFunction& deathComparator);
   /**
    * @brief Only available for @ref chainmatrix "chain matrices". 
-   * Constructs a new matrix from the given ranges of @ref Matrix::cell_rep_type. Each range corresponds to a column 
+   * Constructs a new matrix from the given ranges of @ref Matrix::Cell_representative. Each range corresponds to a column 
    * (the order of the ranges are preserved). The content of the ranges is assumed to be sorted by increasing IDs.
    * The IDs of the simplices are also assumed to be consecutive, ordered by filtration value, starting with 0. 
    *
@@ -136,9 +136,9 @@ class Id_to_index_overlay
    * @ref PersistenceMatrixOptions::has_column_pairings is also true, the comparators are ignored and
    * the current barcode is used to compare birth and deaths. Therefore it is useless to provide them in those cases.
    * 
-   * @tparam BirthComparatorFunction Type of the birth comparator: (@ref pos_index, @ref pos_index) -> bool
-   * @tparam DeathComparatorFunction Type of the death comparator: (@ref pos_index, @ref pos_index) -> bool
-   * @tparam Boundary_type  Range type for @ref Matrix::cell_rep_type ranges.
+   * @tparam BirthComparatorFunction Type of the birth comparator: (@ref Pos_index, @ref Pos_index) -> bool
+   * @tparam DeathComparatorFunction Type of the death comparator: (@ref Pos_index, @ref Pos_index) -> bool
+   * @tparam Boundary_container  Range type for @ref Matrix::Cell_representative ranges.
    * Assumed to have a begin(), end() and size() method.
    * @param orderedBoundaries Range of boundaries: @p orderedBoundaries is interpreted as a boundary matrix of a 
    * filtered **simplicial** complex, whose boundaries are ordered by filtration order. 
@@ -161,8 +161,8 @@ class Id_to_index_overlay
    * the second one with respect to some self defined order. It is used while swapping two positive but paired
    * columns.
    */
-  template <typename BirthComparatorFunction, typename DeathComparatorFunction, class Boundary_type>
-  Id_to_index_overlay(const std::vector<Boundary_type>& orderedBoundaries, 
+  template <typename BirthComparatorFunction, typename DeathComparatorFunction, class Boundary_container>
+  Id_to_index_overlay(const std::vector<Boundary_container>& orderedBoundaries, 
                       Column_settings* colSettings, 
                       const BirthComparatorFunction& birthComparator, 
                       const DeathComparatorFunction& deathComparator);
@@ -175,8 +175,8 @@ class Id_to_index_overlay
    * @ref PersistenceMatrixOptions::has_column_pairings is also true, the comparators are ignored and
    * the current barcode is used to compare birth and deaths. Therefore it is useless to provide them in those cases.
    * 
-   * @tparam BirthComparatorFunction Type of the birth comparator: (@ref pos_index, @ref pos_index) -> bool
-   * @tparam DeathComparatorFunction Type of the death comparator: (@ref pos_index, @ref pos_index) -> bool
+   * @tparam BirthComparatorFunction Type of the birth comparator: (@ref Pos_index, @ref Pos_index) -> bool
+   * @tparam DeathComparatorFunction Type of the death comparator: (@ref Pos_index, @ref Pos_index) -> bool
    * @param numberOfColumns Number of columns to reserve space for.
    * @param colSettings Pointer to an existing setting structure for the columns. The structure should contain all
    * the necessary external classes specifically necessary for the choosen column type, such as custom allocators.
@@ -221,7 +221,7 @@ class Id_to_index_overlay
    * This means that it is assumed that this method is called on boundaries in the order of the filtration. 
    * It also assumes that the faces in the given boundary are identified by their relative position in the filtration, 
    * starting at 0. If it is not the case, use the other
-   * @ref insert_boundary(id_index, const Boundary_type&, dimension_type) "insert_boundary" instead by indicating the
+   * @ref insert_boundary(ID_index, const Boundary_container&, Dimension) "insert_boundary" instead by indicating the
    * face ID used in the boundaries when the face is inserted.
    *
    * Different to the constructor, the boundaries do not have to come from a simplicial complex, but also from
@@ -237,13 +237,13 @@ class Id_to_index_overlay
    *   `IDIdx + linear combination of older column IDIdxs`, where the combination is deduced while reducing the 
    *   given boundary. If the barcode is stored, it will also be updated.
    * 
-   * @tparam Boundary_type Range of @ref Matrix::cell_rep_type. Assumed to have a begin(), end() and size() method.
+   * @tparam Boundary_container Range of @ref Matrix::Cell_representative. Assumed to have a begin(), end() and size() method.
    * @param boundary Boundary generating the new column. The content should be ordered by ID.
    * @param dim Dimension of the face whose boundary is given. If the complex is simplicial, 
    * this parameter can be omitted as it can be deduced from the size of the boundary.
    */
-  template <class Boundary_type = boundary_type>
-  void insert_boundary(const Boundary_type& boundary, dimension_type dim = -1);
+  template <class Boundary_container = Boundary>
+  void insert_boundary(const Boundary_container& boundary, Dimension dim = -1);
   /**
    * @brief It does the same as the other version, but allows the boundary faces to be identified without restrictions
    * except that all IDs have to be strictly increasing in the order of filtration. Note that you should avoid then
@@ -252,7 +252,7 @@ class Id_to_index_overlay
    * As a face has to be inserted before one of its cofaces in a valid filtration (recall that it is assumed that
    * the faces are inserted by order of filtration), it is sufficient to indicate the ID of the face being inserted.
    * 
-   * @tparam Boundary_type Range of @ref Matrix::cell_rep_type. Assumed to have a begin(), end() and size() method.
+   * @tparam Boundary_container Range of @ref Matrix::Cell_representative. Assumed to have a begin(), end() and size() method.
    * @param faceIndex @ref IDIdx index to use to identify the new face.
    * @param boundary Boundary generating the new column. The indices of the boundary have to correspond to the 
    * @p faceIndex values of precedent calls of the method for the corresponding faces and should be ordered in 
@@ -260,8 +260,8 @@ class Id_to_index_overlay
    * @param dim Dimension of the face whose boundary is given. If the complex is simplicial, 
    * this parameter can be omitted as it can be deduced from the size of the boundary.
    */
-  template <class Boundary_type = boundary_type>
-  void insert_boundary(id_index faceIndex, const Boundary_type& boundary, dimension_type dim = -1);
+  template <class Boundary_container = Boundary>
+  void insert_boundary(ID_index faceIndex, const Boundary_container& boundary, Dimension dim = -1);
   /**
    * @brief Returns the column at the given @ref IDIdx index. 
    * For @ref boundarymatrix "RU matrices", the returned column is from \f$ R \f$.
@@ -270,7 +270,7 @@ class Id_to_index_overlay
    * @param faceID @ref IDIdx index of the column to return.
    * @return Reference to the column.
    */
-  Column_type& get_column(id_index faceID);
+  Column& get_column(ID_index faceID);
   /**
    * @brief Only available if @ref PersistenceMatrixOptions::has_row_access is true.
    * Returns the row at the given @ref rowindex "row index".
@@ -285,7 +285,7 @@ class Id_to_index_overlay
    * or updated @ref IDIdx for @ref boundarymatrix "boundary matrices" if swaps occurred.
    * @return Reference to the row.
    */
-  Row_type& get_row(id_index rowIndex);
+  Row& get_row(ID_index rowIndex);
   /**
    * @brief The effect varies depending on the matrices and the options:
    * - @ref boundarymatrix "boundary matrix" with only \f$ R \f$ stored:
@@ -310,7 +310,7 @@ class Id_to_index_overlay
    * 
    * @param rowIndex @ref rowindex "Row index" of the empty row to remove.
    */
-  void erase_empty_row(id_index rowIndex);
+  void erase_empty_row(ID_index rowIndex);
   /**
    * @brief Only available for RU and @ref chainmatrix "chain matrices" and if
    * @ref PersistenceMatrixOptions::has_removable_columns and @ref PersistenceMatrixOptions::has_vine_update are true.
@@ -330,7 +330,7 @@ class Id_to_index_overlay
    * 
    * @param faceID @ref IDIdx index of the face to remove.
    */
-  void remove_maximal_face(id_index faceID);
+  void remove_maximal_face(ID_index faceID);
   /**
    * @brief Only available for @ref chainmatrix "chain matrices" and if
    * @ref PersistenceMatrixOptions::has_removable_columns, @ref PersistenceMatrixOptions::has_vine_update
@@ -346,7 +346,7 @@ class Id_to_index_overlay
    * within the matrix. If the user has an easy access to the @ref IDIdx of the faces in the order of filtration,
    * passing them by argument with @p columnsToSwap allows to skip a linear search process. Typically, if the user knows
    * that the face he wants to remove is already the last face of the filtration, calling
-   * @ref remove_maximal_face(id_index, const std::vector<id_index>&) "remove_maximal_face(faceID, {})"
+   * @ref remove_maximal_face(ID_index, const std::vector<ID_index>&) "remove_maximal_face(faceID, {})"
    * will be faster than @ref remove_last().
    *
    * See also @ref remove_last.
@@ -354,7 +354,7 @@ class Id_to_index_overlay
    * @param faceID @ref IDIdx index of the face to remove.
    * @param columnsToSwap Vector of @ref IDIdx indices of the faces coming after @p faceID in the filtration.
    */
-  void remove_maximal_face(id_index faceID, const std::vector<id_index>& columnsToSwap);
+  void remove_maximal_face(ID_index faceID, const std::vector<ID_index>& columnsToSwap);
   /**
    * @brief Only available if @ref PersistenceMatrixOptions::has_removable_columns is true. Additionally, if the
    * matrix is a @ref chainmatrix "chain matrix", either @ref PersistenceMatrixOptions::has_map_column_container has to
@@ -366,7 +366,7 @@ class Id_to_index_overlay
    * For @ref chainmatrix "chain matrices", if @ref PersistenceMatrixOptions::has_vine_update is true, the last face
    * does not have to be at the end of the matrix and therefore has to be searched first. In this case, if the user
    * already knows the @ref IDIdx of the last face, calling
-   * @ref remove_maximal_face(id_index, const std::vector<id_index>&) "remove_maximal_face(faceID, {})"
+   * @ref remove_maximal_face(ID_index, const std::vector<ID_index>&) "remove_maximal_face(faceID, {})"
    * instead allows to skip the search.
    */
   void remove_last();
@@ -377,20 +377,20 @@ class Id_to_index_overlay
    * 
    * @return The maximal dimension.
    */
-  dimension_type get_max_dimension() const;
+  Dimension get_max_dimension() const;
   /**
    * @brief Returns the current number of columns in the matrix.
    * 
    * @return The number of columns.
    */
-  index get_number_of_columns() const;
+  Index get_number_of_columns() const;
   /**
    * @brief Returns the dimension of the given face. Only available for @ref mp_matrices "non-basic matrices".
    * 
    * @param faceID @ref IDIdx index of the face.
    * @return Dimension of the face.
    */
-  dimension_type get_column_dimension(id_index faceID) const;
+  Dimension get_column_dimension(ID_index faceID) const;
 
   /**
    * @brief Adds column corresponding to @p sourceFaceID onto the column corresponding to @p targetFaceID.
@@ -402,7 +402,7 @@ class Id_to_index_overlay
    * @param sourceFaceID @ref IDIdx index of the source column.
    * @param targetFaceID @ref IDIdx index of the target column.
    */
-  void add_to(id_index sourceFaceID, id_index targetFaceID);
+  void add_to(ID_index sourceFaceID, ID_index targetFaceID);
   /**
    * @brief Multiplies the target column with the coefficient and then adds the source column to it.
    * That is: `targetColumn = (targetColumn * coefficient) + sourceColumn`.
@@ -415,7 +415,7 @@ class Id_to_index_overlay
    * @param coefficient Value to multiply.
    * @param targetFaceID @ref IDIdx index of the target column.
    */
-  void multiply_target_and_add_to(id_index sourceFaceID, const Field_element_type& coefficient, id_index targetFaceID);
+  void multiply_target_and_add_to(ID_index sourceFaceID, const Field_element& coefficient, ID_index targetFaceID);
   /**
    * @brief Multiplies the source column with the coefficient before adding it to the target column.
    * That is: `targetColumn += (coefficient * sourceColumn)`. The source column will **not** be modified.
@@ -428,7 +428,7 @@ class Id_to_index_overlay
    * @param sourceFaceID @ref IDIdx index of the source column.
    * @param targetFaceID @ref IDIdx index of the target column.
    */
-  void multiply_source_and_add_to(const Field_element_type& coefficient, id_index sourceFaceID, id_index targetFaceID);
+  void multiply_source_and_add_to(const Field_element& coefficient, ID_index sourceFaceID, ID_index targetFaceID);
 
   /**
    * @brief Zeroes the cell at the given coordinates. Not available for @ref chainmatrix "chain matrices".
@@ -440,7 +440,7 @@ class Id_to_index_overlay
    * @param faceID @ref IDIdx index of the face corresponding to the column of the cell.
    * @param rowIndex @ref rowindex "Row index" of the row of the cell.
    */
-  void zero_cell(id_index faceID, id_index rowIndex);
+  void zero_cell(ID_index faceID, ID_index rowIndex);
   /**
    * @brief Zeroes the column at the given index. Not available for @ref chainmatrix "chain matrices".
    * In general, should be used with care to not destroy the validity 
@@ -450,7 +450,7 @@ class Id_to_index_overlay
    * 
    * @param faceID @ref IDIdx index of the face corresponding to the column.
    */
-  void zero_column(id_index faceID);
+  void zero_column(ID_index faceID);
   /**
    * @brief Indicates if the cell at given coordinates has value zero.
    *
@@ -461,7 +461,7 @@ class Id_to_index_overlay
    * @return true If the cell has value zero.
    * @return false Otherwise.
    */
-  bool is_zero_cell(id_index faceID, id_index rowIndex) const;
+  bool is_zero_cell(ID_index faceID, ID_index rowIndex) const;
   /**
    * @brief Indicates if the column at given index has value zero.
    *
@@ -474,7 +474,7 @@ class Id_to_index_overlay
    * @return true If the column has value zero.
    * @return false Otherwise.
    */
-  bool is_zero_column(id_index faceID);
+  bool is_zero_column(ID_index faceID);
 
   /**
    * @brief Returns the @ref IDIdx index of the column which has the given @ref rowindex "row index" as pivot.
@@ -487,14 +487,14 @@ class Id_to_index_overlay
    * @param faceIndex @ref rowindex "Row index" of the pivot.
    * @return @ref IDIdx index of the column with the given pivot.
    */
-  id_index get_column_with_pivot(id_index faceIndex) const;
+  ID_index get_column_with_pivot(ID_index faceIndex) const;
   /**
    * @brief Returns the @ref rowindex "row index" of the pivot of the given column.
    * 
    * @param faceID @ref IDIdx index of the face corresponding to the column.
    * @return The @ref rowindex "row index" of the pivot.
    */
-  id_index get_pivot(id_index faceID);
+  ID_index get_pivot(ID_index faceID);
 
   /**
    * @brief Resets the matrix to an empty matrix.
@@ -518,7 +518,7 @@ class Id_to_index_overlay
    */
   friend void swap(Id_to_index_overlay& matrix1, Id_to_index_overlay& matrix2) {
     swap(matrix1.matrix_, matrix2.matrix_);
-    if (Master_matrix_type::Option_list::is_of_boundary_type) std::swap(matrix1.idToIndex_, matrix2.idToIndex_);
+    if (Master_matrix::Option_list::is_of_boundary_type) std::swap(matrix1.idToIndex_, matrix2.idToIndex_);
     std::swap(matrix1.nextIndex_, matrix2.nextIndex_);
   }
 
@@ -538,7 +538,7 @@ class Id_to_index_overlay
    * @return A reference to the barcode. The barcode is a vector of @ref Matrix::Bar. A bar stores three informations:
    * the @ref PosIdx birth index, the @ref PosIdx death index and the dimension of the bar.
    */
-  const barcode_type& get_current_barcode();
+  const Barcode& get_current_barcode();
   
   /**
    * @brief Only available for simple @ref boundarymatrix "boundary matrices" (only storing \f$ R \f$) and if
@@ -549,7 +549,7 @@ class Id_to_index_overlay
    * @param faceID1 First column @ref IDIdx index to swap.
    * @param faceID2 Second column @ref IDIdx index to swap.
    */
-  void swap_columns(id_index faceID1, id_index faceID2);
+  void swap_columns(ID_index faceID1, ID_index faceID2);
   /**
    * @brief Only available for simple @ref boundarymatrix "boundary matrices" (only storing R)
    * and if @ref PersistenceMatrixOptions::has_column_and_row_swaps is true.
@@ -559,7 +559,7 @@ class Id_to_index_overlay
    * @param rowIndex1 First @ref rowindex "row index" to swap.
    * @param rowIndex2 Second @ref rowindex "row index" to swap.
    */
-  void swap_rows(index rowIndex1, index rowIndex2);
+  void swap_rows(Index rowIndex1, Index rowIndex2);
   /**
    * @brief Only available if @ref PersistenceMatrixOptions::has_vine_update is true.
    * Does the same than @ref vine_swap, but assumes that the swap is non trivial and
@@ -571,7 +571,7 @@ class Id_to_index_overlay
    * @p columnIndex2. The method returns the @ref MatIdx of the column which has now, after the swap, the @ref PosIdx
    * \f$ max(pos1, pos2) \f$.
    */
-  id_index vine_swap_with_z_eq_1_case(id_index faceID1, id_index faceID2);
+  ID_index vine_swap_with_z_eq_1_case(ID_index faceID1, ID_index faceID2);
   /**
    * @brief Only available if @ref PersistenceMatrixOptions::has_vine_update is true.
    * Does a vine swap between two faces which are consecutive in the filtration. Roughly, if \f$ F \f$ is
@@ -587,7 +587,7 @@ class Id_to_index_overlay
    * @p columnIndex2. The method returns the @ref MatIdx of the column which has now, after the swap, the @ref PosIdx
    * \f$ max(pos1, pos2) \f$.
    */
-  id_index vine_swap(id_index faceID1, id_index faceID2);
+  ID_index vine_swap(ID_index faceID1, ID_index faceID2);
   
   /**
    * @brief Only available if @ref PersistenceMatrixOptions::can_retrieve_representative_cycles is true. Pre-computes
@@ -603,7 +603,7 @@ class Id_to_index_overlay
    * 
    * @return A const reference to the vector of representative cycles.
    */
-  const std::vector<cycle_type>& get_representative_cycles();
+  const std::vector<Cycle>& get_representative_cycles();
   /**
    * @brief Only available if @ref PersistenceMatrixOptions::can_retrieve_representative_cycles is true.
    * Returns the cycle representing the given bar.
@@ -611,52 +611,52 @@ class Id_to_index_overlay
    * @param bar A bar from the current barcode.
    * @return A const reference to the cycle representing @p bar.
    */
-  const cycle_type& get_representative_cycle(const bar_type& bar);
+  const Cycle& get_representative_cycle(const Bar& bar);
 
  private:
-  using dictionary_type = typename Master_matrix_type::template dictionary_type<index>;
+  using Dictionary = typename Master_matrix::template Dictionary<Index>;
 
-  Matrix_type matrix_;          /**< Interfaced matrix. */
-  dictionary_type* idToIndex_; /**< Map from @ref IDIdx index to @ref MatIdx index. */
-  index nextIndex_;             /**< Next unused index. */
+  Underlying_matrix matrix_;  /**< Interfaced matrix. */
+  Dictionary* idToIndex_;     /**< Map from @ref IDIdx index to @ref MatIdx index. */
+  Index nextIndex_;           /**< Next unused index. */
 
   void _initialize_map(unsigned int size);
-  index _id_to_index(id_index id) const;
-  index& _id_to_index(id_index id);
+  Index _id_to_index(ID_index id) const;
+  Index& _id_to_index(ID_index id);
 };
 
-template <class Matrix_type, class Master_matrix_type>
-inline Id_to_index_overlay<Matrix_type, Master_matrix_type>::Id_to_index_overlay(Column_settings* colSettings)
+template <class Underlying_matrix, class Master_matrix>
+inline Id_to_index_overlay<Underlying_matrix, Master_matrix>::Id_to_index_overlay(Column_settings* colSettings)
     : matrix_(colSettings), idToIndex_(nullptr), nextIndex_(0) 
 {
   _initialize_map(0);
 }
 
-template <class Matrix_type, class Master_matrix_type>
-template <class Boundary_type>
-inline Id_to_index_overlay<Matrix_type, Master_matrix_type>::Id_to_index_overlay(
-    const std::vector<Boundary_type>& orderedBoundaries, Column_settings* colSettings)
+template <class Underlying_matrix, class Master_matrix>
+template <class Boundary_container>
+inline Id_to_index_overlay<Underlying_matrix, Master_matrix>::Id_to_index_overlay(
+    const std::vector<Boundary_container>& orderedBoundaries, Column_settings* colSettings)
     : matrix_(orderedBoundaries, colSettings), idToIndex_(nullptr), nextIndex_(orderedBoundaries.size()) 
 {
   _initialize_map(orderedBoundaries.size());
-  if constexpr (Master_matrix_type::Option_list::is_of_boundary_type) {
+  if constexpr (Master_matrix::Option_list::is_of_boundary_type) {
     for (unsigned int i = 0; i < orderedBoundaries.size(); i++) {
       _id_to_index(i) = i;
     }
   }
 }
 
-template <class Matrix_type, class Master_matrix_type>
-inline Id_to_index_overlay<Matrix_type, Master_matrix_type>::Id_to_index_overlay(unsigned int numberOfColumns,
+template <class Underlying_matrix, class Master_matrix>
+inline Id_to_index_overlay<Underlying_matrix, Master_matrix>::Id_to_index_overlay(unsigned int numberOfColumns,
                                                                                  Column_settings* colSettings)
     : matrix_(numberOfColumns, colSettings), idToIndex_(nullptr), nextIndex_(0) 
 {
   _initialize_map(numberOfColumns);
 }
 
-template <class Matrix_type, class Master_matrix_type>
+template <class Underlying_matrix, class Master_matrix>
 template <typename BirthComparatorFunction, typename DeathComparatorFunction>
-inline Id_to_index_overlay<Matrix_type, Master_matrix_type>::Id_to_index_overlay(
+inline Id_to_index_overlay<Underlying_matrix, Master_matrix>::Id_to_index_overlay(
     Column_settings* colSettings, 
     const BirthComparatorFunction& birthComparator, 
     const DeathComparatorFunction& deathComparator)
@@ -665,10 +665,10 @@ inline Id_to_index_overlay<Matrix_type, Master_matrix_type>::Id_to_index_overlay
   _initialize_map(0);
 }
 
-template <class Matrix_type, class Master_matrix_type>
-template <typename BirthComparatorFunction, typename DeathComparatorFunction, class Boundary_type>
-inline Id_to_index_overlay<Matrix_type, Master_matrix_type>::Id_to_index_overlay(
-    const std::vector<Boundary_type>& orderedBoundaries, 
+template <class Underlying_matrix, class Master_matrix>
+template <typename BirthComparatorFunction, typename DeathComparatorFunction, class Boundary_container>
+inline Id_to_index_overlay<Underlying_matrix, Master_matrix>::Id_to_index_overlay(
+    const std::vector<Boundary_container>& orderedBoundaries, 
     Column_settings* colSettings,
     const BirthComparatorFunction& birthComparator, 
     const DeathComparatorFunction& deathComparator)
@@ -677,16 +677,16 @@ inline Id_to_index_overlay<Matrix_type, Master_matrix_type>::Id_to_index_overlay
       nextIndex_(orderedBoundaries.size()) 
 {
   _initialize_map(orderedBoundaries.size());
-  if constexpr (Master_matrix_type::Option_list::is_of_boundary_type) {
+  if constexpr (Master_matrix::Option_list::is_of_boundary_type) {
     for (unsigned int i = 0; i < orderedBoundaries.size(); i++) {
       _id_to_index(i) = i;
     }
   }
 }
 
-template <class Matrix_type, class Master_matrix_type>
+template <class Underlying_matrix, class Master_matrix>
 template <typename BirthComparatorFunction, typename DeathComparatorFunction>
-inline Id_to_index_overlay<Matrix_type, Master_matrix_type>::Id_to_index_overlay(
+inline Id_to_index_overlay<Underlying_matrix, Master_matrix>::Id_to_index_overlay(
     unsigned int numberOfColumns, 
     Column_settings* colSettings,
     const BirthComparatorFunction& birthComparator, 
@@ -698,43 +698,43 @@ inline Id_to_index_overlay<Matrix_type, Master_matrix_type>::Id_to_index_overlay
   _initialize_map(numberOfColumns);
 }
 
-template <class Matrix_type, class Master_matrix_type>
-inline Id_to_index_overlay<Matrix_type, Master_matrix_type>::Id_to_index_overlay(
+template <class Underlying_matrix, class Master_matrix>
+inline Id_to_index_overlay<Underlying_matrix, Master_matrix>::Id_to_index_overlay(
     const Id_to_index_overlay& matrixToCopy, Column_settings* colSettings)
     : matrix_(matrixToCopy.matrix_, colSettings),
       idToIndex_(nullptr),
       nextIndex_(matrixToCopy.nextIndex_) 
 {
-  if constexpr (Master_matrix_type::Option_list::is_of_boundary_type) {
-    idToIndex_ = new dictionary_type(*matrixToCopy.idToIndex_);
+  if constexpr (Master_matrix::Option_list::is_of_boundary_type) {
+    idToIndex_ = new Dictionary(*matrixToCopy.idToIndex_);
   } else {
     idToIndex_ = &matrix_.pivotToColumnIndex_;
   }
 }
 
-template <class Matrix_type, class Master_matrix_type>
-inline Id_to_index_overlay<Matrix_type, Master_matrix_type>::Id_to_index_overlay(Id_to_index_overlay&& other) noexcept
+template <class Underlying_matrix, class Master_matrix>
+inline Id_to_index_overlay<Underlying_matrix, Master_matrix>::Id_to_index_overlay(Id_to_index_overlay&& other) noexcept
     : matrix_(std::move(other.matrix_)),
       idToIndex_(std::exchange(other.idToIndex_, nullptr)),
       nextIndex_(std::exchange(other.nextIndex_, 0)) 
 {}
 
-template <class Matrix_type, class Master_matrix_type>
-inline Id_to_index_overlay<Matrix_type, Master_matrix_type>::~Id_to_index_overlay() 
+template <class Underlying_matrix, class Master_matrix>
+inline Id_to_index_overlay<Underlying_matrix, Master_matrix>::~Id_to_index_overlay() 
 {
-  if constexpr (Master_matrix_type::Option_list::is_of_boundary_type) {
+  if constexpr (Master_matrix::Option_list::is_of_boundary_type) {
     if (idToIndex_ != nullptr) delete idToIndex_;
   }
 }
 
-template <class Matrix_type, class Master_matrix_type>
-template <class Boundary_type>
-inline void Id_to_index_overlay<Matrix_type, Master_matrix_type>::insert_boundary(const Boundary_type& boundary,
-                                                                                  dimension_type dim) 
+template <class Underlying_matrix, class Master_matrix>
+template <class Boundary_container>
+inline void Id_to_index_overlay<Underlying_matrix, Master_matrix>::insert_boundary(const Boundary_container& boundary,
+                                                                                  Dimension dim) 
 {
   matrix_.insert_boundary(boundary, dim);
-  if constexpr (Master_matrix_type::Option_list::is_of_boundary_type) {
-    if constexpr (Master_matrix_type::Option_list::has_map_column_container) {
+  if constexpr (Master_matrix::Option_list::is_of_boundary_type) {
+    if constexpr (Master_matrix::Option_list::has_map_column_container) {
       idToIndex_->emplace(nextIndex_, nextIndex_);
     } else {
       if (idToIndex_->size() == nextIndex_) {
@@ -747,22 +747,22 @@ inline void Id_to_index_overlay<Matrix_type, Master_matrix_type>::insert_boundar
   }
 }
 
-template <class Matrix_type, class Master_matrix_type>
-template <class Boundary_type>
-inline void Id_to_index_overlay<Matrix_type, Master_matrix_type>::insert_boundary(id_index faceIndex,
-                                                                                  const Boundary_type& boundary,
-                                                                                  dimension_type dim) 
+template <class Underlying_matrix, class Master_matrix>
+template <class Boundary_container>
+inline void Id_to_index_overlay<Underlying_matrix, Master_matrix>::insert_boundary(ID_index faceIndex,
+                                                                                  const Boundary_container& boundary,
+                                                                                  Dimension dim) 
 {
-  if constexpr (Master_matrix_type::Option_list::has_map_column_container) {
+  if constexpr (Master_matrix::Option_list::has_map_column_container) {
     GUDHI_CHECK(idToIndex_->find(faceIndex) == idToIndex_->end(),
                 std::invalid_argument("Id_to_index_overlay::insert_boundary - Index for simplex already chosen!"));
   } else {
-    GUDHI_CHECK((idToIndex_->size() <= faceIndex || _id_to_index(faceIndex) == static_cast<index>(-1)),
+    GUDHI_CHECK((idToIndex_->size() <= faceIndex || _id_to_index(faceIndex) == static_cast<Index>(-1)),
                 std::invalid_argument("Id_to_index_overlay::insert_boundary - Index for simplex already chosen!"));
   }
   matrix_.insert_boundary(faceIndex, boundary, dim);
-  if constexpr (Master_matrix_type::Option_list::is_of_boundary_type) {
-    if constexpr (Master_matrix_type::Option_list::has_map_column_container) {
+  if constexpr (Master_matrix::Option_list::is_of_boundary_type) {
+    if constexpr (Master_matrix::Option_list::has_map_column_container) {
       idToIndex_->emplace(faceIndex, nextIndex_);
     } else {
       if (idToIndex_->size() <= faceIndex) {
@@ -774,42 +774,42 @@ inline void Id_to_index_overlay<Matrix_type, Master_matrix_type>::insert_boundar
   }
 }
 
-template <class Matrix_type, class Master_matrix_type>
-inline typename Id_to_index_overlay<Matrix_type, Master_matrix_type>::Column_type&
-Id_to_index_overlay<Matrix_type, Master_matrix_type>::get_column(id_index faceID) 
+template <class Underlying_matrix, class Master_matrix>
+inline typename Id_to_index_overlay<Underlying_matrix, Master_matrix>::Column&
+Id_to_index_overlay<Underlying_matrix, Master_matrix>::get_column(ID_index faceID) 
 {
   return matrix_.get_column(_id_to_index(faceID));
 }
 
-template <class Matrix_type, class Master_matrix_type>
-inline typename Id_to_index_overlay<Matrix_type, Master_matrix_type>::Row_type&
-Id_to_index_overlay<Matrix_type, Master_matrix_type>::get_row(id_index rowIndex) 
+template <class Underlying_matrix, class Master_matrix>
+inline typename Id_to_index_overlay<Underlying_matrix, Master_matrix>::Row&
+Id_to_index_overlay<Underlying_matrix, Master_matrix>::get_row(ID_index rowIndex) 
 {
   return matrix_.get_row(rowIndex);
 }
 
-template <class Matrix_type, class Master_matrix_type>
-inline void Id_to_index_overlay<Matrix_type, Master_matrix_type>::erase_empty_row(id_index rowIndex) 
+template <class Underlying_matrix, class Master_matrix>
+inline void Id_to_index_overlay<Underlying_matrix, Master_matrix>::erase_empty_row(ID_index rowIndex) 
 {
   return matrix_.erase_empty_row(rowIndex);
 }
 
-template <class Matrix_type, class Master_matrix_type>
-inline void Id_to_index_overlay<Matrix_type, Master_matrix_type>::remove_maximal_face(id_index faceID) 
+template <class Underlying_matrix, class Master_matrix>
+inline void Id_to_index_overlay<Underlying_matrix, Master_matrix>::remove_maximal_face(ID_index faceID) 
 {
-  if constexpr (Master_matrix_type::Option_list::is_of_boundary_type) {
-    std::vector<id_index> indexToID(nextIndex_);
-    if constexpr (Master_matrix_type::Option_list::has_map_column_container) {
+  if constexpr (Master_matrix::Option_list::is_of_boundary_type) {
+    std::vector<ID_index> indexToID(nextIndex_);
+    if constexpr (Master_matrix::Option_list::has_map_column_container) {
       for (auto& p : *idToIndex_) {
         indexToID[p.second] = p.first;
       }
     } else {
-      for (id_index i = 0; i < idToIndex_->size(); ++i) {
-        if (_id_to_index(i) != static_cast<index>(-1)) indexToID[_id_to_index(i)] = i;
+      for (ID_index i = 0; i < idToIndex_->size(); ++i) {
+        if (_id_to_index(i) != static_cast<Index>(-1)) indexToID[_id_to_index(i)] = i;
       }
     }
     --nextIndex_;
-    for (index curr = _id_to_index(faceID); curr < nextIndex_; ++curr) {
+    for (Index curr = _id_to_index(faceID); curr < nextIndex_; ++curr) {
       matrix_.vine_swap(curr);
       std::swap(idToIndex_->at(indexToID[curr]), idToIndex_->at(indexToID[curr + 1]));
     }
@@ -817,7 +817,7 @@ inline void Id_to_index_overlay<Matrix_type, Master_matrix_type>::remove_maximal
     GUDHI_CHECK(_id_to_index(faceID) == nextIndex_,
                 std::logic_error("Id_to_index_overlay::remove_maximal_face - Indexation problem."));
 
-    if constexpr (Master_matrix_type::Option_list::has_map_column_container) {
+    if constexpr (Master_matrix::Option_list::has_map_column_container) {
       idToIndex_->erase(faceID);
     } else {
       _id_to_index(faceID) = -1;
@@ -827,34 +827,34 @@ inline void Id_to_index_overlay<Matrix_type, Master_matrix_type>::remove_maximal
   }
 }
 
-template <class Matrix_type, class Master_matrix_type>
-inline void Id_to_index_overlay<Matrix_type, Master_matrix_type>::remove_maximal_face(
-    id_index faceID, const std::vector<id_index>& columnsToSwap) 
+template <class Underlying_matrix, class Master_matrix>
+inline void Id_to_index_overlay<Underlying_matrix, Master_matrix>::remove_maximal_face(
+    ID_index faceID, const std::vector<ID_index>& columnsToSwap) 
 {
-  static_assert(!Master_matrix_type::Option_list::is_of_boundary_type,
-                "'remove_maximal_face(id_index,const std::vector<index>&)' is not available for the chosen options.");
-  std::vector<index> translatedIndices;
+  static_assert(!Master_matrix::Option_list::is_of_boundary_type,
+                "'remove_maximal_face(ID_index,const std::vector<Index>&)' is not available for the chosen options.");
+  std::vector<Index> translatedIndices;
   std::transform(columnsToSwap.cbegin(), columnsToSwap.cend(), std::back_inserter(translatedIndices),
-                 [&](id_index id) { return _id_to_index(id); });
+                 [&](ID_index id) { return _id_to_index(id); });
   matrix_.remove_maximal_face(faceID, translatedIndices);
 }
 
-template <class Matrix_type, class Master_matrix_type>
-inline void Id_to_index_overlay<Matrix_type, Master_matrix_type>::remove_last() 
+template <class Underlying_matrix, class Master_matrix>
+inline void Id_to_index_overlay<Underlying_matrix, Master_matrix>::remove_last() 
 {
   if (idToIndex_->empty()) return;  //empty matrix
 
   matrix_.remove_last();
 
-  if constexpr (Master_matrix_type::Option_list::is_of_boundary_type) {
+  if constexpr (Master_matrix::Option_list::is_of_boundary_type) {
     --nextIndex_;
-    if constexpr (Master_matrix_type::Option_list::has_map_column_container) {
+    if constexpr (Master_matrix::Option_list::has_map_column_container) {
       auto it = idToIndex_->begin();
       while (it->second != nextIndex_) ++it;   //should never reach idToIndex_->end()
       idToIndex_->erase(it);
     } else {
-      index id = idToIndex_->size() - 1;
-      while (_id_to_index(id) == static_cast<index>(-1)) --id;  // should always stop before reaching -1
+      Index id = idToIndex_->size() - 1;
+      while (_id_to_index(id) == static_cast<Index>(-1)) --id;  // should always stop before reaching -1
       GUDHI_CHECK(_id_to_index(id) == nextIndex_,
                   std::logic_error("Id_to_index_overlay::remove_last - Indexation problem."));
       _id_to_index(id) = -1;
@@ -862,79 +862,79 @@ inline void Id_to_index_overlay<Matrix_type, Master_matrix_type>::remove_last()
   }
 }
 
-template <class Matrix_type, class Master_matrix_type>
-inline typename Id_to_index_overlay<Matrix_type, Master_matrix_type>::dimension_type
-Id_to_index_overlay<Matrix_type, Master_matrix_type>::get_max_dimension() const 
+template <class Underlying_matrix, class Master_matrix>
+inline typename Id_to_index_overlay<Underlying_matrix, Master_matrix>::Dimension
+Id_to_index_overlay<Underlying_matrix, Master_matrix>::get_max_dimension() const 
 {
   return matrix_.get_max_dimension();
 }
 
-template <class Matrix_type, class Master_matrix_type>
-inline typename Id_to_index_overlay<Matrix_type, Master_matrix_type>::index
-Id_to_index_overlay<Matrix_type, Master_matrix_type>::get_number_of_columns() const 
+template <class Underlying_matrix, class Master_matrix>
+inline typename Id_to_index_overlay<Underlying_matrix, Master_matrix>::Index
+Id_to_index_overlay<Underlying_matrix, Master_matrix>::get_number_of_columns() const 
 {
   return matrix_.get_number_of_columns();
 }
 
-template <class Matrix_type, class Master_matrix_type>
-inline typename Id_to_index_overlay<Matrix_type, Master_matrix_type>::dimension_type
-Id_to_index_overlay<Matrix_type, Master_matrix_type>::get_column_dimension(id_index faceID) const 
+template <class Underlying_matrix, class Master_matrix>
+inline typename Id_to_index_overlay<Underlying_matrix, Master_matrix>::Dimension
+Id_to_index_overlay<Underlying_matrix, Master_matrix>::get_column_dimension(ID_index faceID) const 
 {
   return matrix_.get_column_dimension(_id_to_index(faceID));
 }
 
-template <class Matrix_type, class Master_matrix_type>
-inline void Id_to_index_overlay<Matrix_type, Master_matrix_type>::add_to(id_index sourceFaceID, id_index targetFaceID) 
+template <class Underlying_matrix, class Master_matrix>
+inline void Id_to_index_overlay<Underlying_matrix, Master_matrix>::add_to(ID_index sourceFaceID, ID_index targetFaceID) 
 {
   return matrix_.add_to(_id_to_index(sourceFaceID), _id_to_index(targetFaceID));
 }
 
-template <class Matrix_type, class Master_matrix_type>
-inline void Id_to_index_overlay<Matrix_type, Master_matrix_type>::multiply_target_and_add_to(
-    id_index sourceFaceID, const Field_element_type& coefficient, id_index targetFaceID) 
+template <class Underlying_matrix, class Master_matrix>
+inline void Id_to_index_overlay<Underlying_matrix, Master_matrix>::multiply_target_and_add_to(
+    ID_index sourceFaceID, const Field_element& coefficient, ID_index targetFaceID) 
 {
   return matrix_.multiply_target_and_add_to(_id_to_index(sourceFaceID), coefficient, _id_to_index(targetFaceID));
 }
 
-template <class Matrix_type, class Master_matrix_type>
-inline void Id_to_index_overlay<Matrix_type, Master_matrix_type>::multiply_source_and_add_to(
-    const Field_element_type& coefficient, id_index sourceFaceID, id_index targetFaceID) 
+template <class Underlying_matrix, class Master_matrix>
+inline void Id_to_index_overlay<Underlying_matrix, Master_matrix>::multiply_source_and_add_to(
+    const Field_element& coefficient, ID_index sourceFaceID, ID_index targetFaceID) 
 {
   return matrix_.multiply_source_and_add_to(coefficient, _id_to_index(sourceFaceID), _id_to_index(targetFaceID));
 }
 
-template <class Matrix_type, class Master_matrix_type>
-inline void Id_to_index_overlay<Matrix_type, Master_matrix_type>::zero_cell(id_index faceID, id_index rowIndex) 
+template <class Underlying_matrix, class Master_matrix>
+inline void Id_to_index_overlay<Underlying_matrix, Master_matrix>::zero_cell(ID_index faceID, ID_index rowIndex) 
 {
   return matrix_.zero_cell(_id_to_index(faceID), rowIndex);
 }
 
-template <class Matrix_type, class Master_matrix_type>
-inline void Id_to_index_overlay<Matrix_type, Master_matrix_type>::zero_column(id_index faceID) 
+template <class Underlying_matrix, class Master_matrix>
+inline void Id_to_index_overlay<Underlying_matrix, Master_matrix>::zero_column(ID_index faceID) 
 {
   return matrix_.zero_column(_id_to_index(faceID));
 }
 
-template <class Matrix_type, class Master_matrix_type>
-inline bool Id_to_index_overlay<Matrix_type, Master_matrix_type>::is_zero_cell(id_index faceID,
-                                                                               id_index rowIndex) const 
+template <class Underlying_matrix, class Master_matrix>
+inline bool Id_to_index_overlay<Underlying_matrix, Master_matrix>::is_zero_cell(ID_index faceID,
+                                                                               ID_index rowIndex) const 
 {
   return matrix_.is_zero_cell(_id_to_index(faceID), rowIndex);
 }
 
-template <class Matrix_type, class Master_matrix_type>
-inline bool Id_to_index_overlay<Matrix_type, Master_matrix_type>::is_zero_column(id_index faceID) 
+template <class Underlying_matrix, class Master_matrix>
+inline bool Id_to_index_overlay<Underlying_matrix, Master_matrix>::is_zero_column(ID_index faceID) 
 {
   return matrix_.is_zero_column(_id_to_index(faceID));
 }
 
-template <class Matrix_type, class Master_matrix_type>
-inline typename Id_to_index_overlay<Matrix_type, Master_matrix_type>::id_index
-Id_to_index_overlay<Matrix_type, Master_matrix_type>::get_column_with_pivot(id_index simplexIndex) const 
+template <class Underlying_matrix, class Master_matrix>
+inline typename Id_to_index_overlay<Underlying_matrix, Master_matrix>::ID_index
+Id_to_index_overlay<Underlying_matrix, Master_matrix>::get_column_with_pivot(ID_index simplexIndex) const 
 {
-  if constexpr (Master_matrix_type::Option_list::is_of_boundary_type) {
-    index pos = matrix_.get_column_with_pivot(simplexIndex);
-    id_index i = 0;
+  if constexpr (Master_matrix::Option_list::is_of_boundary_type) {
+    Index pos = matrix_.get_column_with_pivot(simplexIndex);
+    ID_index i = 0;
     while (_id_to_index(i) != pos) ++i;
     return i;
   } else {
@@ -942,23 +942,23 @@ Id_to_index_overlay<Matrix_type, Master_matrix_type>::get_column_with_pivot(id_i
   }
 }
 
-template <class Matrix_type, class Master_matrix_type>
-inline typename Id_to_index_overlay<Matrix_type, Master_matrix_type>::id_index
-Id_to_index_overlay<Matrix_type, Master_matrix_type>::get_pivot(id_index faceID) 
+template <class Underlying_matrix, class Master_matrix>
+inline typename Id_to_index_overlay<Underlying_matrix, Master_matrix>::ID_index
+Id_to_index_overlay<Underlying_matrix, Master_matrix>::get_pivot(ID_index faceID) 
 {
-  if constexpr (Master_matrix_type::Option_list::is_of_boundary_type) {
+  if constexpr (Master_matrix::Option_list::is_of_boundary_type) {
     return matrix_.get_pivot(_id_to_index(faceID));
   } else {
     return faceID;
   }
 }
 
-template <class Matrix_type, class Master_matrix_type>
-inline Id_to_index_overlay<Matrix_type, Master_matrix_type>&
-Id_to_index_overlay<Matrix_type, Master_matrix_type>::operator=(const Id_to_index_overlay& other) 
+template <class Underlying_matrix, class Master_matrix>
+inline Id_to_index_overlay<Underlying_matrix, Master_matrix>&
+Id_to_index_overlay<Underlying_matrix, Master_matrix>::operator=(const Id_to_index_overlay& other) 
 {
   matrix_ = other.matrix_;
-  if (Master_matrix_type::Option_list::is_of_boundary_type)
+  if (Master_matrix::Option_list::is_of_boundary_type)
     idToIndex_ = other.idToIndex_;
   else
     idToIndex_ = &matrix_.pivotToColumnIndex_;
@@ -967,61 +967,61 @@ Id_to_index_overlay<Matrix_type, Master_matrix_type>::operator=(const Id_to_inde
   return *this;
 }
 
-template <class Matrix_type, class Master_matrix_type>
-inline void Id_to_index_overlay<Matrix_type, Master_matrix_type>::print() 
+template <class Underlying_matrix, class Master_matrix>
+inline void Id_to_index_overlay<Underlying_matrix, Master_matrix>::print() 
 {
   return matrix_.print();
 }
 
-template <class Matrix_type, class Master_matrix_type>
-inline const typename Id_to_index_overlay<Matrix_type, Master_matrix_type>::barcode_type&
-Id_to_index_overlay<Matrix_type, Master_matrix_type>::get_current_barcode() 
+template <class Underlying_matrix, class Master_matrix>
+inline const typename Id_to_index_overlay<Underlying_matrix, Master_matrix>::Barcode&
+Id_to_index_overlay<Underlying_matrix, Master_matrix>::get_current_barcode() 
 {
   return matrix_.get_current_barcode();
 }
 
-template <class Matrix_type, class Master_matrix_type>
-inline void Id_to_index_overlay<Matrix_type, Master_matrix_type>::update_representative_cycles() 
+template <class Underlying_matrix, class Master_matrix>
+inline void Id_to_index_overlay<Underlying_matrix, Master_matrix>::update_representative_cycles() 
 {
   matrix_.update_representative_cycles();
 }
 
-template <class Matrix_type, class Master_matrix_type>
-inline const std::vector<typename Id_to_index_overlay<Matrix_type, Master_matrix_type>::cycle_type>&
-Id_to_index_overlay<Matrix_type, Master_matrix_type>::get_representative_cycles() 
+template <class Underlying_matrix, class Master_matrix>
+inline const std::vector<typename Id_to_index_overlay<Underlying_matrix, Master_matrix>::Cycle>&
+Id_to_index_overlay<Underlying_matrix, Master_matrix>::get_representative_cycles() 
 {
   return matrix_.get_representative_cycles();
 }
 
-template <class Matrix_type, class Master_matrix_type>
-inline const typename Id_to_index_overlay<Matrix_type, Master_matrix_type>::cycle_type&
-Id_to_index_overlay<Matrix_type, Master_matrix_type>::get_representative_cycle(const bar_type& bar) 
+template <class Underlying_matrix, class Master_matrix>
+inline const typename Id_to_index_overlay<Underlying_matrix, Master_matrix>::Cycle&
+Id_to_index_overlay<Underlying_matrix, Master_matrix>::get_representative_cycle(const Bar& bar) 
 {
   return matrix_.get_representative_cycle(bar);
 }
 
-template <class Matrix_type, class Master_matrix_type>
-inline void Id_to_index_overlay<Matrix_type, Master_matrix_type>::swap_columns(id_index faceID1, id_index faceID2) 
+template <class Underlying_matrix, class Master_matrix>
+inline void Id_to_index_overlay<Underlying_matrix, Master_matrix>::swap_columns(ID_index faceID1, ID_index faceID2) 
 {
   matrix_.swap_columns(_id_to_index(faceID1), _id_to_index(faceID2));
   std::swap(idToIndex_->at(faceID1), idToIndex_->at(faceID2));
 }
 
-template <class Matrix_type, class Master_matrix_type>
-inline void Id_to_index_overlay<Matrix_type, Master_matrix_type>::swap_rows(index rowIndex1, index rowIndex2) 
+template <class Underlying_matrix, class Master_matrix>
+inline void Id_to_index_overlay<Underlying_matrix, Master_matrix>::swap_rows(Index rowIndex1, Index rowIndex2) 
 {
   matrix_.swap_rows(rowIndex1, rowIndex2);
 }
 
-template <class Matrix_type, class Master_matrix_type>
-inline typename Id_to_index_overlay<Matrix_type, Master_matrix_type>::id_index
-Id_to_index_overlay<Matrix_type, Master_matrix_type>::vine_swap_with_z_eq_1_case(id_index faceID1, id_index faceID2) 
+template <class Underlying_matrix, class Master_matrix>
+inline typename Id_to_index_overlay<Underlying_matrix, Master_matrix>::ID_index
+Id_to_index_overlay<Underlying_matrix, Master_matrix>::vine_swap_with_z_eq_1_case(ID_index faceID1, ID_index faceID2) 
 {
-  index first = _id_to_index(faceID1);
-  index second = _id_to_index(faceID2);
+  Index first = _id_to_index(faceID1);
+  Index second = _id_to_index(faceID2);
   if (first > second) std::swap(first, second);
 
-  if constexpr (Master_matrix_type::Option_list::is_of_boundary_type) {
+  if constexpr (Master_matrix::Option_list::is_of_boundary_type) {
     GUDHI_CHECK(second - first == 1,
                 std::invalid_argument(
                     "Id_to_index_overlay::vine_swap_with_z_eq_1_case - The columns to swap are not contiguous."));
@@ -1039,15 +1039,15 @@ Id_to_index_overlay<Matrix_type, Master_matrix_type>::vine_swap_with_z_eq_1_case
   }
 }
 
-template <class Matrix_type, class Master_matrix_type>
-inline typename Id_to_index_overlay<Matrix_type, Master_matrix_type>::id_index
-Id_to_index_overlay<Matrix_type, Master_matrix_type>::vine_swap(id_index faceID1, id_index faceID2) 
+template <class Underlying_matrix, class Master_matrix>
+inline typename Id_to_index_overlay<Underlying_matrix, Master_matrix>::ID_index
+Id_to_index_overlay<Underlying_matrix, Master_matrix>::vine_swap(ID_index faceID1, ID_index faceID2) 
 {
-  index first = _id_to_index(faceID1);
-  index second = _id_to_index(faceID2);
+  Index first = _id_to_index(faceID1);
+  Index second = _id_to_index(faceID2);
   if (first > second) std::swap(first, second);
 
-  if constexpr (Master_matrix_type::Option_list::is_of_boundary_type) {
+  if constexpr (Master_matrix::Option_list::is_of_boundary_type) {
     GUDHI_CHECK(second - first == 1,
                 std::invalid_argument("Id_to_index_overlay::vine_swap - The columns to swap are not contiguous."));
 
@@ -1064,34 +1064,34 @@ Id_to_index_overlay<Matrix_type, Master_matrix_type>::vine_swap(id_index faceID1
   }
 }
 
-template <class Matrix_type, class Master_matrix_type>
-inline void Id_to_index_overlay<Matrix_type, Master_matrix_type>::_initialize_map([[maybe_unused]] unsigned int size) 
+template <class Underlying_matrix, class Master_matrix>
+inline void Id_to_index_overlay<Underlying_matrix, Master_matrix>::_initialize_map([[maybe_unused]] unsigned int size) 
 {
-  if constexpr (Master_matrix_type::Option_list::is_of_boundary_type) {
-    if constexpr (Master_matrix_type::Option_list::has_map_column_container) {
-      idToIndex_ = new dictionary_type(size);
+  if constexpr (Master_matrix::Option_list::is_of_boundary_type) {
+    if constexpr (Master_matrix::Option_list::has_map_column_container) {
+      idToIndex_ = new Dictionary(size);
     } else {
-      idToIndex_ = new dictionary_type(size, -1);
+      idToIndex_ = new Dictionary(size, -1);
     }
   } else {
     idToIndex_ = &matrix_.pivotToColumnIndex_;
   }
 }
 
-template <class Matrix_type, class Master_matrix_type>
-inline typename Id_to_index_overlay<Matrix_type, Master_matrix_type>::index
-Id_to_index_overlay<Matrix_type, Master_matrix_type>::_id_to_index(id_index id) const 
+template <class Underlying_matrix, class Master_matrix>
+inline typename Id_to_index_overlay<Underlying_matrix, Master_matrix>::Index
+Id_to_index_overlay<Underlying_matrix, Master_matrix>::_id_to_index(ID_index id) const 
 {
-  if constexpr (Master_matrix_type::Option_list::has_map_column_container) {
+  if constexpr (Master_matrix::Option_list::has_map_column_container) {
     return idToIndex_->at(id);
   } else {
     return idToIndex_->operator[](id);
   }
 }
 
-template <class Matrix_type, class Master_matrix_type>
-inline typename Id_to_index_overlay<Matrix_type, Master_matrix_type>::index&
-Id_to_index_overlay<Matrix_type, Master_matrix_type>::_id_to_index(id_index id)
+template <class Underlying_matrix, class Master_matrix>
+inline typename Id_to_index_overlay<Underlying_matrix, Master_matrix>::Index&
+Id_to_index_overlay<Underlying_matrix, Master_matrix>::_id_to_index(ID_index id)
 {
   return idToIndex_->operator[](id);  //for maps, the entry is created if not existing as needed in the constructors
 }

--- a/src/Persistence_matrix/include/gudhi/Persistence_matrix/overlay_posidx_to_matidx.h
+++ b/src/Persistence_matrix/include/gudhi/Persistence_matrix/overlay_posidx_to_matidx.h
@@ -32,33 +32,33 @@ namespace persistence_matrix {
  * original methods with @ref PosIdx indices. The overlay is useless for @ref boundarymatrix "boundary matrices"
  * as @ref MatIdx == @ref PosIdx for them.
  * 
- * @tparam %Matrix_type Matrix type taking the overlay.
- * @tparam Master_matrix_type An instantiation of @ref Matrix from which all types and options are deduced.
+ * @tparam %Underlying_matrix Matrix type taking the overlay.
+ * @tparam Master_matrix An instantiation of @ref Matrix from which all types and options are deduced.
  */
-template <class Matrix_type, class Master_matrix_type>
+template <class Underlying_matrix, class Master_matrix>
 class Position_to_index_overlay 
 {
  public:
-  using index = typename Master_matrix_type::index;                       /**< @ref MatIdx index type. */
-  using id_index = typename Master_matrix_type::id_index;                 /**< @ref IDIdx index type. */
-  using pos_index = typename Master_matrix_type::pos_index;               /**< @ref PosIdx index type. */
-  using dimension_type = typename Master_matrix_type::dimension_type;     /**< Dimension value type. */
+  using Index = typename Master_matrix::Index;                              /**< @ref MatIdx index type. */
+  using ID_index = typename Master_matrix::ID_index;                        /**< @ref IDIdx index type. */
+  using Pos_index = typename Master_matrix::Pos_index;                      /**< @ref PosIdx index type. */
+  using Dimension = typename Master_matrix::Dimension;                      /**< Dimension value type. */
   /**
    * @brief Field operators class. Necessary only if @ref PersistenceMatrixOptions::is_z2 is false.
    */
-  using Field_operators = typename Master_matrix_type::Field_operators;
-  using Field_element_type = typename Master_matrix_type::element_type;   /**< Type of an field element. */
-  using boundary_type = typename Master_matrix_type::boundary_type;       /**< Type of an input column. */
-  using Column_type = typename Master_matrix_type::Column_type;           /**< Column type. */
-  using Row_type = typename Master_matrix_type::Row_type;                 /**< Row type,
-                                                                               only necessary with row access option. */
-  using bar_type = typename Master_matrix_type::Bar;                      /**< Bar type. */
-  using barcode_type = typename Master_matrix_type::barcode_type;         /**< Barcode type. */
-  using cycle_type = typename Master_matrix_type::cycle_type;             /**< Cycle type. */
-  using cell_rep_type = typename Master_matrix_type::cell_rep_type;       /**< %Cell content representative. */
-  using Cell_constructor = typename Master_matrix_type::Cell_constructor; /**< Factory of @ref Cell classes. */
-  using Column_settings = typename Master_matrix_type::Column_settings;   /**< Structure giving access to the columns to
-                                                                               necessary external classes. */
+  using Field_operators = typename Master_matrix::Field_operators;
+  using Field_element = typename Master_matrix::Element;                    /**< Type of an field element. */
+  using Boundary = typename Master_matrix::Boundary;                        /**< Type of an input column. */
+  using Column = typename Master_matrix::Column;                            /**< Column type. */
+  using Row = typename Master_matrix::Row;                                  /**< Row type, only
+                                                                                 necessary with row access option. */
+  using Bar = typename Master_matrix::Bar;                                  /**< Bar type. */
+  using Barcode = typename Master_matrix::Barcode;                          /**< Barcode type. */
+  using Cycle = typename Master_matrix::Cycle;                              /**< Cycle type. */
+  using Cell_representative = typename Master_matrix::Cell_representative;  /**< %Cell content representative. */
+  using Cell_constructor = typename Master_matrix::Cell_constructor;        /**< Factory of @ref Cell classes. */
+  using Column_settings = typename Master_matrix::Column_settings;          /**< Structure giving access to the columns
+                                                                                 to necessary external classes. */
 
   /**
    * @brief Constructs an empty matrix.
@@ -68,11 +68,11 @@ class Position_to_index_overlay
    */
   Position_to_index_overlay(Column_settings* colSettings);
   /**
-   * @brief Constructs a new matrix from the given ranges of @ref Matrix::cell_rep_type. Each range corresponds to a
+   * @brief Constructs a new matrix from the given ranges of @ref Matrix::Cell_representative. Each range corresponds to a
    * column (the order of the ranges are preserved). The content of the ranges is assumed to be sorted by increasing
    * IDs. The IDs of the simplices are also assumed to be consecutive, ordered by filtration value, starting with 0.
    * 
-   * @tparam Boundary_type Range type for @ref Matrix::cell_rep_type ranges.
+   * @tparam Boundary_container Range type for @ref Matrix::Cell_representative ranges.
    * Assumed to have a begin(), end() and size() method.
    * @param orderedBoundaries Range of boundaries: @p orderedBoundaries is interpreted as a boundary matrix of a 
    * filtered **simplicial** complex, whose boundaries are ordered by filtration order. 
@@ -87,8 +87,8 @@ class Position_to_index_overlay
    * @param colSettings Pointer to an existing setting structure for the columns. The structure should contain all
    * the necessary external classes specifically necessary for the choosen column type, such as custom allocators.
    */
-  template <class Boundary_type = boundary_type>
-  Position_to_index_overlay(const std::vector<Boundary_type>& orderedBoundaries, 
+  template <class Boundary_container = Boundary>
+  Position_to_index_overlay(const std::vector<Boundary_container>& orderedBoundaries, 
                             Column_settings* colSettings);
   /**
    * @brief Constructs a new empty matrix and reserves space for the given number of columns.
@@ -108,8 +108,8 @@ class Position_to_index_overlay
    * @ref PersistenceMatrixOptions::has_column_pairings is also true, the comparators are ignored and
    * the current barcode is used to compare birth and deaths. Therefore it is useless to provide them in those cases.
    * 
-   * @tparam BirthComparatorFunction Type of the birth comparator: (@ref pos_index, @ref pos_index) -> bool
-   * @tparam DeathComparatorFunction Type of the death comparator: (@ref pos_index, @ref pos_index) -> bool
+   * @tparam BirthComparatorFunction Type of the birth comparator: (@ref Pos_index, @ref Pos_index) -> bool
+   * @tparam DeathComparatorFunction Type of the death comparator: (@ref Pos_index, @ref Pos_index) -> bool
    * @param colSettings Pointer to an existing setting structure for the columns. The structure should contain all
    * the necessary external classes specifically necessary for the choosen column type, such as custom allocators.
    * @param birthComparator Method taking two @ref PosIdx indices as input and returning true if and only if
@@ -127,7 +127,7 @@ class Position_to_index_overlay
                             const DeathComparatorFunction& deathComparator);
   /**
    * @brief Only available for @ref chainmatrix "chain matrices". 
-   * Constructs a new matrix from the given ranges of @ref Matrix::cell_rep_type. Each range corresponds to a column 
+   * Constructs a new matrix from the given ranges of @ref Matrix::Cell_representative. Each range corresponds to a column 
    * (the order of the ranges are preserved). The content of the ranges is assumed to be sorted by increasing IDs.
    * The IDs of the simplices are also assumed to be consecutive, ordered by filtration value, starting with 0. 
    *
@@ -136,9 +136,9 @@ class Position_to_index_overlay
    * @ref PersistenceMatrixOptions::has_column_pairings is also true, the comparators are ignored and
    * the current barcode is used to compare birth and deaths. Therefore it is useless to provide them in those cases.
    * 
-   * @tparam BirthComparatorFunction Type of the birth comparator: (@ref pos_index, @ref pos_index) -> bool
-   * @tparam DeathComparatorFunction Type of the death comparator: (@ref pos_index, @ref pos_index) -> bool
-   * @tparam Boundary_type  Range type for @ref Matrix::cell_rep_type ranges.
+   * @tparam BirthComparatorFunction Type of the birth comparator: (@ref Pos_index, @ref Pos_index) -> bool
+   * @tparam DeathComparatorFunction Type of the death comparator: (@ref Pos_index, @ref Pos_index) -> bool
+   * @tparam Boundary_container  Range type for @ref Matrix::Cell_representative ranges.
    * Assumed to have a begin(), end() and size() method.
    * @param orderedBoundaries Range of boundaries: @p orderedBoundaries is interpreted as a boundary matrix of a 
    * filtered **simplicial** complex, whose boundaries are ordered by filtration order. 
@@ -161,8 +161,8 @@ class Position_to_index_overlay
    * the second one with respect to some self defined order. It is used while swapping two positive but paired
    * columns.
    */
-  template <typename BirthComparatorFunction, typename DeathComparatorFunction, class Boundary_type>
-  Position_to_index_overlay(const std::vector<Boundary_type>& orderedBoundaries, 
+  template <typename BirthComparatorFunction, typename DeathComparatorFunction, class Boundary_container>
+  Position_to_index_overlay(const std::vector<Boundary_container>& orderedBoundaries, 
                             Column_settings* colSettings, 
                             const BirthComparatorFunction& birthComparator, 
                             const DeathComparatorFunction& deathComparator);
@@ -175,8 +175,8 @@ class Position_to_index_overlay
    * @ref PersistenceMatrixOptions::has_column_pairings is also true, the comparators are ignored and
    * the current barcode is used to compare birth and deaths. Therefore it is useless to provide them in those cases.
    * 
-   * @tparam BirthComparatorFunction Type of the birth comparator: (@ref pos_index, @ref pos_index) -> bool
-   * @tparam DeathComparatorFunction Type of the death comparator: (@ref pos_index, @ref pos_index) -> bool
+   * @tparam BirthComparatorFunction Type of the birth comparator: (@ref Pos_index, @ref Pos_index) -> bool
+   * @tparam DeathComparatorFunction Type of the death comparator: (@ref Pos_index, @ref Pos_index) -> bool
    * @param numberOfColumns Number of columns to reserve space for.
    * @param colSettings Pointer to an existing setting structure for the columns. The structure should contain all
    * the necessary external classes specifically necessary for the choosen column type, such as custom allocators.
@@ -217,7 +217,7 @@ class Position_to_index_overlay
    * This means that it is assumed that this method is called on boundaries in the order of the filtration. 
    * It also assumes that the faces in the given boundary are identified by their relative position in the filtration, 
    * starting at 0. If it is not the case, use the other
-   * @ref insert_boundary(id_index, const Boundary_type&, dimension_type) "insert_boundary" instead by indicating the
+   * @ref insert_boundary(ID_index, const Boundary_container&, Dimension) "insert_boundary" instead by indicating the
    * face ID used in the boundaries when the face is inserted.
    *
    * Different to the constructor, the boundaries do not have to come from a simplicial complex, but also from
@@ -226,13 +226,13 @@ class Position_to_index_overlay
    * When inserted, the given boundary is reduced and from the reduction process, the column is deduced in the form of:
    * `IDIdx + linear combination of older column IDIdxs`. If the barcode is stored, it will be updated.
    * 
-   * @tparam Boundary_type Range of @ref Matrix::cell_rep_type. Assumed to have a begin(), end() and size() method.
+   * @tparam Boundary_container Range of @ref Matrix::Cell_representative. Assumed to have a begin(), end() and size() method.
    * @param boundary Boundary generating the new column. The content should be ordered by ID.
    * @param dim Dimension of the face whose boundary is given. If the complex is simplicial, 
    * this parameter can be omitted as it can be deduced from the size of the boundary.
    */
-  template <class Boundary_type = boundary_type>
-  void insert_boundary(const Boundary_type& boundary, dimension_type dim = -1);
+  template <class Boundary_container = Boundary>
+  void insert_boundary(const Boundary_container& boundary, Dimension dim = -1);
   /**
    * @brief It does the same as the other version, but allows the boundary faces to be identified without restrictions
    * except that all IDs have to be strictly increasing in the order of filtration. Note that you should avoid then
@@ -241,7 +241,7 @@ class Position_to_index_overlay
    * As a face has to be inserted before one of its cofaces in a valid filtration (recall that it is assumed that
    * the faces are inserted by order of filtration), it is sufficient to indicate the ID of the face being inserted.
    * 
-   * @tparam Boundary_type Range of @ref Matrix::cell_rep_type. Assumed to have a begin(), end() and size() method.
+   * @tparam Boundary_container Range of @ref Matrix::Cell_representative. Assumed to have a begin(), end() and size() method.
    * @param faceIndex @ref IDIdx index to use to identify the new face.
    * @param boundary Boundary generating the new column. The indices of the boundary have to correspond to the 
    * @p faceID values of precedent calls of the method for the corresponding faces and should be ordered in 
@@ -249,8 +249,8 @@ class Position_to_index_overlay
    * @param dim Dimension of the face whose boundary is given. If the complex is simplicial, 
    * this parameter can be omitted as it can be deduced from the size of the boundary.
    */
-  template <class Boundary_type = boundary_type>
-  void insert_boundary(id_index faceIndex, const Boundary_type& boundary, dimension_type dim = -1);
+  template <class Boundary_container = Boundary>
+  void insert_boundary(ID_index faceIndex, const Boundary_container& boundary, Dimension dim = -1);
   /**
    * @brief Returns the column at the given @ref PosIdx index.
    * The type of the column depends on the choosen options, see @ref PersistenceMatrixOptions::column_type.
@@ -258,7 +258,7 @@ class Position_to_index_overlay
    * @param position @ref PosIdx index of the column to return.
    * @return Reference to the column.
    */
-  Column_type& get_column(pos_index position);
+  Column& get_column(Pos_index position);
   /**
    * @brief Returns the column at the given @ref PosIdx index.
    * The type of the column depends on the choosen options, see @ref PersistenceMatrixOptions::column_type.
@@ -266,7 +266,7 @@ class Position_to_index_overlay
    * @param position @ref PosIdx index of the column to return.
    * @return Const reference to the column.
    */
-  const Column_type& get_column(pos_index position) const;
+  const Column& get_column(Pos_index position) const;
   /**
    * @brief Only available if @ref PersistenceMatrixOptions::has_row_access is true.
    * Returns the row at the given @ref rowindex "row index".
@@ -275,7 +275,7 @@ class Position_to_index_overlay
    * @param rowIndex @ref rowindex "Row index" of the row to return.
    * @return Reference to the row.
    */
-  Row_type& get_row(id_index rowIndex);
+  Row& get_row(ID_index rowIndex);
   /**
    * @brief Only available if @ref PersistenceMatrixOptions::has_row_access is true.
    * Returns the row at the given @ref rowindex "row index".
@@ -284,7 +284,7 @@ class Position_to_index_overlay
    * @param rowIndex @ref rowindex "Row index" of the row to return.
    * @return Const reference to the row.
    */
-  const Row_type& get_row(id_index rowIndex) const;
+  const Row& get_row(ID_index rowIndex) const;
   /**
    * @brief Only available if @ref PersistenceMatrixOptions::has_row_access and
    * @ref PersistenceMatrixOptions::has_removable_rows are true.
@@ -299,7 +299,7 @@ class Position_to_index_overlay
    * 
    * @param rowIndex @ref rowindex "Row index" of the empty row to remove.
    */
-  void erase_empty_row(id_index rowIndex);
+  void erase_empty_row(ID_index rowIndex);
   /**
    * @brief Only available if @ref PersistenceMatrixOptions::has_removable_columns,
    * @ref PersistenceMatrixOptions::has_vine_update and @ref PersistenceMatrixOptions::has_map_column_container
@@ -313,7 +313,7 @@ class Position_to_index_overlay
    * 
    * @param position @ref PosIdx index of the face to remove.
    */
-  void remove_maximal_face(pos_index position);
+  void remove_maximal_face(Pos_index position);
   /**
    * @brief Only available if @ref PersistenceMatrixOptions::has_removable_columns is true and,
    * if @ref PersistenceMatrixOptions::has_map_column_container is true or
@@ -330,20 +330,20 @@ class Position_to_index_overlay
    * 
    * @return The maximal dimension.
    */
-  dimension_type get_max_dimension() const;
+  Dimension get_max_dimension() const;
   /**
    * @brief Returns the current number of columns in the matrix.
    * 
    * @return The number of columns.
    */
-  index get_number_of_columns() const;
+  Index get_number_of_columns() const;
   /**
    * @brief Returns the dimension of the given face.
    * 
    * @param position @ref PosIdx index of the face.
    * @return Dimension of the face.
    */
-  dimension_type get_column_dimension(pos_index position) const;
+  Dimension get_column_dimension(Pos_index position) const;
 
   /**
    * @brief Adds column corresponding to @p sourcePosition onto the column corresponding to @p targetPosition.
@@ -355,7 +355,7 @@ class Position_to_index_overlay
    * @param sourcePosition @ref PosIdx index of the source column.
    * @param targetPosition @ref PosIdx index of the target column.
    */
-  void add_to(pos_index sourcePosition, pos_index targetPosition);
+  void add_to(Pos_index sourcePosition, Pos_index targetPosition);
   /**
    * @brief Multiplies the target column with the coefficient and then adds the source column to it.
    * That is: `targetColumn = (targetColumn * coefficient) + sourceColumn`.
@@ -368,9 +368,9 @@ class Position_to_index_overlay
    * @param coefficient Value to multiply.
    * @param targetPosition @ref PosIdx index of the target column.
    */
-  void multiply_target_and_add_to(pos_index sourcePosition, 
-                                  const Field_element_type& coefficient,
-                                  pos_index targetPosition);
+  void multiply_target_and_add_to(Pos_index sourcePosition, 
+                                  const Field_element& coefficient,
+                                  Pos_index targetPosition);
   /**
    * @brief Multiplies the source column with the coefficient before adding it to the target column.
    * That is: `targetColumn += (coefficient * sourceColumn)`. The source column will **not** be modified.
@@ -383,9 +383,9 @@ class Position_to_index_overlay
    * @param sourcePosition @ref PosIdx index of the source column.
    * @param targetPosition @ref PosIdx index of the target column.
    */
-  void multiply_source_and_add_to(const Field_element_type& coefficient, 
-                                  pos_index sourcePosition,
-                                  pos_index targetPosition);
+  void multiply_source_and_add_to(const Field_element& coefficient, 
+                                  Pos_index sourcePosition,
+                                  Pos_index targetPosition);
 
   /**
    * @brief Indicates if the cell at given coordinates has value zero.
@@ -395,7 +395,7 @@ class Position_to_index_overlay
    * @return true If the cell has value zero.
    * @return false Otherwise.
    */
-  bool is_zero_cell(pos_index position, id_index rowIndex) const;
+  bool is_zero_cell(Pos_index position, ID_index rowIndex) const;
   /**
    * @brief Indicates if the column at given index has value zero.
    *
@@ -406,7 +406,7 @@ class Position_to_index_overlay
    * @return true If the column has value zero.
    * @return false Otherwise.
    */
-  bool is_zero_column(pos_index position);
+  bool is_zero_column(Pos_index position);
 
   /**
    * @brief Returns the @ref PosIdx index of the column which has the given @ref rowindex "row index" as pivot.
@@ -415,14 +415,14 @@ class Position_to_index_overlay
    * @param faceIndex @ref rowindex "Row index" of the pivot.
    * @return @ref PosIdx index of the column with the given pivot.
    */
-  pos_index get_column_with_pivot(id_index faceIndex) const;  // assumes that pivot exists
+  Pos_index get_column_with_pivot(ID_index faceIndex) const;  // assumes that pivot exists
   /**
    * @brief Returns the @ref rowindex "row index" of the pivot of the given column.
    * 
    * @param position @ref PosIdx index of the face corresponding to the column.
    * @return The @ref rowindex "row index" of the pivot.
    */
-  id_index get_pivot(pos_index position);
+  ID_index get_pivot(Pos_index position);
 
   /**
    * @brief Resets the matrix to an empty matrix.
@@ -466,7 +466,7 @@ class Position_to_index_overlay
    * @return A reference to the barcode. The barcode is a vector of @ref Matrix::Bar. A bar stores three informations:
    * the @ref PosIdx birth index, the @ref PosIdx death index and the dimension of the bar.
    */
-  const barcode_type& get_current_barcode() const;
+  const Barcode& get_current_barcode() const;
   
   /**
    * @brief Only available if @ref PersistenceMatrixOptions::can_retrieve_representative_cycles is true. Pre-computes
@@ -482,7 +482,7 @@ class Position_to_index_overlay
    * 
    * @return A const reference to the vector of representative cycles.
    */
-  const std::vector<cycle_type>& get_representative_cycles();
+  const std::vector<Cycle>& get_representative_cycles();
   /**
    * @brief Only available if @ref PersistenceMatrixOptions::can_retrieve_representative_cycles is true.
    * Returns the cycle representing the given bar.
@@ -490,7 +490,7 @@ class Position_to_index_overlay
    * @param bar A bar from the current barcode.
    * @return A const reference to the cycle representing @p bar.
    */
-  const cycle_type& get_representative_cycle(const bar_type& bar);
+  const Cycle& get_representative_cycle(const Bar& bar);
   
   /**
    * @brief Only available if @ref PersistenceMatrixOptions::has_vine_update is true.
@@ -501,7 +501,7 @@ class Position_to_index_overlay
    * @return true If the barcode changed from the swap.
    * @return false Otherwise.
    */
-  bool vine_swap_with_z_eq_1_case(pos_index position);
+  bool vine_swap_with_z_eq_1_case(Pos_index position);
   /**
    * @brief Only available if @ref PersistenceMatrixOptions::has_vine_update is true.
    * Does a vine swap between two faces which are consecutive in the filtration. Roughly, if \f$ F \f$ is the current
@@ -515,37 +515,37 @@ class Position_to_index_overlay
    * @return true If the barcode changed from the swap.
    * @return false Otherwise.
    */
-  bool vine_swap(pos_index position);
+  bool vine_swap(Pos_index position);
 
  private:
-  Matrix_type matrix_;                  /**< Interfaced matrix. */
-  std::vector<index> positionToIndex_;  /**< Map from @ref PosIdx index to @ref MatIdx index. */
-  pos_index nextPosition_;              /**< Next unused position. */
-  index nextIndex_;                     /**< Next unused index. */
+  Underlying_matrix matrix_;            /**< Interfaced matrix. */
+  std::vector<Index> positionToIndex_;  /**< Map from @ref PosIdx index to @ref MatIdx index. */
+  Pos_index nextPosition_;              /**< Next unused position. */
+  Index nextIndex_;                     /**< Next unused index. */
 };
 
-template <class Matrix_type, class Master_matrix_type>
-inline Position_to_index_overlay<Matrix_type, Master_matrix_type>::Position_to_index_overlay(
+template <class Underlying_matrix, class Master_matrix>
+inline Position_to_index_overlay<Underlying_matrix, Master_matrix>::Position_to_index_overlay(
     Column_settings* colSettings)
     : matrix_(colSettings), nextPosition_(0), nextIndex_(0) 
 {}
 
-template <class Matrix_type, class Master_matrix_type>
-template <class Boundary_type>
-inline Position_to_index_overlay<Matrix_type, Master_matrix_type>::Position_to_index_overlay(
-    const std::vector<Boundary_type>& orderedBoundaries, Column_settings* colSettings)
+template <class Underlying_matrix, class Master_matrix>
+template <class Boundary_container>
+inline Position_to_index_overlay<Underlying_matrix, Master_matrix>::Position_to_index_overlay(
+    const std::vector<Boundary_container>& orderedBoundaries, Column_settings* colSettings)
     : matrix_(orderedBoundaries, colSettings),
       positionToIndex_(orderedBoundaries.size()),
       nextPosition_(orderedBoundaries.size()),
       nextIndex_(orderedBoundaries.size()) 
 {
-  for (index i = 0; i < orderedBoundaries.size(); i++) {
+  for (Index i = 0; i < orderedBoundaries.size(); i++) {
     positionToIndex_[i] = i;
   }
 }
 
-template <class Matrix_type, class Master_matrix_type>
-inline Position_to_index_overlay<Matrix_type, Master_matrix_type>::Position_to_index_overlay(
+template <class Underlying_matrix, class Master_matrix>
+inline Position_to_index_overlay<Underlying_matrix, Master_matrix>::Position_to_index_overlay(
     unsigned int numberOfColumns, Column_settings* colSettings)
     : matrix_(numberOfColumns, colSettings),
       positionToIndex_(numberOfColumns),
@@ -553,19 +553,19 @@ inline Position_to_index_overlay<Matrix_type, Master_matrix_type>::Position_to_i
       nextIndex_(0) 
 {}
 
-template <class Matrix_type, class Master_matrix_type>
+template <class Underlying_matrix, class Master_matrix>
 template <typename BirthComparatorFunction, typename DeathComparatorFunction>
-inline Position_to_index_overlay<Matrix_type, Master_matrix_type>::Position_to_index_overlay(
+inline Position_to_index_overlay<Underlying_matrix, Master_matrix>::Position_to_index_overlay(
     Column_settings* colSettings, 
     const BirthComparatorFunction& birthComparator, 
     const DeathComparatorFunction& deathComparator)
     : matrix_(colSettings, birthComparator, deathComparator), nextPosition_(0), nextIndex_(0) 
 {}
 
-template <class Matrix_type, class Master_matrix_type>
-template <typename BirthComparatorFunction, typename DeathComparatorFunction, class Boundary_type>
-inline Position_to_index_overlay<Matrix_type, Master_matrix_type>::Position_to_index_overlay(
-    const std::vector<Boundary_type>& orderedBoundaries, 
+template <class Underlying_matrix, class Master_matrix>
+template <typename BirthComparatorFunction, typename DeathComparatorFunction, class Boundary_container>
+inline Position_to_index_overlay<Underlying_matrix, Master_matrix>::Position_to_index_overlay(
+    const std::vector<Boundary_container>& orderedBoundaries, 
     Column_settings* colSettings,
     const BirthComparatorFunction& birthComparator, 
     const DeathComparatorFunction& deathComparator)
@@ -574,14 +574,14 @@ inline Position_to_index_overlay<Matrix_type, Master_matrix_type>::Position_to_i
       nextPosition_(orderedBoundaries.size()),
       nextIndex_(orderedBoundaries.size()) 
 {
-  for (index i = 0; i < orderedBoundaries.size(); i++) {
+  for (Index i = 0; i < orderedBoundaries.size(); i++) {
     positionToIndex_[i] = i;
   }
 }
 
-template <class Matrix_type, class Master_matrix_type>
+template <class Underlying_matrix, class Master_matrix>
 template <typename BirthComparatorFunction, typename DeathComparatorFunction>
-inline Position_to_index_overlay<Matrix_type, Master_matrix_type>::Position_to_index_overlay(
+inline Position_to_index_overlay<Underlying_matrix, Master_matrix>::Position_to_index_overlay(
     unsigned int numberOfColumns, 
     Column_settings* colSettings,
     const BirthComparatorFunction& birthComparator, 
@@ -592,8 +592,8 @@ inline Position_to_index_overlay<Matrix_type, Master_matrix_type>::Position_to_i
       nextIndex_(0) 
 {}
 
-template <class Matrix_type, class Master_matrix_type>
-inline Position_to_index_overlay<Matrix_type, Master_matrix_type>::Position_to_index_overlay(
+template <class Underlying_matrix, class Master_matrix>
+inline Position_to_index_overlay<Underlying_matrix, Master_matrix>::Position_to_index_overlay(
     const Position_to_index_overlay& matrixToCopy, Column_settings* colSettings)
     : matrix_(matrixToCopy.matrix_, colSettings),
       positionToIndex_(matrixToCopy.positionToIndex_),
@@ -601,8 +601,8 @@ inline Position_to_index_overlay<Matrix_type, Master_matrix_type>::Position_to_i
       nextIndex_(matrixToCopy.nextIndex_) 
 {}
 
-template <class Matrix_type, class Master_matrix_type>
-inline Position_to_index_overlay<Matrix_type, Master_matrix_type>::Position_to_index_overlay(
+template <class Underlying_matrix, class Master_matrix>
+inline Position_to_index_overlay<Underlying_matrix, Master_matrix>::Position_to_index_overlay(
     Position_to_index_overlay&& other) noexcept
     : matrix_(std::move(other.matrix_)),
       positionToIndex_(std::move(other.positionToIndex_)),
@@ -610,10 +610,10 @@ inline Position_to_index_overlay<Matrix_type, Master_matrix_type>::Position_to_i
       nextIndex_(std::exchange(other.nextIndex_, 0)) 
 {}
 
-template <class Matrix_type, class Master_matrix_type>
-template <class Boundary_type>
-inline void Position_to_index_overlay<Matrix_type, Master_matrix_type>::insert_boundary(const Boundary_type& boundary,
-                                                                                        dimension_type dim) 
+template <class Underlying_matrix, class Master_matrix>
+template <class Boundary_container>
+inline void Position_to_index_overlay<Underlying_matrix, Master_matrix>::insert_boundary(const Boundary_container& boundary,
+                                                                                        Dimension dim) 
 {
   if (positionToIndex_.size() <= nextPosition_) {
     positionToIndex_.resize(nextPosition_ * 2 + 1);
@@ -624,11 +624,11 @@ inline void Position_to_index_overlay<Matrix_type, Master_matrix_type>::insert_b
   matrix_.insert_boundary(boundary, dim);
 }
 
-template <class Matrix_type, class Master_matrix_type>
-template <class Boundary_type>
-inline void Position_to_index_overlay<Matrix_type, Master_matrix_type>::insert_boundary(id_index faceIndex,
-                                                                                        const Boundary_type& boundary,
-                                                                                        dimension_type dim) 
+template <class Underlying_matrix, class Master_matrix>
+template <class Boundary_container>
+inline void Position_to_index_overlay<Underlying_matrix, Master_matrix>::insert_boundary(ID_index faceIndex,
+                                                                                        const Boundary_container& boundary,
+                                                                                        Dimension dim) 
 {
   if (positionToIndex_.size() <= nextPosition_) {
     positionToIndex_.resize(nextPosition_ * 2 + 1);
@@ -639,51 +639,51 @@ inline void Position_to_index_overlay<Matrix_type, Master_matrix_type>::insert_b
   matrix_.insert_boundary(faceIndex, boundary, dim);
 }
 
-template <class Matrix_type, class Master_matrix_type>
-inline typename Position_to_index_overlay<Matrix_type, Master_matrix_type>::Column_type&
-Position_to_index_overlay<Matrix_type, Master_matrix_type>::get_column(pos_index position) 
+template <class Underlying_matrix, class Master_matrix>
+inline typename Position_to_index_overlay<Underlying_matrix, Master_matrix>::Column&
+Position_to_index_overlay<Underlying_matrix, Master_matrix>::get_column(Pos_index position) 
 {
   return matrix_.get_column(positionToIndex_[position]);
 }
 
-template <class Matrix_type, class Master_matrix_type>
-inline const typename Position_to_index_overlay<Matrix_type, Master_matrix_type>::Column_type&
-Position_to_index_overlay<Matrix_type, Master_matrix_type>::get_column(pos_index position) const 
+template <class Underlying_matrix, class Master_matrix>
+inline const typename Position_to_index_overlay<Underlying_matrix, Master_matrix>::Column&
+Position_to_index_overlay<Underlying_matrix, Master_matrix>::get_column(Pos_index position) const 
 {
   return matrix_.get_column(positionToIndex_[position]);
 }
 
-template <class Matrix_type, class Master_matrix_type>
-inline typename Position_to_index_overlay<Matrix_type, Master_matrix_type>::Row_type&
-Position_to_index_overlay<Matrix_type, Master_matrix_type>::get_row(id_index rowIndex) 
+template <class Underlying_matrix, class Master_matrix>
+inline typename Position_to_index_overlay<Underlying_matrix, Master_matrix>::Row&
+Position_to_index_overlay<Underlying_matrix, Master_matrix>::get_row(ID_index rowIndex) 
 {
   return matrix_.get_row(rowIndex);
 }
 
-template <class Matrix_type, class Master_matrix_type>
-inline const typename Position_to_index_overlay<Matrix_type, Master_matrix_type>::Row_type&
-Position_to_index_overlay<Matrix_type, Master_matrix_type>::get_row(id_index rowIndex) const 
+template <class Underlying_matrix, class Master_matrix>
+inline const typename Position_to_index_overlay<Underlying_matrix, Master_matrix>::Row&
+Position_to_index_overlay<Underlying_matrix, Master_matrix>::get_row(ID_index rowIndex) const 
 {
   return matrix_.get_row(rowIndex);
 }
 
-template <class Matrix_type, class Master_matrix_type>
-inline void Position_to_index_overlay<Matrix_type, Master_matrix_type>::erase_empty_row(id_index rowIndex) 
+template <class Underlying_matrix, class Master_matrix>
+inline void Position_to_index_overlay<Underlying_matrix, Master_matrix>::erase_empty_row(ID_index rowIndex) 
 {
   return matrix_.erase_empty_row(rowIndex);
 }
 
-template <class Matrix_type, class Master_matrix_type>
-inline void Position_to_index_overlay<Matrix_type, Master_matrix_type>::remove_maximal_face(pos_index position) 
+template <class Underlying_matrix, class Master_matrix>
+inline void Position_to_index_overlay<Underlying_matrix, Master_matrix>::remove_maximal_face(Pos_index position) 
 {
   --nextPosition_;
 
-  id_index pivot = matrix_.get_pivot(positionToIndex_[position]);
-  std::vector<index> columnsToSwap(nextPosition_ - position);
+  ID_index pivot = matrix_.get_pivot(positionToIndex_[position]);
+  std::vector<Index> columnsToSwap(nextPosition_ - position);
 
   if (nextPosition_ != position) {
     positionToIndex_[position] = positionToIndex_[position + 1];
-    for (pos_index p = position + 1; p < nextPosition_; ++p) {
+    for (Pos_index p = position + 1; p < nextPosition_; ++p) {
       columnsToSwap[p - position - 1] = positionToIndex_[p];
       positionToIndex_[p] = positionToIndex_[p + 1];
     }
@@ -693,97 +693,97 @@ inline void Position_to_index_overlay<Matrix_type, Master_matrix_type>::remove_m
   matrix_.remove_maximal_face(pivot, columnsToSwap);
 }
 
-template <class Matrix_type, class Master_matrix_type>
-inline void Position_to_index_overlay<Matrix_type, Master_matrix_type>::remove_last() 
+template <class Underlying_matrix, class Master_matrix>
+inline void Position_to_index_overlay<Underlying_matrix, Master_matrix>::remove_last() 
 {
   --nextPosition_;
-  if constexpr (Master_matrix_type::Option_list::has_vine_update) {
-    std::vector<index> columnsToSwap;
+  if constexpr (Master_matrix::Option_list::has_vine_update) {
+    std::vector<Index> columnsToSwap;
     matrix_.remove_maximal_face(matrix_.get_pivot(positionToIndex_[nextPosition_]), columnsToSwap);
   } else {
     matrix_.remove_last();  // linear with vine updates, so it is better to use remove_maximal_face
   }
 }
 
-template <class Matrix_type, class Master_matrix_type>
-inline typename Position_to_index_overlay<Matrix_type, Master_matrix_type>::dimension_type
-Position_to_index_overlay<Matrix_type, Master_matrix_type>::get_max_dimension() const 
+template <class Underlying_matrix, class Master_matrix>
+inline typename Position_to_index_overlay<Underlying_matrix, Master_matrix>::Dimension
+Position_to_index_overlay<Underlying_matrix, Master_matrix>::get_max_dimension() const 
 {
   return matrix_.get_max_dimension();
 }
 
-template <class Matrix_type, class Master_matrix_type>
-inline typename Position_to_index_overlay<Matrix_type, Master_matrix_type>::index
-Position_to_index_overlay<Matrix_type, Master_matrix_type>::get_number_of_columns() const 
+template <class Underlying_matrix, class Master_matrix>
+inline typename Position_to_index_overlay<Underlying_matrix, Master_matrix>::Index
+Position_to_index_overlay<Underlying_matrix, Master_matrix>::get_number_of_columns() const 
 {
   return matrix_.get_number_of_columns();
 }
 
-template <class Matrix_type, class Master_matrix_type>
-inline typename Position_to_index_overlay<Matrix_type, Master_matrix_type>::dimension_type
-Position_to_index_overlay<Matrix_type, Master_matrix_type>::get_column_dimension(pos_index position) const 
+template <class Underlying_matrix, class Master_matrix>
+inline typename Position_to_index_overlay<Underlying_matrix, Master_matrix>::Dimension
+Position_to_index_overlay<Underlying_matrix, Master_matrix>::get_column_dimension(Pos_index position) const 
 {
   return matrix_.get_column_dimension(positionToIndex_[position]);
 }
 
-template <class Matrix_type, class Master_matrix_type>
-inline void Position_to_index_overlay<Matrix_type, Master_matrix_type>::add_to(pos_index sourcePosition,
-                                                                               pos_index targetPosition) 
+template <class Underlying_matrix, class Master_matrix>
+inline void Position_to_index_overlay<Underlying_matrix, Master_matrix>::add_to(Pos_index sourcePosition,
+                                                                               Pos_index targetPosition) 
 {
   return matrix_.add_to(positionToIndex_[sourcePosition], positionToIndex_[targetPosition]);
 }
 
-template <class Matrix_type, class Master_matrix_type>
-inline void Position_to_index_overlay<Matrix_type, Master_matrix_type>::multiply_target_and_add_to(
-    pos_index sourcePosition, const Field_element_type& coefficient, pos_index targetPosition) 
+template <class Underlying_matrix, class Master_matrix>
+inline void Position_to_index_overlay<Underlying_matrix, Master_matrix>::multiply_target_and_add_to(
+    Pos_index sourcePosition, const Field_element& coefficient, Pos_index targetPosition) 
 {
   return matrix_.multiply_target_and_add_to(positionToIndex_[sourcePosition], 
                                             coefficient,
                                             positionToIndex_[targetPosition]);
 }
 
-template <class Matrix_type, class Master_matrix_type>
-inline void Position_to_index_overlay<Matrix_type, Master_matrix_type>::multiply_source_and_add_to(
-    const Field_element_type& coefficient, pos_index sourcePosition, pos_index targetPosition) 
+template <class Underlying_matrix, class Master_matrix>
+inline void Position_to_index_overlay<Underlying_matrix, Master_matrix>::multiply_source_and_add_to(
+    const Field_element& coefficient, Pos_index sourcePosition, Pos_index targetPosition) 
 {
   return matrix_.multiply_source_and_add_to(coefficient, 
                                             positionToIndex_[sourcePosition],
                                             positionToIndex_[targetPosition]);
 }
 
-template <class Matrix_type, class Master_matrix_type>
-inline bool Position_to_index_overlay<Matrix_type, Master_matrix_type>::is_zero_cell(pos_index position,
-                                                                                     id_index rowIndex) const 
+template <class Underlying_matrix, class Master_matrix>
+inline bool Position_to_index_overlay<Underlying_matrix, Master_matrix>::is_zero_cell(Pos_index position,
+                                                                                     ID_index rowIndex) const 
 {
   return matrix_.is_zero_cell(positionToIndex_[position], rowIndex);
 }
 
-template <class Matrix_type, class Master_matrix_type>
-inline bool Position_to_index_overlay<Matrix_type, Master_matrix_type>::is_zero_column(pos_index position) 
+template <class Underlying_matrix, class Master_matrix>
+inline bool Position_to_index_overlay<Underlying_matrix, Master_matrix>::is_zero_column(Pos_index position) 
 {
   return matrix_.is_zero_column(positionToIndex_[position]);
 }
 
-template <class Matrix_type, class Master_matrix_type>
-inline typename Position_to_index_overlay<Matrix_type, Master_matrix_type>::pos_index
-Position_to_index_overlay<Matrix_type, Master_matrix_type>::get_column_with_pivot(id_index faceIndex) const 
+template <class Underlying_matrix, class Master_matrix>
+inline typename Position_to_index_overlay<Underlying_matrix, Master_matrix>::Pos_index
+Position_to_index_overlay<Underlying_matrix, Master_matrix>::get_column_with_pivot(ID_index faceIndex) const 
 {
-  index id = matrix_.get_column_with_pivot(faceIndex);
-  pos_index i = 0;
+  Index id = matrix_.get_column_with_pivot(faceIndex);
+  Pos_index i = 0;
   while (positionToIndex_[i] != id) ++i;
   return i;
 }
 
-template <class Matrix_type, class Master_matrix_type>
-inline typename Position_to_index_overlay<Matrix_type, Master_matrix_type>::id_index
-Position_to_index_overlay<Matrix_type, Master_matrix_type>::get_pivot(pos_index position) 
+template <class Underlying_matrix, class Master_matrix>
+inline typename Position_to_index_overlay<Underlying_matrix, Master_matrix>::ID_index
+Position_to_index_overlay<Underlying_matrix, Master_matrix>::get_pivot(Pos_index position) 
 {
   return matrix_.get_pivot(positionToIndex_[position]);
 }
 
-template <class Matrix_type, class Master_matrix_type>
-inline Position_to_index_overlay<Matrix_type, Master_matrix_type>&
-Position_to_index_overlay<Matrix_type, Master_matrix_type>::operator=(const Position_to_index_overlay& other) 
+template <class Underlying_matrix, class Master_matrix>
+inline Position_to_index_overlay<Underlying_matrix, Master_matrix>&
+Position_to_index_overlay<Underlying_matrix, Master_matrix>::operator=(const Position_to_index_overlay& other) 
 {
   matrix_ = other.matrix_;
   positionToIndex_ = other.positionToIndex_;
@@ -793,43 +793,43 @@ Position_to_index_overlay<Matrix_type, Master_matrix_type>::operator=(const Posi
   return *this;
 }
 
-template <class Matrix_type, class Master_matrix_type>
-inline void Position_to_index_overlay<Matrix_type, Master_matrix_type>::print() 
+template <class Underlying_matrix, class Master_matrix>
+inline void Position_to_index_overlay<Underlying_matrix, Master_matrix>::print() 
 {
   return matrix_.print();
 }
 
-template <class Matrix_type, class Master_matrix_type>
-inline const typename Position_to_index_overlay<Matrix_type, Master_matrix_type>::barcode_type&
-Position_to_index_overlay<Matrix_type, Master_matrix_type>::get_current_barcode() const 
+template <class Underlying_matrix, class Master_matrix>
+inline const typename Position_to_index_overlay<Underlying_matrix, Master_matrix>::Barcode&
+Position_to_index_overlay<Underlying_matrix, Master_matrix>::get_current_barcode() const 
 {
   return matrix_.get_current_barcode();
 }
 
-template <class Matrix_type, class Master_matrix_type>
-inline void Position_to_index_overlay<Matrix_type, Master_matrix_type>::update_representative_cycles() 
+template <class Underlying_matrix, class Master_matrix>
+inline void Position_to_index_overlay<Underlying_matrix, Master_matrix>::update_representative_cycles() 
 {
   matrix_.update_representative_cycles();
 }
 
-template <class Matrix_type, class Master_matrix_type>
-inline const std::vector<typename Position_to_index_overlay<Matrix_type, Master_matrix_type>::cycle_type>&
-Position_to_index_overlay<Matrix_type, Master_matrix_type>::get_representative_cycles() 
+template <class Underlying_matrix, class Master_matrix>
+inline const std::vector<typename Position_to_index_overlay<Underlying_matrix, Master_matrix>::Cycle>&
+Position_to_index_overlay<Underlying_matrix, Master_matrix>::get_representative_cycles() 
 {
   return matrix_.get_representative_cycles();
 }
 
-template <class Matrix_type, class Master_matrix_type>
-inline const typename Position_to_index_overlay<Matrix_type, Master_matrix_type>::cycle_type&
-Position_to_index_overlay<Matrix_type, Master_matrix_type>::get_representative_cycle(const bar_type& bar) 
+template <class Underlying_matrix, class Master_matrix>
+inline const typename Position_to_index_overlay<Underlying_matrix, Master_matrix>::Cycle&
+Position_to_index_overlay<Underlying_matrix, Master_matrix>::get_representative_cycle(const Bar& bar) 
 {
   return matrix_.get_representative_cycle(bar);
 }
 
-template <class Matrix_type, class Master_matrix_type>
-inline bool Position_to_index_overlay<Matrix_type, Master_matrix_type>::vine_swap_with_z_eq_1_case(pos_index position) 
+template <class Underlying_matrix, class Master_matrix>
+inline bool Position_to_index_overlay<Underlying_matrix, Master_matrix>::vine_swap_with_z_eq_1_case(Pos_index position) 
 {
-  index next = matrix_.vine_swap_with_z_eq_1_case(positionToIndex_[position], positionToIndex_[position + 1]);
+  Index next = matrix_.vine_swap_with_z_eq_1_case(positionToIndex_[position], positionToIndex_[position + 1]);
   if (next == positionToIndex_[position]) {
     std::swap(positionToIndex_[position], positionToIndex_[position + 1]);
     return true;
@@ -838,10 +838,10 @@ inline bool Position_to_index_overlay<Matrix_type, Master_matrix_type>::vine_swa
   return false;
 }
 
-template <class Matrix_type, class Master_matrix_type>
-inline bool Position_to_index_overlay<Matrix_type, Master_matrix_type>::vine_swap(pos_index position) 
+template <class Underlying_matrix, class Master_matrix>
+inline bool Position_to_index_overlay<Underlying_matrix, Master_matrix>::vine_swap(Pos_index position) 
 {
-  index next = matrix_.vine_swap(positionToIndex_[position], positionToIndex_[position + 1]);
+  Index next = matrix_.vine_swap(positionToIndex_[position], positionToIndex_[position + 1]);
   if (next == positionToIndex_[position]) {
     std::swap(positionToIndex_[position], positionToIndex_[position + 1]);
     return true;

--- a/src/Persistence_matrix/include/gudhi/Persistence_matrix/ru_matrix.h
+++ b/src/Persistence_matrix/include/gudhi/Persistence_matrix/ru_matrix.h
@@ -32,64 +32,63 @@ namespace persistence_matrix {
  * complex in order to compute its persistent homology, as well as representative cycles.
  * Supports vineyards (see @cite vineyards) and the removal of maximal faces while maintaining
  * a valid barcode. Provides an access to its columns and rows.
- * 
+ *
  * @tparam Master_matrix An instantiation of @ref Matrix from which all types and options are deduced.
  */
 template <class Master_matrix>
 class RU_matrix : public Master_matrix::RU_pairing_option,
                   public Master_matrix::RU_vine_swap_option,
-                  public Master_matrix::RU_representative_cycles_option 
+                  public Master_matrix::RU_representative_cycles_option
 {
  public:
   /**
    * @brief Field operators class. Necessary only if @ref PersistenceMatrixOptions::is_z2 is false.
    */
   using Field_operators = typename Master_matrix::Field_operators;
-  using Field_element_type = typename Master_matrix::element_type;    /**< Type of an field element. */
-  using Column_type = typename Master_matrix::Column_type;            /**< Column type. */
-  using Row_type = typename Master_matrix::Row_type;                  /**< Row type,
-                                                                           only necessary with row access option. */
-  using Cell_constructor = typename Master_matrix::Cell_constructor;  /**< Factory of @ref Cell classes. */
-  using Column_settings = typename Master_matrix::Column_settings;    /**< Structure giving access to the columns to
-                                                                           necessary external classes. */
-  using boundary_type = typename Master_matrix::boundary_type;        /**< Type of an input column. */
-  using index = typename Master_matrix::index;                        /**< @ref MatIdx index type. */
-  using id_index = typename Master_matrix::id_index;                  /**< @ref IDIdx index type. */
-  using pos_index = typename Master_matrix::pos_index;                /**< @ref PosIdx index type. */
-  using dimension_type = typename Master_matrix::dimension_type;      /**< Dimension value type. */
+  using Field_element = typename Master_matrix::Element;             /**< Type of an field element. */
+  using Column = typename Master_matrix::Column;                     /**< Column type. */
+  using Row = typename Master_matrix::Row;                           /**< Row type,
+                                                                          only necessary with row access option. */
+  using Cell_constructor = typename Master_matrix::Cell_constructor; /**< Factory of @ref Cell classes. */
+  using Column_settings = typename Master_matrix::Column_settings;   /**< Structure giving access to the columns to
+                                                                          necessary external classes. */
+  using Boundary = typename Master_matrix::Boundary;                 /**< Type of an input column. */
+  using Index = typename Master_matrix::Index;                       /**< @ref MatIdx index type. */
+  using ID_index = typename Master_matrix::ID_index;                 /**< @ref IDIdx index type. */
+  using Pos_index = typename Master_matrix::Pos_index;               /**< @ref PosIdx index type. */
+  using Dimension = typename Master_matrix::Dimension;               /**< Dimension value type. */
 
   /**
    * @brief Constructs an empty matrix.
-   * 
+   *
    * @param colSettings Pointer to an existing setting structure for the columns. The structure should contain all
    * the necessary external classes specifically necessary for the choosen column type, such as custom allocators.
    */
   RU_matrix(Column_settings* colSettings);
   /**
-   * @brief Constructs a new matrix from the given ranges of @ref Matrix::cell_rep_type. Each range corresponds to a
-   * column (the order of the ranges are preserved). The content of the ranges is assumed to be sorted by increasing
-   * IDs. The IDs of the simplices are also assumed to be consecutive, ordered by filtration value, starting with 0. 
-   * 
-   * @tparam Boundary_type Range type for @ref Matrix::cell_rep_type ranges.
+   * @brief Constructs a new matrix from the given ranges of @ref Matrix::Cell_representative. Each range corresponds to
+   * a column (the order of the ranges are preserved). The content of the ranges is assumed to be sorted by increasing
+   * IDs. The IDs of the simplices are also assumed to be consecutive, ordered by filtration value, starting with 0.
+   *
+   * @tparam Boundary_container Range type for @ref Matrix::Cell_representative ranges.
    * Assumed to have a begin(), end() and size() method.
-   * @param orderedBoundaries Range of boundaries: @p orderedBoundaries is interpreted as a boundary matrix of a 
-   * filtered **simplicial** complex, whose boundaries are ordered by filtration order. 
+   * @param orderedBoundaries Range of boundaries: @p orderedBoundaries is interpreted as a boundary matrix of a
+   * filtered **simplicial** complex, whose boundaries are ordered by filtration order.
    * Therefore, `orderedBoundaries[i]` should store the boundary of the \f$ i^{th} \f$ simplex in the filtration,
    * as an ordered list of indices of its facets (again those indices correspond to their respective position
-   * in the matrix). That is why the indices of the simplices are assumed to be consecutive and starting with 0 
-   * (an empty boundary is interpreted as a vertex boundary and not as a non existing simplex). 
-   * All dimensions up to the maximal dimension of interest have to be present. If only a higher dimension is of 
+   * in the matrix). That is why the indices of the simplices are assumed to be consecutive and starting with 0
+   * (an empty boundary is interpreted as a vertex boundary and not as a non existing simplex).
+   * All dimensions up to the maximal dimension of interest have to be present. If only a higher dimension is of
    * interest and not everything should be stored, then use the @ref insert_boundary method instead (after creating the
    * matrix with the @ref RU_matrix(unsigned int, Column_settings*) constructor preferably).
    * @param colSettings Pointer to an existing setting structure for the columns. The structure should contain all
    * the necessary external classes specifically necessary for the choosen column type, such as custom allocators.
    */
-  template <class Boundary_type = boundary_type>
-  RU_matrix(const std::vector<Boundary_type>& orderedBoundaries, 
-            Column_settings* colSettings);
+  template <class Boundary_container = Boundary>
+  RU_matrix(const std::vector<Boundary_container>& orderedBoundaries, Column_settings* colSettings);
   /**
    * @brief Constructs a new empty matrix and reserves space for the given number of columns.
-   * 
+   *
    * @param numberOfColumns Number of columns to reserve space for.
    * @param colSettings Pointer to an existing setting structure for the columns. The structure should contain all
    * the necessary external classes specifically necessary for the choosen column type, such as custom allocators.
@@ -98,17 +97,16 @@ class RU_matrix : public Master_matrix::RU_pairing_option,
   /**
    * @brief Copy constructor. If @p colSettings is not a null pointer, its value is kept
    * instead of the one in the copied matrix.
-   * 
+   *
    * @param matrixToCopy Matrix to copy.
    * @param colSettings Either a pointer to an existing setting structure for the columns or a null pointer.
    * The structure should contain all the necessary external classes specifically necessary for the choosen column type,
    * such as custom allocators. If null pointer, the pointer stored in @p matrixToCopy is used instead.
    */
-  RU_matrix(const RU_matrix& matrixToCopy, 
-            Column_settings* colSettings = nullptr);
+  RU_matrix(const RU_matrix& matrixToCopy, Column_settings* colSettings = nullptr);
   /**
    * @brief Move constructor.
-   * 
+   *
    * @param other Matrix to move.
    */
   RU_matrix(RU_matrix&& other) noexcept;
@@ -118,21 +116,22 @@ class RU_matrix : public Master_matrix::RU_pairing_option,
    * This means that it is assumed that this method is called on boundaries in the order of the filtration.
    * It also assumes that the faces in the given boundary are identified by their relative position in the filtration,
    * starting at 0. If it is not the case, use the other
-   * @ref insert_boundary(id_index, const Boundary_type&, dimension_type) "insert_boundary" instead by indicating the
+   * @ref insert_boundary(ID_index, const Boundary_container&, Dimension) "insert_boundary" instead by indicating the
    * face ID used in the boundaries when the face is inserted.
    *
    * Different to the constructor, the boundaries do not have to come from a simplicial complex, but also from
    * a more general cell complex. This includes cubical complexes or Morse complexes for example.
    *
    * At the insertion, the boundary is stored in its reduced form and the barcode, if enabled, is updated.
-   * 
-   * @tparam Boundary_type Range of @ref Matrix::cell_rep_type. Assumed to have a begin(), end() and size() method.
+   *
+   * @tparam Boundary_container Range of @ref Matrix::Cell_representative. Assumed to have a begin(), end() and size()
+   * method.
    * @param boundary Boundary generating the new column. The content should be ordered by ID.
-   * @param dim Dimension of the face whose boundary is given. If the complex is simplicial, 
+   * @param dim Dimension of the face whose boundary is given. If the complex is simplicial,
    * this parameter can be omitted as it can be deduced from the size of the boundary.
    */
-  template <class Boundary_type = boundary_type>
-  void insert_boundary(const Boundary_type& boundary, dimension_type dim = -1);
+  template <class Boundary_container = Boundary>
+  void insert_boundary(const Boundary_container& boundary, Dimension dim = -1);
   /**
    * @brief It does the same as the other version, but allows the boundary faces to be identified without restrictions
    * except that all IDs have to be strictly increasing in the order of filtration. Note that you should avoid then
@@ -140,17 +139,18 @@ class RU_matrix : public Master_matrix::RU_pairing_option,
    *
    * As a face has to be inserted before one of its cofaces in a valid filtration (recall that it is assumed that
    * the faces are inserted by order of filtration), it is sufficient to indicate the ID of the face being inserted.
-   * 
-   * @tparam Boundary_type Range of @ref Matrix::cell_rep_type. Assumed to have a begin(), end() and size() method.
+   *
+   * @tparam Boundary_container Range of @ref Matrix::Cell_representative. Assumed to have a begin(), end() and size()
+   * method.
    * @param faceIndex @ref IDIdx index to use to identify the new face.
-   * @param boundary Boundary generating the new column. The indices of the boundary have to correspond to the 
-   * @p faceIndex values of precedent calls of the method for the corresponding faces and should be ordered in 
+   * @param boundary Boundary generating the new column. The indices of the boundary have to correspond to the
+   * @p faceIndex values of precedent calls of the method for the corresponding faces and should be ordered in
    * increasing order.
-   * @param dim Dimension of the face whose boundary is given. If the complex is simplicial, 
+   * @param dim Dimension of the face whose boundary is given. If the complex is simplicial,
    * this parameter can be omitted as it can be deduced from the size of the boundary.
    */
-  template <class Boundary_type = boundary_type>
-  void insert_boundary(id_index faceIndex, const Boundary_type& boundary, dimension_type dim = -1);
+  template <class Boundary_container = Boundary>
+  void insert_boundary(ID_index faceIndex, const Boundary_container& boundary, Dimension dim = -1);
   /**
    * @brief Returns the column at the given @ref MatIdx index in \f$ R \f$ if @p inR is true and
    * in \f$ U \f$ if @p inR is false.
@@ -159,13 +159,13 @@ class RU_matrix : public Master_matrix::RU_pairing_option,
    * Note that before returning the column, all column cells can eventually be reordered, if lazy swaps occurred.
    * It is therefore recommended to avoid calling @ref get_column between vine swaps, otherwise the benefits
    * of the the laziness is lost.
-   * 
+   *
    * @param columnIndex @ref MatIdx index of the column to return.
    * @param inR If true, returns the column in \f$ R \f$, if false, returns the column in \f$ U \f$.
    * Default value: true.
    * @return Reference to the column.
    */
-  Column_type& get_column(index columnIndex, bool inR = true);
+  Column& get_column(Index columnIndex, bool inR = true);
   /**
    * @brief Returns the row at the given @ref rowindex "row index" in \f$ R \f$ if @p inR is true and
    * in \f$ U \f$ if @p inR is false.
@@ -174,13 +174,13 @@ class RU_matrix : public Master_matrix::RU_pairing_option,
    * Note that before returning the row, all column cells can eventually be reordered, if lazy swaps occurred.
    * It is therefore recommended to avoid calling @ref get_row between vine swaps, otherwise the benefits
    * of the the laziness is lost.
-   * 
+   *
    * @param rowIndex @ref rowindex "Row index" of the row to return.
    * @param inR If true, returns the row in \f$ R \f$, if false, returns the row in \f$ U \f$.
    * Default value: true.
    * @return Reference to the row.
    */
-  Row_type& get_row(index rowIndex, bool inR = true);
+  Row& get_row(Index rowIndex, bool inR = true);
   /**
    * @brief If @ref PersistenceMatrixOptions::has_row_access and @ref PersistenceMatrixOptions::has_removable_rows
    * are true: assumes that the row is empty in \f$ R \f$ and removes it from \f$ R \f$. If the matrix is valid,
@@ -194,11 +194,11 @@ class RU_matrix : public Master_matrix::RU_pairing_option,
    * fault when the column cells are destroyed later. The row access is just meant as a "read only" access to the
    * rows and the @ref erase_empty_row method just as a way to specify that a row is empty and can therefore be removed
    * from dictionaries. This allows to avoid testing the emptiness of a row at each column cell removal, what can
-   * be quite frequent. 
-   * 
+   * be quite frequent.
+   *
    * @param rowIndex @ref rowindex "Row index" of the empty row.
    */
-  void erase_empty_row(index rowIndex);
+  void erase_empty_row(Index rowIndex);
   /**
    * @brief Only available if @ref PersistenceMatrixOptions::has_removable_columns and
    * @ref PersistenceMatrixOptions::has_vine_update are true.
@@ -208,10 +208,10 @@ class RU_matrix : public Master_matrix::RU_pairing_option,
    * Also updates the barcode if it is stored.
    *
    * See also @ref remove_last.
-   * 
+   *
    * @param columnIndex @ref MatIdx index of the face to remove.
    */
-  void remove_maximal_face(index columnIndex);
+  void remove_maximal_face(Index columnIndex);
   /**
    * @brief Only available if @ref PersistenceMatrixOptions::has_removable_columns is true.
    * Removes the last face in the filtration from the matrix and updates the barcode if it is stored.
@@ -223,23 +223,23 @@ class RU_matrix : public Master_matrix::RU_pairing_option,
   /**
    * @brief Returns the maximal dimension of a face stored in the matrix.
    * Only available if @ref PersistenceMatrixOptions::has_matrix_maximal_dimension_access is true.
-   * 
+   *
    * @return The maximal dimension.
    */
-  dimension_type get_max_dimension() const;
+  Dimension get_max_dimension() const;
   /**
    * @brief Returns the current number of columns in the matrix.
-   * 
+   *
    * @return The number of columns.
    */
-  index get_number_of_columns() const;
+  Index get_number_of_columns() const;
   /**
    * @brief Returns the dimension of the given column.
-   * 
+   *
    * @param columnIndex @ref MatIdx index of the column representing the face.
    * @return Dimension of the face.
    */
-  dimension_type get_column_dimension(index columnIndex) const;
+  Dimension get_column_dimension(Index columnIndex) const;
 
   /**
    * @brief Adds column at @p sourceColumnIndex onto the column at @p targetColumnIndex in the matrix.
@@ -247,11 +247,11 @@ class RU_matrix : public Master_matrix::RU_pairing_option,
    * @warning They will be no verification to ensure that the addition makes sense for the validity of a
    * boundary matrix of a filtered complex. For example, a right-to-left addition could corrupt the computation
    * of the barcode if done blindly. So should be used with care.
-   * 
+   *
    * @param sourceColumnIndex @ref MatIdx index of the source column.
    * @param targetColumnIndex @ref MatIdx index of the target column.
    */
-  void add_to(index sourceColumnIndex, index targetColumnIndex);
+  void add_to(Index sourceColumnIndex, Index targetColumnIndex);
   /**
    * @brief Multiplies the target column with the coefficient and then adds the source column to it.
    * That is: `targetColumn = (targetColumn * coefficient) + sourceColumn`.
@@ -259,14 +259,12 @@ class RU_matrix : public Master_matrix::RU_pairing_option,
    * @warning They will be no verification to ensure that the addition makes sense for the validity of a
    * boundary matrix of a filtered complex. For example, a right-to-left addition could corrupt the computation
    * of the barcode if done blindly. So should be used with care.
-   * 
+   *
    * @param sourceColumnIndex @ref MatIdx index of the source column.
    * @param coefficient Value to multiply.
    * @param targetColumnIndex @ref MatIdx index of the target column.
    */
-  void multiply_target_and_add_to(index sourceColumnIndex, 
-                                  const Field_element_type& coefficient,
-                                  index targetColumnIndex);
+  void multiply_target_and_add_to(Index sourceColumnIndex, const Field_element& coefficient, Index targetColumnIndex);
   /**
    * @brief Multiplies the source column with the coefficient before adding it to the target column.
    * That is: `targetColumn += (coefficient * sourceColumn)`. The source column will **not** be modified.
@@ -274,40 +272,38 @@ class RU_matrix : public Master_matrix::RU_pairing_option,
    * @warning They will be no verification to ensure that the addition makes sense for the validity of a
    * boundary matrix of a filtered complex. For example, a right-to-left addition could corrupt the computation
    * of the barcode if done blindly. So should be used with care.
-   * 
+   *
    * @param coefficient Value to multiply.
    * @param sourceColumnIndex @ref MatIdx index of the source column.
    * @param targetColumnIndex @ref MatIdx index of the target column.
    */
-  void multiply_source_and_add_to(const Field_element_type& coefficient, 
-                                  index sourceColumnIndex,
-                                  index targetColumnIndex);
+  void multiply_source_and_add_to(const Field_element& coefficient, Index sourceColumnIndex, Index targetColumnIndex);
 
   /**
    * @brief Zeroes the cell at the given coordinates in \f$ R \f$ if @p inR is true or in
    * \f$ U \f$ if @p inR is false. Should be used with care to not destroy the validity of the persistence
    * related properties of the matrix.
-   * 
+   *
    * @param columnIndex @ref MatIdx index of the column of the cell.
    * @param rowIndex @ref rowindex "Row index" of the row of the cell.
    * @param inR Boolean indicating in which matrix to zero: if true in \f$ R \f$ and if false in \f$ U \f$.
    * Default value: true.
    */
-  void zero_cell(index columnIndex, index rowIndex, bool inR = true);
+  void zero_cell(Index columnIndex, Index rowIndex, bool inR = true);
   /**
    * @brief Zeroes the column at the given index in \f$ R \f$ if @p inR is true or in
    * \f$ U \f$ if @p inR is false. Should be used with care to not destroy the validity of the persistence
    * related properties of the matrix.
-   * 
+   *
    * @param columnIndex @ref MatIdx index of the column to zero.
    * @param inR Boolean indicating in which matrix to zero: if true in \f$ R \f$ and if false in \f$ U \f$.
    * Default value: true.
    */
-  void zero_column(index columnIndex, bool inR = true);
+  void zero_column(Index columnIndex, bool inR = true);
   /**
    * @brief Indicates if the cell at given coordinates has value zero in \f$ R \f$
    * if @p inR is true or in \f$ U \f$ if @p inR is false.
-   * 
+   *
    * @param columnIndex @ref MatIdx index of the column of the cell.
    * @param rowIndex @ref rowindex "Row index" of the row of the cell.
    * @param inR Boolean indicating in which matrix to look: if true in \f$ R \f$ and if false in \f$ U \f$.
@@ -315,40 +311,40 @@ class RU_matrix : public Master_matrix::RU_pairing_option,
    * @return true If the cell has value zero.
    * @return false Otherwise.
    */
-  bool is_zero_cell(index columnIndex, index rowIndex, bool inR = true) const;
+  bool is_zero_cell(Index columnIndex, Index rowIndex, bool inR = true) const;
   /**
    * @brief Indicates if the column at given index has value zero in \f$ R \f$
    * if @p inR is true or in \f$ U \f$ if @p inR is false.
    *
    * Note that if @p inR is false, this method should usually return false.
-   * 
+   *
    * @param columnIndex @ref MatIdx index of the column.
    * @param inR Boolean indicating in which matrix to look: if true in \f$ R \f$ and if false in \f$ U \f$.
    * Default value: true.
    * @return true If the column has value zero.
    * @return false Otherwise.
    */
-  bool is_zero_column(index columnIndex, bool inR = true);
+  bool is_zero_column(Index columnIndex, bool inR = true);
 
   /**
    * @brief Returns the @ref MatIdx index of the column which has the given @ref rowindex "row index" as pivot in
    * \f$ R \f$. Assumes that the pivot exists.
-   * 
+   *
    * @param faceIndex @ref rowindex "Row index" of the pivot.
    * @return @ref MatIdx index of the column in \f$ R \f$ with the given pivot.
    */
-  index get_column_with_pivot(index faceIndex) const;
+  Index get_column_with_pivot(Index faceIndex) const;
   /**
    * @brief Returns the @ref rowindex "row index" of the pivot of the given column in \f$ R \f$.
-   * 
+   *
    * @param columnIndex @ref MatIdx index of the column in \f$ R \f$.
    * @return The @ref rowindex "row index" of the pivot.
    */
-  index get_pivot(index columnIndex);
+  Index get_pivot(Index columnIndex);
 
   /**
    * @brief Resets the matrix to an empty matrix.
-   * 
+   *
    * @param colSettings Pointer to an existing setting structure for the columns. The structure should contain all
    * the necessary external classes specifically necessary for the choosen column type, such as custom allocators.
    */
@@ -357,7 +353,7 @@ class RU_matrix : public Master_matrix::RU_pairing_option,
     mirrorMatrixU_.reset(colSettings);
     pivotToColumnIndex_.clear();
     nextEventIndex_ = 0;
-    if constexpr (!Master_matrix::Option_list::is_z2){
+    if constexpr (!Master_matrix::Option_list::is_z2) {
       operators_ = &(colSettings->operators);
     }
   }
@@ -386,68 +382,68 @@ class RU_matrix : public Master_matrix::RU_pairing_option,
   void print();  // for debug
 
  private:
-  using swap_opt = typename Master_matrix::RU_vine_swap_option;
-  using pair_opt = typename Master_matrix::RU_pairing_option;
-  using rep_opt = typename Master_matrix::RU_representative_cycles_option;
-  using dictionary_type = typename Master_matrix::template dictionary_type<index>;
-  using barcode_type = typename Master_matrix::barcode_type;
-  using bar_dictionary_type = typename Master_matrix::bar_dictionary_type;
-  using r_matrix_type = typename Master_matrix::Boundary_matrix_type;
-  using u_matrix_type = typename Master_matrix::Base_matrix_type;
+  using Swap_opt = typename Master_matrix::RU_vine_swap_option;
+  using Pair_opt = typename Master_matrix::RU_pairing_option;
+  using Rep_opt = typename Master_matrix::RU_representative_cycles_option;
+  using Dictionary = typename Master_matrix::template Dictionary<Index>;
+  using Barcode = typename Master_matrix::Barcode;
+  using Bar_dictionary = typename Master_matrix::Bar_dictionary;
+  using R_matrix = typename Master_matrix::Master_boundary_matrix;
+  using U_matrix = typename Master_matrix::Master_base_matrix;
 
-  friend rep_opt;   // direct access to the two matrices
-  friend swap_opt;  // direct access to the two matrices
+  friend Rep_opt;   // direct access to the two matrices
+  friend Swap_opt;  // direct access to the two matrices
 
-  r_matrix_type reducedMatrixR_;        /**< R. */
+  R_matrix reducedMatrixR_;       /**< R. */
   // TODO: make U not accessible by default and add option to enable access? Inaccessible, it
   // needs less options and we could avoid some ifs.
-  u_matrix_type mirrorMatrixU_;         /**< U. */
-  dictionary_type pivotToColumnIndex_; /**< Map from pivot row index to column @ref MatIdx index. */
-  pos_index nextEventIndex_;            /**< Next birth or death index. */
-  Field_operators* operators_;          /**< Field operators,
-                                             can be nullptr if @ref PersistenceMatrixOptions::is_z2 is true. */
+  U_matrix mirrorMatrixU_;        /**< U. */
+  Dictionary pivotToColumnIndex_; /**< Map from pivot row index to column @ref MatIdx index. */
+  Pos_index nextEventIndex_;      /**< Next birth or death index. */
+  Field_operators* operators_;    /**< Field operators,
+                                       can be nullptr if @ref PersistenceMatrixOptions::is_z2 is true. */
 
-  void _insert_boundary(index currentIndex);
+  void _insert_boundary(Index currentIndex);
   void _initialize_U();
   void _reduce();
-  void _reduce_last_column(index lastIndex);
-  void _reduce_column(index target, index eventIndex);
-  void _reduce_column_by(index target, index source);
-  void _update_barcode(id_index birthPivot, pos_index death);
-  void _add_bar(dimension_type dim, pos_index birth);
-  void _remove_last_in_barcode(pos_index eventIndex);
+  void _reduce_last_column(Index lastIndex);
+  void _reduce_column(Index target, Index eventIndex);
+  void _reduce_column_by(Index target, Index source);
+  void _update_barcode(ID_index birthPivot, Pos_index death);
+  void _add_bar(Dimension dim, Pos_index birth);
+  void _remove_last_in_barcode(Pos_index eventIndex);
 
-  constexpr bar_dictionary_type& _indexToBar();
+  constexpr Bar_dictionary& _indexToBar();
 };
 
 template <class Master_matrix>
 inline RU_matrix<Master_matrix>::RU_matrix(Column_settings* colSettings)
-    : pair_opt(),
-      swap_opt(),
-      rep_opt(),
+    : Pair_opt(),
+      Swap_opt(),
+      Rep_opt(),
       reducedMatrixR_(colSettings),
       mirrorMatrixU_(colSettings),
       nextEventIndex_(0),
-      operators_(nullptr) 
+      operators_(nullptr)
 {
-  if constexpr (!Master_matrix::Option_list::is_z2){
+  if constexpr (!Master_matrix::Option_list::is_z2) {
     operators_ = &(colSettings->operators);
   }
 }
 
 template <class Master_matrix>
-template <class Boundary_type>
-inline RU_matrix<Master_matrix>::RU_matrix(const std::vector<Boundary_type>& orderedBoundaries,
+template <class Boundary_container>
+inline RU_matrix<Master_matrix>::RU_matrix(const std::vector<Boundary_container>& orderedBoundaries,
                                            Column_settings* colSettings)
-    : pair_opt(),
-      swap_opt(),
-      rep_opt(),
+    : Pair_opt(),
+      Swap_opt(),
+      Rep_opt(),
       reducedMatrixR_(orderedBoundaries, colSettings),
       mirrorMatrixU_(orderedBoundaries.size(), colSettings),
       nextEventIndex_(orderedBoundaries.size()),
-      operators_(nullptr) 
+      operators_(nullptr)
 {
-  if constexpr (!Master_matrix::Option_list::is_z2){
+  if constexpr (!Master_matrix::Option_list::is_z2) {
     operators_ = &(colSettings->operators);
   }
 
@@ -462,17 +458,16 @@ inline RU_matrix<Master_matrix>::RU_matrix(const std::vector<Boundary_type>& ord
 }
 
 template <class Master_matrix>
-inline RU_matrix<Master_matrix>::RU_matrix(unsigned int numberOfColumns, 
-                                           Column_settings* colSettings)
-    : pair_opt(),
-      swap_opt(),
-      rep_opt(),
+inline RU_matrix<Master_matrix>::RU_matrix(unsigned int numberOfColumns, Column_settings* colSettings)
+    : Pair_opt(),
+      Swap_opt(),
+      Rep_opt(),
       reducedMatrixR_(numberOfColumns, colSettings),
       mirrorMatrixU_(numberOfColumns, colSettings),
       nextEventIndex_(0),
-      operators_(nullptr) 
+      operators_(nullptr)
 {
-  if constexpr (!Master_matrix::Option_list::is_z2){
+  if constexpr (!Master_matrix::Option_list::is_z2) {
     operators_ = &(colSettings->operators);
   }
 
@@ -485,66 +480,65 @@ inline RU_matrix<Master_matrix>::RU_matrix(unsigned int numberOfColumns,
     _indexToBar().reserve(numberOfColumns);
   }
   if constexpr (Master_matrix::Option_list::has_vine_update) {
-    swap_opt::_positionToRowIdx().reserve(numberOfColumns);
+    Swap_opt::_positionToRowIdx().reserve(numberOfColumns);
   }
 }
 
 template <class Master_matrix>
-inline RU_matrix<Master_matrix>::RU_matrix(const RU_matrix& matrixToCopy, 
-                                           Column_settings* colSettings)
-    : pair_opt(static_cast<const pair_opt&>(matrixToCopy)),
-      swap_opt(static_cast<const swap_opt&>(matrixToCopy)),
-      rep_opt(static_cast<const rep_opt&>(matrixToCopy)),
+inline RU_matrix<Master_matrix>::RU_matrix(const RU_matrix& matrixToCopy, Column_settings* colSettings)
+    : Pair_opt(static_cast<const Pair_opt&>(matrixToCopy)),
+      Swap_opt(static_cast<const Swap_opt&>(matrixToCopy)),
+      Rep_opt(static_cast<const Rep_opt&>(matrixToCopy)),
       reducedMatrixR_(matrixToCopy.reducedMatrixR_, colSettings),
       mirrorMatrixU_(matrixToCopy.mirrorMatrixU_, colSettings),
       pivotToColumnIndex_(matrixToCopy.pivotToColumnIndex_),
       nextEventIndex_(matrixToCopy.nextEventIndex_),
-      operators_(colSettings == nullptr ? matrixToCopy.operators_ : nullptr) 
+      operators_(colSettings == nullptr ? matrixToCopy.operators_ : nullptr)
 {
-  if constexpr (!Master_matrix::Option_list::is_z2){
+  if constexpr (!Master_matrix::Option_list::is_z2) {
     if (colSettings != nullptr) operators_ = &(colSettings->operators);
   }
 }
 
 template <class Master_matrix>
 inline RU_matrix<Master_matrix>::RU_matrix(RU_matrix&& other) noexcept
-    : pair_opt(std::move(static_cast<pair_opt&>(other))),
-      swap_opt(std::move(static_cast<swap_opt&>(other))),
-      rep_opt(std::move(static_cast<rep_opt&>(other))),
+    : Pair_opt(std::move(static_cast<Pair_opt&>(other))),
+      Swap_opt(std::move(static_cast<Swap_opt&>(other))),
+      Rep_opt(std::move(static_cast<Rep_opt&>(other))),
       reducedMatrixR_(std::move(other.reducedMatrixR_)),
       mirrorMatrixU_(std::move(other.mirrorMatrixU_)),
       pivotToColumnIndex_(std::move(other.pivotToColumnIndex_)),
       nextEventIndex_(std::exchange(other.nextEventIndex_, 0)),
-      operators_(std::exchange(other.operators_, nullptr)) 
+      operators_(std::exchange(other.operators_, nullptr))
 {}
 
 template <class Master_matrix>
-template <class Boundary_type>
-inline void RU_matrix<Master_matrix>::insert_boundary(const Boundary_type& boundary, dimension_type dim) 
+template <class Boundary_container>
+inline void RU_matrix<Master_matrix>::insert_boundary(const Boundary_container& boundary, Dimension dim)
 {
   _insert_boundary(reducedMatrixR_.insert_boundary(boundary, dim));
 }
 
 template <class Master_matrix>
-template <class Boundary_type>
-inline void RU_matrix<Master_matrix>::insert_boundary(id_index faceIndex, 
-                                                      const Boundary_type& boundary,
-                                                      dimension_type dim) 
+template <class Boundary_container>
+inline void RU_matrix<Master_matrix>::insert_boundary(ID_index faceIndex,
+                                                      const Boundary_container& boundary,
+                                                      Dimension dim)
 {
-  //maps for possible shifting between column content and position indices used for birth events
-  if constexpr (Master_matrix::Option_list::has_column_pairings && !Master_matrix::Option_list::has_vine_update){
-    if (faceIndex != nextEventIndex_){
-      pair_opt::idToPosition_.emplace(faceIndex, nextEventIndex_);
-      if constexpr (Master_matrix::Option_list::has_removable_columns){
-        pair_opt::PIDM::map_.emplace(nextEventIndex_, faceIndex);
+  // maps for possible shifting between column content and position indices used for birth events
+  if constexpr (Master_matrix::Option_list::has_column_pairings && !Master_matrix::Option_list::has_vine_update) {
+    if (faceIndex != nextEventIndex_) {
+      Pair_opt::idToPosition_.emplace(faceIndex, nextEventIndex_);
+      if constexpr (Master_matrix::Option_list::has_removable_columns) {
+        Pair_opt::PIDM::map_.emplace(nextEventIndex_, faceIndex);
       }
     }
   }
   if constexpr (Master_matrix::Option_list::has_vine_update) {
-    if (faceIndex != nextEventIndex_){
-      swap_opt::_positionToRowIdx().emplace(nextEventIndex_, faceIndex);
-      if (Master_matrix::Option_list::has_column_pairings){
-        swap_opt::template RU_pairing<Master_matrix>::idToPosition_.emplace(faceIndex, nextEventIndex_);
+    if (faceIndex != nextEventIndex_) {
+      Swap_opt::_positionToRowIdx().emplace(nextEventIndex_, faceIndex);
+      if (Master_matrix::Option_list::has_column_pairings) {
+        Swap_opt::template RU_pairing<Master_matrix>::idToPosition_.emplace(faceIndex, nextEventIndex_);
       }
     }
   }
@@ -552,8 +546,7 @@ inline void RU_matrix<Master_matrix>::insert_boundary(id_index faceIndex,
 }
 
 template <class Master_matrix>
-inline typename RU_matrix<Master_matrix>::Column_type& RU_matrix<Master_matrix>::get_column(index columnIndex,
-                                                                                            bool inR) 
+inline typename RU_matrix<Master_matrix>::Column& RU_matrix<Master_matrix>::get_column(Index columnIndex, bool inR)
 {
   if (inR) {
     return reducedMatrixR_.get_column(columnIndex);
@@ -562,7 +555,7 @@ inline typename RU_matrix<Master_matrix>::Column_type& RU_matrix<Master_matrix>:
 }
 
 template <class Master_matrix>
-inline typename RU_matrix<Master_matrix>::Row_type& RU_matrix<Master_matrix>::get_row(index rowIndex, bool inR) 
+inline typename RU_matrix<Master_matrix>::Row& RU_matrix<Master_matrix>::get_row(Index rowIndex, bool inR)
 {
   static_assert(Master_matrix::Option_list::has_row_access, "'get_row' is not implemented for the chosen options.");
 
@@ -573,28 +566,28 @@ inline typename RU_matrix<Master_matrix>::Row_type& RU_matrix<Master_matrix>::ge
 }
 
 template <class Master_matrix>
-inline void RU_matrix<Master_matrix>::erase_empty_row(index rowIndex) 
+inline void RU_matrix<Master_matrix>::erase_empty_row(Index rowIndex)
 {
   reducedMatrixR_.erase_empty_row(rowIndex);
 }
 
 template <class Master_matrix>
-inline void RU_matrix<Master_matrix>::remove_maximal_face(index columnIndex) 
+inline void RU_matrix<Master_matrix>::remove_maximal_face(Index columnIndex)
 {
   static_assert(Master_matrix::Option_list::has_removable_columns && Master_matrix::Option_list::has_vine_update,
                 "'remove_maximal_face' is not implemented for the chosen options.");
 
   // TODO: is there an easy test to verify maximality even without row access?
 
-  for (index curr = columnIndex; curr < nextEventIndex_ - 1; ++curr) {
-    swap_opt::vine_swap(curr);
+  for (Index curr = columnIndex; curr < nextEventIndex_ - 1; ++curr) {
+    Swap_opt::vine_swap(curr);
   }
 
   remove_last();
 }
 
 template <class Master_matrix>
-inline void RU_matrix<Master_matrix>::remove_last() 
+inline void RU_matrix<Master_matrix>::remove_last()
 {
   static_assert(Master_matrix::Option_list::has_removable_columns,
                 "'remove_last' is not implemented for the chosen options.");
@@ -609,41 +602,41 @@ inline void RU_matrix<Master_matrix>::remove_last()
   if constexpr (Master_matrix::Option_list::has_map_column_container) {
     pivotToColumnIndex_.erase(reducedMatrixR_.remove_last());
   } else {
-    id_index lastPivot = reducedMatrixR_.remove_last();
-    if (lastPivot != static_cast<id_index>(-1)) pivotToColumnIndex_[lastPivot] = -1;
+    ID_index lastPivot = reducedMatrixR_.remove_last();
+    if (lastPivot != static_cast<ID_index>(-1)) pivotToColumnIndex_[lastPivot] = -1;
   }
 
   // if has_vine_update and has_column_pairings are both true,
   // then the element is already removed in _remove_last_in_barcode
   if constexpr (Master_matrix::Option_list::has_vine_update && !Master_matrix::Option_list::has_column_pairings) {
-    swap_opt::_positionToRowIdx().erase(nextEventIndex_);
+    Swap_opt::_positionToRowIdx().erase(nextEventIndex_);
   }
 }
 
 template <class Master_matrix>
-inline typename RU_matrix<Master_matrix>::dimension_type RU_matrix<Master_matrix>::get_max_dimension() const 
+inline typename RU_matrix<Master_matrix>::Dimension RU_matrix<Master_matrix>::get_max_dimension() const
 {
   return reducedMatrixR_.get_max_dimension();
 }
 
 template <class Master_matrix>
-inline typename RU_matrix<Master_matrix>::index RU_matrix<Master_matrix>::get_number_of_columns() const 
+inline typename RU_matrix<Master_matrix>::Index RU_matrix<Master_matrix>::get_number_of_columns() const
 {
   return reducedMatrixR_.get_number_of_columns();
 }
 
 template <class Master_matrix>
-inline typename RU_matrix<Master_matrix>::dimension_type RU_matrix<Master_matrix>::get_column_dimension(
-    index columnIndex) const 
+inline typename RU_matrix<Master_matrix>::Dimension RU_matrix<Master_matrix>::get_column_dimension(
+    Index columnIndex) const
 {
   return reducedMatrixR_.get_column_dimension(columnIndex);
 }
 
 template <class Master_matrix>
-inline void RU_matrix<Master_matrix>::add_to(index sourceColumnIndex, index targetColumnIndex) 
+inline void RU_matrix<Master_matrix>::add_to(Index sourceColumnIndex, Index targetColumnIndex)
 {
   reducedMatrixR_.add_to(sourceColumnIndex, targetColumnIndex);
-  //U transposed to avoid row operations
+  // U transposed to avoid row operations
   if constexpr (Master_matrix::Option_list::has_vine_update)
     mirrorMatrixU_.add_to(targetColumnIndex, sourceColumnIndex);
   else
@@ -651,25 +644,25 @@ inline void RU_matrix<Master_matrix>::add_to(index sourceColumnIndex, index targ
 }
 
 template <class Master_matrix>
-inline void RU_matrix<Master_matrix>::multiply_target_and_add_to(index sourceColumnIndex,
-                                                                 const Field_element_type& coefficient,
-                                                                 index targetColumnIndex) 
+inline void RU_matrix<Master_matrix>::multiply_target_and_add_to(Index sourceColumnIndex,
+                                                                 const Field_element& coefficient,
+                                                                 Index targetColumnIndex)
 {
   reducedMatrixR_.multiply_target_and_add_to(sourceColumnIndex, coefficient, targetColumnIndex);
   mirrorMatrixU_.multiply_target_and_add_to(sourceColumnIndex, coefficient, targetColumnIndex);
 }
 
 template <class Master_matrix>
-inline void RU_matrix<Master_matrix>::multiply_source_and_add_to(const Field_element_type& coefficient,
-                                                                 index sourceColumnIndex, 
-                                                                 index targetColumnIndex) 
+inline void RU_matrix<Master_matrix>::multiply_source_and_add_to(const Field_element& coefficient,
+                                                                 Index sourceColumnIndex,
+                                                                 Index targetColumnIndex)
 {
   reducedMatrixR_.multiply_source_and_add_to(coefficient, sourceColumnIndex, targetColumnIndex);
   mirrorMatrixU_.multiply_source_and_add_to(coefficient, sourceColumnIndex, targetColumnIndex);
 }
 
 template <class Master_matrix>
-inline void RU_matrix<Master_matrix>::zero_cell(index columnIndex, index rowIndex, bool inR) 
+inline void RU_matrix<Master_matrix>::zero_cell(Index columnIndex, Index rowIndex, bool inR)
 {
   if (inR) {
     return reducedMatrixR_.zero_cell(columnIndex, rowIndex);
@@ -678,7 +671,7 @@ inline void RU_matrix<Master_matrix>::zero_cell(index columnIndex, index rowInde
 }
 
 template <class Master_matrix>
-inline void RU_matrix<Master_matrix>::zero_column(index columnIndex, bool inR) 
+inline void RU_matrix<Master_matrix>::zero_column(Index columnIndex, bool inR)
 {
   if (inR) {
     return reducedMatrixR_.zero_column(columnIndex);
@@ -687,7 +680,7 @@ inline void RU_matrix<Master_matrix>::zero_column(index columnIndex, bool inR)
 }
 
 template <class Master_matrix>
-inline bool RU_matrix<Master_matrix>::is_zero_cell(index columnIndex, index rowIndex, bool inR) const 
+inline bool RU_matrix<Master_matrix>::is_zero_cell(Index columnIndex, Index rowIndex, bool inR) const
 {
   if (inR) {
     return reducedMatrixR_.is_zero_cell(columnIndex, rowIndex);
@@ -696,7 +689,7 @@ inline bool RU_matrix<Master_matrix>::is_zero_cell(index columnIndex, index rowI
 }
 
 template <class Master_matrix>
-inline bool RU_matrix<Master_matrix>::is_zero_column(index columnIndex, bool inR) 
+inline bool RU_matrix<Master_matrix>::is_zero_column(Index columnIndex, bool inR)
 {
   if (inR) {
     return reducedMatrixR_.is_zero_column(columnIndex);
@@ -705,8 +698,7 @@ inline bool RU_matrix<Master_matrix>::is_zero_column(index columnIndex, bool inR
 }
 
 template <class Master_matrix>
-inline typename RU_matrix<Master_matrix>::index RU_matrix<Master_matrix>::get_column_with_pivot(
-    index faceIndex) const 
+inline typename RU_matrix<Master_matrix>::Index RU_matrix<Master_matrix>::get_column_with_pivot(Index faceIndex) const
 {
   if constexpr (Master_matrix::Option_list::has_map_column_container) {
     return pivotToColumnIndex_.at(faceIndex);
@@ -716,17 +708,17 @@ inline typename RU_matrix<Master_matrix>::index RU_matrix<Master_matrix>::get_co
 }
 
 template <class Master_matrix>
-inline typename RU_matrix<Master_matrix>::index RU_matrix<Master_matrix>::get_pivot(index columnIndex) 
+inline typename RU_matrix<Master_matrix>::Index RU_matrix<Master_matrix>::get_pivot(Index columnIndex)
 {
   return reducedMatrixR_.get_column(columnIndex).get_pivot();
 }
 
 template <class Master_matrix>
-inline RU_matrix<Master_matrix>& RU_matrix<Master_matrix>::operator=(const RU_matrix& other) 
+inline RU_matrix<Master_matrix>& RU_matrix<Master_matrix>::operator=(const RU_matrix& other)
 {
-  swap_opt::operator=(other);
-  pair_opt::operator=(other);
-  rep_opt::operator=(other);
+  Swap_opt::operator=(other);
+  Pair_opt::operator=(other);
+  Rep_opt::operator=(other);
   reducedMatrixR_ = other.reducedMatrixR_;
   mirrorMatrixU_ = other.mirrorMatrixU_;
   pivotToColumnIndex_ = other.pivotToColumnIndex_;
@@ -736,7 +728,7 @@ inline RU_matrix<Master_matrix>& RU_matrix<Master_matrix>::operator=(const RU_ma
 }
 
 template <class Master_matrix>
-inline void RU_matrix<Master_matrix>::print() 
+inline void RU_matrix<Master_matrix>::print()
 {
   std::cout << "R_matrix:\n";
   reducedMatrixR_.print();
@@ -745,7 +737,7 @@ inline void RU_matrix<Master_matrix>::print()
 }
 
 template <class Master_matrix>
-inline void RU_matrix<Master_matrix>::_insert_boundary(index currentIndex) 
+inline void RU_matrix<Master_matrix>::_insert_boundary(Index currentIndex)
 {
   if constexpr (Master_matrix::Option_list::is_z2) {
     mirrorMatrixU_.insert_column({currentIndex});
@@ -754,8 +746,8 @@ inline void RU_matrix<Master_matrix>::_insert_boundary(index currentIndex)
   }
 
   if constexpr (!Master_matrix::Option_list::has_map_column_container) {
-    id_index pivot = reducedMatrixR_.get_column(currentIndex).get_pivot();
-    if (pivot != static_cast<id_index>(-1) && pivotToColumnIndex_.size() <= pivot)
+    ID_index pivot = reducedMatrixR_.get_column(currentIndex).get_pivot();
+    if (pivot != static_cast<ID_index>(-1) && pivotToColumnIndex_.size() <= pivot)
       pivotToColumnIndex_.resize((pivot + 1) * 2, -1);
   }
 
@@ -764,12 +756,12 @@ inline void RU_matrix<Master_matrix>::_insert_boundary(index currentIndex)
 }
 
 template <class Master_matrix>
-inline void RU_matrix<Master_matrix>::_initialize_U() 
+inline void RU_matrix<Master_matrix>::_initialize_U()
 {
-  typename std::conditional<Master_matrix::Option_list::is_z2, index, std::pair<index, Field_element_type> >::type id;
+  typename std::conditional<Master_matrix::Option_list::is_z2, Index, std::pair<Index, Field_element> >::type id;
   if constexpr (!Master_matrix::Option_list::is_z2) id.second = 1;
 
-  for (id_index i = 0; i < reducedMatrixR_.get_number_of_columns(); i++) {
+  for (ID_index i = 0; i < reducedMatrixR_.get_number_of_columns(); i++) {
     if constexpr (Master_matrix::Option_list::is_z2)
       id = i;
     else
@@ -779,13 +771,13 @@ inline void RU_matrix<Master_matrix>::_initialize_U()
 }
 
 template <class Master_matrix>
-inline void RU_matrix<Master_matrix>::_reduce() 
+inline void RU_matrix<Master_matrix>::_reduce()
 {
   if constexpr (Master_matrix::Option_list::has_column_pairings) {
     _indexToBar().reserve(reducedMatrixR_.get_number_of_columns());
   }
 
-  for (index i = 0; i < reducedMatrixR_.get_number_of_columns(); i++) {
+  for (Index i = 0; i < reducedMatrixR_.get_number_of_columns(); i++) {
     if (!(reducedMatrixR_.is_zero_column(i))) {
       _reduce_column(i, i);
     } else {
@@ -795,7 +787,7 @@ inline void RU_matrix<Master_matrix>::_reduce()
 }
 
 template <class Master_matrix>
-inline void RU_matrix<Master_matrix>::_reduce_last_column(index lastIndex) 
+inline void RU_matrix<Master_matrix>::_reduce_last_column(Index lastIndex)
 {
   if (reducedMatrixR_.get_column(lastIndex).is_empty()) {
     _add_bar(get_column_dimension(lastIndex), nextEventIndex_);
@@ -806,10 +798,10 @@ inline void RU_matrix<Master_matrix>::_reduce_last_column(index lastIndex)
 }
 
 template <class Master_matrix>
-inline void RU_matrix<Master_matrix>::_reduce_column(index target, index eventIndex)
+inline void RU_matrix<Master_matrix>::_reduce_column(Index target, Index eventIndex)
 {
-  auto get_column_with_pivot_ = [&](id_index pivot) -> index {
-    if (pivot == static_cast<id_index>(-1)) return -1;
+  auto get_column_with_pivot_ = [&](ID_index pivot) -> Index {
+    if (pivot == static_cast<ID_index>(-1)) return -1;
     if constexpr (Master_matrix::Option_list::has_map_column_container) {
       auto it = pivotToColumnIndex_.find(pivot);
       if (it == pivotToColumnIndex_.end())
@@ -821,17 +813,17 @@ inline void RU_matrix<Master_matrix>::_reduce_column(index target, index eventIn
     }
   };
 
-  Column_type& curr = reducedMatrixR_.get_column(target);
-  id_index pivot = curr.get_pivot();
-  index currIndex = get_column_with_pivot_(pivot);
+  Column& curr = reducedMatrixR_.get_column(target);
+  ID_index pivot = curr.get_pivot();
+  Index currIndex = get_column_with_pivot_(pivot);
 
-  while (pivot != static_cast<id_index>(-1) && currIndex != static_cast<index>(-1)) {
+  while (pivot != static_cast<ID_index>(-1) && currIndex != static_cast<Index>(-1)) {
     _reduce_column_by(target, currIndex);
     pivot = curr.get_pivot();
     currIndex = get_column_with_pivot_(pivot);
   }
 
-  if (pivot != static_cast<id_index>(-1)) {
+  if (pivot != static_cast<ID_index>(-1)) {
     if constexpr (Master_matrix::Option_list::has_map_column_container) {
       pivotToColumnIndex_.try_emplace(pivot, target);
     } else {
@@ -844,20 +836,20 @@ inline void RU_matrix<Master_matrix>::_reduce_column(index target, index eventIn
 }
 
 template <class Master_matrix>
-inline void RU_matrix<Master_matrix>::_reduce_column_by(index target, index source)
+inline void RU_matrix<Master_matrix>::_reduce_column_by(Index target, Index source)
 {
-  Column_type& curr = reducedMatrixR_.get_column(target);
+  Column& curr = reducedMatrixR_.get_column(target);
   if constexpr (Master_matrix::Option_list::is_z2) {
     curr += reducedMatrixR_.get_column(source);
-    //to avoid having to do line operations during vineyards, U is transposed
-    //TODO: explain this somewhere in the documentation...
+    // to avoid having to do line operations during vineyards, U is transposed
+    // TODO: explain this somewhere in the documentation...
     if constexpr (Master_matrix::Option_list::has_vine_update)
       mirrorMatrixU_.get_column(source) += mirrorMatrixU_.get_column(target);
     else
       mirrorMatrixU_.get_column(target) += mirrorMatrixU_.get_column(source);
   } else {
-    Column_type& toadd = reducedMatrixR_.get_column(source);
-    Field_element_type coef = toadd.get_pivot_value();
+    Column& toadd = reducedMatrixR_.get_column(source);
+    Field_element coef = toadd.get_pivot_value();
     coef = operators_->get_inverse(coef);
     operators_->multiply_inplace(coef, operators_->get_characteristic() - curr.get_pivot_value());
 
@@ -868,45 +860,45 @@ inline void RU_matrix<Master_matrix>::_reduce_column_by(index target, index sour
 }
 
 template <class Master_matrix>
-inline void RU_matrix<Master_matrix>::_update_barcode(id_index birthPivot, pos_index death)
+inline void RU_matrix<Master_matrix>::_update_barcode(ID_index birthPivot, Pos_index death)
 {
   if constexpr (Master_matrix::Option_list::has_column_pairings) {
     if constexpr (Master_matrix::Option_list::has_vine_update)
-      swap_opt::template RU_pairing<Master_matrix>::_update_barcode(birthPivot, death);
+      Swap_opt::template RU_pairing<Master_matrix>::_update_barcode(birthPivot, death);
     else
-      pair_opt::_update_barcode(birthPivot, death);
+      Pair_opt::_update_barcode(birthPivot, death);
   }
 }
 
 template <class Master_matrix>
-inline void RU_matrix<Master_matrix>::_add_bar(dimension_type dim, pos_index birth) 
+inline void RU_matrix<Master_matrix>::_add_bar(Dimension dim, Pos_index birth)
 {
   if constexpr (Master_matrix::Option_list::has_column_pairings) {
     if constexpr (Master_matrix::Option_list::has_vine_update)
-      swap_opt::template RU_pairing<Master_matrix>::_add_bar(dim, birth);
+      Swap_opt::template RU_pairing<Master_matrix>::_add_bar(dim, birth);
     else
-      pair_opt::_add_bar(dim, birth);
+      Pair_opt::_add_bar(dim, birth);
   }
 }
 
 template <class Master_matrix>
-inline void RU_matrix<Master_matrix>::_remove_last_in_barcode(pos_index eventIndex) 
+inline void RU_matrix<Master_matrix>::_remove_last_in_barcode(Pos_index eventIndex)
 {
   if constexpr (Master_matrix::Option_list::has_column_pairings) {
     if constexpr (Master_matrix::Option_list::has_vine_update)
-      swap_opt::template RU_pairing<Master_matrix>::_remove_last(eventIndex);
+      Swap_opt::template RU_pairing<Master_matrix>::_remove_last(eventIndex);
     else
-      pair_opt::_remove_last(eventIndex);
+      Pair_opt::_remove_last(eventIndex);
   }
 }
 
 template <class Master_matrix>
-inline constexpr typename RU_matrix<Master_matrix>::bar_dictionary_type& RU_matrix<Master_matrix>::_indexToBar() 
+inline constexpr typename RU_matrix<Master_matrix>::Bar_dictionary& RU_matrix<Master_matrix>::_indexToBar()
 {
   if constexpr (Master_matrix::Option_list::has_vine_update)
-    return swap_opt::template RU_pairing<Master_matrix>::indexToBar_;
+    return Swap_opt::template RU_pairing<Master_matrix>::indexToBar_;
   else
-    return pair_opt::indexToBar_;
+    return Pair_opt::indexToBar_;
 }
 
 }  // namespace persistence_matrix

--- a/src/Persistence_matrix/include/gudhi/Persistence_matrix/ru_rep_cycles.h
+++ b/src/Persistence_matrix/include/gudhi/Persistence_matrix/ru_rep_cycles.h
@@ -32,7 +32,8 @@ namespace persistence_matrix {
  * Inherited instead of @ref RU_representative_cycles, when the computation of the representative cycles
  * were not enabled.
  */
-struct Dummy_ru_representative_cycles {
+struct Dummy_ru_representative_cycles
+{
   friend void swap([[maybe_unused]] Dummy_ru_representative_cycles& d1,
                    [[maybe_unused]] Dummy_ru_representative_cycles& d2) {}
 };
@@ -50,9 +51,9 @@ template <class Master_matrix>
 class RU_representative_cycles 
 {
  public:
-  using index = typename Master_matrix::index;            /**< @ref MatIdx index type. */
-  using Bar = typename Master_matrix::Bar;                /**< Bar type. */
-  using cycle_type = typename Master_matrix::cycle_type;  /**< Cycle type. */
+  using Index = typename Master_matrix::Index;  /**< @ref MatIdx index type. */
+  using Bar = typename Master_matrix::Bar;      /**< Bar type. */
+  using Cycle = typename Master_matrix::Cycle;  /**< Cycle type. */
 
   /**
    * @brief Default constructor.
@@ -80,9 +81,9 @@ class RU_representative_cycles
    * @brief Returns the current representative cycles. If the matrix is modified later after the first call,
    * @ref update_representative_cycles has to be called to update the returned cycles.
    * 
-   * @return A const reference to a vector of @ref Matrix::cycle_type containing all representative cycles.
+   * @return A const reference to a vector of @ref Matrix::Cycle containing all representative cycles.
    */
-  const std::vector<cycle_type>& get_representative_cycles();
+  const std::vector<Cycle>& get_representative_cycles();
   /**
    * @brief Returns the representative cycle corresponding to the given bar.
    * If the matrix is modified later after the first call,
@@ -91,7 +92,7 @@ class RU_representative_cycles
    * @param bar Bar corresponding to the wanted representative cycle.
    * @return A const reference to the representative cycle.
    */
-  const cycle_type& get_representative_cycle(const Bar& bar);
+  const Cycle& get_representative_cycle(const Bar& bar);
 
   /**
    * @brief Assign operator.
@@ -106,13 +107,13 @@ class RU_representative_cycles
   }
 
  private:
-  using ru_matrix = typename Master_matrix::RU_matrix_type;
+  using Master_RU_matrix = typename Master_matrix::Master_RU_matrix;
 
-  std::vector<cycle_type> representativeCycles_;  /**< Cycle container. */
-  std::vector<index> birthToCycle_;               /**< Map from birth index to cycle index. */
+  std::vector<Cycle> representativeCycles_; /**< Cycle container. */
+  std::vector<Index> birthToCycle_;         /**< Map from birth index to cycle index. */
 
-  constexpr ru_matrix* _matrix() { return static_cast<ru_matrix*>(this); }
-  constexpr const ru_matrix* _matrix() const { return static_cast<const ru_matrix*>(this); }
+  constexpr Master_RU_matrix* _matrix() { return static_cast<Master_RU_matrix*>(this); }
+  constexpr const Master_RU_matrix* _matrix() const { return static_cast<const Master_RU_matrix*>(this); }
 };
 
 template <class Master_matrix>
@@ -137,8 +138,8 @@ inline void RU_representative_cycles<Master_matrix>::update_representative_cycle
   if constexpr (Master_matrix::Option_list::has_vine_update) {
     birthToCycle_.clear();
     birthToCycle_.resize(_matrix()->reducedMatrixR_.get_number_of_columns(), -1);
-    index c = 0;
-    for (index i = 0; i < _matrix()->reducedMatrixR_.get_number_of_columns(); i++) {
+    Index c = 0;
+    for (Index i = 0; i < _matrix()->reducedMatrixR_.get_number_of_columns(); i++) {
       if (_matrix()->reducedMatrixR_.is_zero_column(i)) {
         birthToCycle_[i] = c;
         ++c;
@@ -146,10 +147,10 @@ inline void RU_representative_cycles<Master_matrix>::update_representative_cycle
     }
     representativeCycles_.clear();
     representativeCycles_.resize(c);
-    for (index i = 0; i < _matrix()->mirrorMatrixU_.get_number_of_columns(); i++) {
+    for (Index i = 0; i < _matrix()->mirrorMatrixU_.get_number_of_columns(); i++) {
       for (const auto& cell : _matrix()->mirrorMatrixU_.get_column(i)) {
         auto idx = birthToCycle_[cell.get_row_index()];
-        if (idx != static_cast<index>(-1)) {
+        if (idx != static_cast<Index>(-1)) {
           representativeCycles_[idx].push_back(i);
         }
       }
@@ -157,15 +158,15 @@ inline void RU_representative_cycles<Master_matrix>::update_representative_cycle
   } else {
     birthToCycle_.clear();
     birthToCycle_.resize(_matrix()->reducedMatrixR_.get_number_of_columns(), -1);
-    for (index i = 0; i < _matrix()->reducedMatrixR_.get_number_of_columns(); i++) {
+    for (Index i = 0; i < _matrix()->reducedMatrixR_.get_number_of_columns(); i++) {
       if (_matrix()->reducedMatrixR_.is_zero_column(i)) {
-        representativeCycles_.push_back(cycle_type());
+        representativeCycles_.push_back(Cycle());
         for (const auto& cell : _matrix()->mirrorMatrixU_.get_column(i)) {
           representativeCycles_.back().push_back(cell.get_row_index());
         }
-        if constexpr (std::is_same_v<typename Master_matrix::Column_type, typename Master_matrix::Heap_column_type> ||
-                      std::is_same_v<typename Master_matrix::Column_type,
-                                     typename Master_matrix::Unordered_set_column_type>)
+        if constexpr (std::is_same_v<typename Master_matrix::Column, typename Master_matrix::Matrix_heap_column> ||
+                      std::is_same_v<typename Master_matrix::Column,
+                                     typename Master_matrix::Matrix_unordered_set_column>)
           std::sort(representativeCycles_.back().begin(), representativeCycles_.back().end());
         birthToCycle_[i] = representativeCycles_.size() - 1;
       }
@@ -174,7 +175,7 @@ inline void RU_representative_cycles<Master_matrix>::update_representative_cycle
 }
 
 template <class Master_matrix>
-inline const std::vector<typename RU_representative_cycles<Master_matrix>::cycle_type>&
+inline const std::vector<typename RU_representative_cycles<Master_matrix>::Cycle>&
 RU_representative_cycles<Master_matrix>::get_representative_cycles() 
 {
   if (representativeCycles_.empty()) update_representative_cycles();
@@ -182,7 +183,7 @@ RU_representative_cycles<Master_matrix>::get_representative_cycles()
 }
 
 template <class Master_matrix>
-inline const typename RU_representative_cycles<Master_matrix>::cycle_type&
+inline const typename RU_representative_cycles<Master_matrix>::Cycle&
 RU_representative_cycles<Master_matrix>::get_representative_cycle(const Bar& bar) 
 {
   if (representativeCycles_.empty()) update_representative_cycles();

--- a/src/Persistence_matrix/include/gudhi/Persistence_matrix/ru_vine_swap.h
+++ b/src/Persistence_matrix/include/gudhi/Persistence_matrix/ru_vine_swap.h
@@ -36,7 +36,8 @@ namespace persistence_matrix {
  * @brief Empty structure.
  * Inherited instead of @ref RU_vine_swap, when vine swaps are not enabled.
  */
-struct Dummy_ru_vine_swap {
+struct Dummy_ru_vine_swap
+{
   friend void swap([[maybe_unused]] Dummy_ru_vine_swap& d1, [[maybe_unused]] Dummy_ru_vine_swap& d2) {}
 };
 
@@ -46,7 +47,8 @@ struct Dummy_ru_vine_swap {
  * @brief Empty structure.
  * Inherited instead of @ref RU_pairing, when the barcode is not stored.
  */
-struct Dummy_ru_vine_pairing {
+struct Dummy_ru_vine_pairing
+{
   friend void swap([[maybe_unused]] Dummy_ru_vine_pairing& d1, [[maybe_unused]] Dummy_ru_vine_pairing& d2) {}
 };
 
@@ -66,14 +68,14 @@ class RU_vine_swap : public std::conditional<Master_matrix::Option_list::has_col
                      public std::conditional<Master_matrix::Option_list::has_column_pairings &&
                                                 Master_matrix::Option_list::has_removable_columns, 
                                              Dummy_pos_mapper,
-                                             Face_position_to_ID_mapper<typename Master_matrix::id_index,
-                                                                        typename Master_matrix::pos_index>
+                                             Face_position_to_ID_mapper<typename Master_matrix::ID_index,
+                                                                        typename Master_matrix::Pos_index>
                                             >::type
 {
  public:
-  using index = typename Master_matrix::index;          /**< @ref MatIdx index type. */
-  using id_index = typename Master_matrix::id_index;    /**< @ref IDIdx index type. */
-  using pos_index = typename Master_matrix::pos_index;  /**< @ref PosIdx index type. */
+  using Index = typename Master_matrix::Index;          /**< @ref MatIdx index type. */
+  using ID_index = typename Master_matrix::ID_index;    /**< @ref IDIdx index type. */
+  using Pos_index = typename Master_matrix::Pos_index;  /**< @ref PosIdx index type. */
 
   /**
    * @brief Default constructor.
@@ -100,7 +102,7 @@ class RU_vine_swap : public std::conditional<Master_matrix::Option_list::has_col
    * @return true If the barcode changed from the swap.
    * @return false Otherwise.
    */
-  bool vine_swap_with_z_eq_1_case(pos_index index);
+  bool vine_swap_with_z_eq_1_case(Pos_index index);
   /**
    * @brief Does a vine swap between two faces which are consecutive in the filtration.
    * Roughly, if \f$ F \f$ is the current filtration represented by the matrix, the method modifies the matrix
@@ -113,7 +115,7 @@ class RU_vine_swap : public std::conditional<Master_matrix::Option_list::has_col
    * @return true If the barcode changed from the swap.
    * @return false Otherwise.
    */
-  bool vine_swap(pos_index index);
+  bool vine_swap(Pos_index index);
 
   /**
    * @brief Assign operator.
@@ -127,8 +129,8 @@ class RU_vine_swap : public std::conditional<Master_matrix::Option_list::has_col
       swap(static_cast<RU_pairing<Master_matrix>&>(swap1), static_cast<RU_pairing<Master_matrix>&>(swap2));
     }
     if (!Master_matrix::Option_list::has_column_pairings || !Master_matrix::Option_list::has_removable_columns) {
-      swap(static_cast<Face_position_to_ID_mapper<id_index, pos_index>&>(swap1),
-           static_cast<Face_position_to_ID_mapper<id_index, pos_index>&>(swap2));
+      swap(static_cast<Face_position_to_ID_mapper<ID_index, Pos_index>&>(swap1),
+           static_cast<Face_position_to_ID_mapper<ID_index, Pos_index>&>(swap2));
     }
   }
 
@@ -140,37 +142,37 @@ class RU_vine_swap : public std::conditional<Master_matrix::Option_list::has_col
                                        >::type;
   //RUM = RU matrix position to id Map
   using RUM = typename std::conditional<Master_matrix::Option_list::has_column_pairings &&
-                                            Master_matrix::Option_list::has_removable_columns, 
-                                         Dummy_pos_mapper,
-                                         Face_position_to_ID_mapper<id_index,pos_index>
+                                            Master_matrix::Option_list::has_removable_columns,
+                                        Dummy_pos_mapper,
+                                        Face_position_to_ID_mapper<ID_index, Pos_index>
                                        >::type;
   constexpr auto& _positionToRowIdx();
 
  private:
-  using ru_matrix = typename Master_matrix::RU_matrix_type;
+  using Master_RU_matrix = typename Master_matrix::Master_RU_matrix;
 
-  bool _is_paired(index columnIndex);
+  bool _is_paired(Index columnIndex);
 
-  void _swap_at_index(index columnIndex);
-  void _add_to(index sourceIndex, index targetIndex);
-  void _positive_transpose(index columnIndex);
-  void _negative_transpose(index columnIndex);
-  void _positive_negative_transpose(index columnIndex);
-  void _negative_positive_transpose(index columnIndex);
-  bool _positive_vine_swap(index columnIndex);
-  bool _negative_vine_swap(index columnIndex);
-  bool _positive_negative_vine_swap(index columnIndex);
-  bool _negative_positive_vine_swap(index columnIndex);
+  void _swap_at_index(Index columnIndex);
+  void _add_to(Index sourceIndex, Index targetIndex);
+  void _positive_transpose(Index columnIndex);
+  void _negative_transpose(Index columnIndex);
+  void _positive_negative_transpose(Index columnIndex);
+  void _negative_positive_transpose(Index columnIndex);
+  bool _positive_vine_swap(Index columnIndex);
+  bool _negative_vine_swap(Index columnIndex);
+  bool _positive_negative_vine_swap(Index columnIndex);
+  bool _negative_positive_vine_swap(Index columnIndex);
 
-  pos_index& _death(pos_index simplexIndex);
-  pos_index& _birth(pos_index simplexIndex);
-  pos_index _get_death(index simplexIndex);
-  pos_index _get_birth(index simplexIndex);
+  Pos_index& _death(Pos_index simplexIndex);
+  Pos_index& _birth(Pos_index simplexIndex);
+  Pos_index _get_death(Index simplexIndex);
+  Pos_index _get_birth(Index simplexIndex);
 
-  id_index _get_row_id_from_position(pos_index position);
+  ID_index _get_row_id_from_position(Pos_index position);
 
-  constexpr ru_matrix* _matrix() { return static_cast<ru_matrix*>(this); }
-  constexpr const ru_matrix* _matrix() const { return static_cast<const ru_matrix*>(this); }
+  constexpr Master_RU_matrix* _matrix() { return static_cast<Master_RU_matrix*>(this); }
+  constexpr const Master_RU_matrix* _matrix() const { return static_cast<const Master_RU_matrix*>(this); }
 };
 
 template <class Master_matrix>
@@ -190,7 +192,7 @@ inline RU_vine_swap<Master_matrix>::RU_vine_swap(RU_vine_swap<Master_matrix>&& o
 {}
 
 template <class Master_matrix>
-inline bool RU_vine_swap<Master_matrix>::vine_swap_with_z_eq_1_case(pos_index index) 
+inline bool RU_vine_swap<Master_matrix>::vine_swap_with_z_eq_1_case(Pos_index index) 
 {
   GUDHI_CHECK(index < _matrix()->reducedMatrixR_.get_number_of_columns() - 1,
               std::invalid_argument("RU_vine_swap::vine_swap_with_z_eq_1_case - Index to swap out of bound."));
@@ -211,7 +213,7 @@ inline bool RU_vine_swap<Master_matrix>::vine_swap_with_z_eq_1_case(pos_index in
 }
 
 template <class Master_matrix>
-inline bool RU_vine_swap<Master_matrix>::vine_swap(pos_index index) 
+inline bool RU_vine_swap<Master_matrix>::vine_swap(Pos_index index) 
 {
   GUDHI_CHECK(index < _matrix()->reducedMatrixR_.get_number_of_columns() - 1,
               std::invalid_argument("RU_vine_swap::vine_swap - Index to swap out of bound."));
@@ -269,17 +271,17 @@ inline RU_vine_swap<Master_matrix>& RU_vine_swap<Master_matrix>::operator=(RU_vi
 }
 
 template <class Master_matrix>
-inline bool RU_vine_swap<Master_matrix>::_is_paired(index columnIndex) 
+inline bool RU_vine_swap<Master_matrix>::_is_paired(Index columnIndex) 
 {
   if constexpr (Master_matrix::Option_list::has_column_pairings) {
-    return _get_death(columnIndex) != static_cast<pos_index>(-1);
+    return _get_death(columnIndex) != static_cast<Pos_index>(-1);
   } else {
     if (!_matrix()->reducedMatrixR_.is_zero_column(columnIndex)) return true;
 
     if constexpr (Master_matrix::Option_list::has_map_column_container) {
       if (_matrix()->pivotToColumnIndex_.find(columnIndex) == _matrix()->pivotToColumnIndex_.end()) return false;
     } else {
-      if (_matrix()->pivotToColumnIndex_.operator[](columnIndex) == static_cast<index>(-1)) return false;
+      if (_matrix()->pivotToColumnIndex_.operator[](columnIndex) == static_cast<Index>(-1)) return false;
     }
 
     return true;
@@ -287,7 +289,7 @@ inline bool RU_vine_swap<Master_matrix>::_is_paired(index columnIndex)
 }
 
 template <class Master_matrix>
-inline void RU_vine_swap<Master_matrix>::_swap_at_index(index columnIndex)
+inline void RU_vine_swap<Master_matrix>::_swap_at_index(Index columnIndex)
 {
   _matrix()->reducedMatrixR_.swap_columns(columnIndex, columnIndex + 1);
   _matrix()->reducedMatrixR_.swap_rows(_get_row_id_from_position(columnIndex),
@@ -298,14 +300,14 @@ inline void RU_vine_swap<Master_matrix>::_swap_at_index(index columnIndex)
 }
 
 template <class Master_matrix>
-inline void RU_vine_swap<Master_matrix>::_add_to(index sourceIndex, index targetIndex) 
+inline void RU_vine_swap<Master_matrix>::_add_to(Index sourceIndex, Index targetIndex) 
 {
   _matrix()->reducedMatrixR_.add_to(sourceIndex, targetIndex);
   _matrix()->mirrorMatrixU_.add_to(targetIndex, sourceIndex);
 }
 
 template <class Master_matrix>
-inline void RU_vine_swap<Master_matrix>::_positive_transpose(index columnIndex) 
+inline void RU_vine_swap<Master_matrix>::_positive_transpose(Index columnIndex) 
 {
   if constexpr (Master_matrix::Option_list::has_map_column_container) {
     if (_is_paired(columnIndex) && _is_paired(columnIndex + 1)) {
@@ -330,7 +332,7 @@ inline void RU_vine_swap<Master_matrix>::_positive_transpose(index columnIndex)
 }
 
 template <class Master_matrix>
-inline void RU_vine_swap<Master_matrix>::_negative_transpose(index columnIndex) 
+inline void RU_vine_swap<Master_matrix>::_negative_transpose(Index columnIndex) 
 {
   if constexpr (Master_matrix::Option_list::has_column_pairings) {
     _death(columnIndex) = columnIndex + 1;
@@ -342,7 +344,7 @@ inline void RU_vine_swap<Master_matrix>::_negative_transpose(index columnIndex)
 }
 
 template <class Master_matrix>
-inline void RU_vine_swap<Master_matrix>::_positive_negative_transpose(index columnIndex) 
+inline void RU_vine_swap<Master_matrix>::_positive_negative_transpose(Index columnIndex) 
 {
   _matrix()->pivotToColumnIndex_.at(_get_birth(columnIndex + 1)) = columnIndex;
   if constexpr (Master_matrix::Option_list::has_map_column_container) {
@@ -363,7 +365,7 @@ inline void RU_vine_swap<Master_matrix>::_positive_negative_transpose(index colu
 }
 
 template <class Master_matrix>
-inline void RU_vine_swap<Master_matrix>::_negative_positive_transpose(index columnIndex) 
+inline void RU_vine_swap<Master_matrix>::_negative_positive_transpose(Index columnIndex) 
 {
   _matrix()->pivotToColumnIndex_.at(_get_birth(columnIndex)) = columnIndex + 1;
   if constexpr (Master_matrix::Option_list::has_map_column_container) {
@@ -384,12 +386,12 @@ inline void RU_vine_swap<Master_matrix>::_negative_positive_transpose(index colu
 }
 
 template <class Master_matrix>
-inline bool RU_vine_swap<Master_matrix>::_positive_vine_swap(index columnIndex) 
+inline bool RU_vine_swap<Master_matrix>::_positive_vine_swap(Index columnIndex) 
 {
-  const pos_index iDeath = _get_death(columnIndex);
-  const pos_index iiDeath = _get_death(columnIndex + 1);
+  const Pos_index iDeath = _get_death(columnIndex);
+  const Pos_index iiDeath = _get_death(columnIndex + 1);
 
-  if (iDeath != static_cast<pos_index>(-1) && iiDeath != static_cast<pos_index>(-1) &&
+  if (iDeath != static_cast<Pos_index>(-1) && iiDeath != static_cast<Pos_index>(-1) &&
       !(_matrix()->reducedMatrixR_.is_zero_cell(iiDeath, _get_row_id_from_position(columnIndex)))) {
     if (iDeath < iiDeath) {
       _swap_at_index(columnIndex);
@@ -405,7 +407,7 @@ inline bool RU_vine_swap<Master_matrix>::_positive_vine_swap(index columnIndex)
 
   _swap_at_index(columnIndex);
 
-  if (iDeath != static_cast<pos_index>(-1) || iiDeath == static_cast<pos_index>(-1) ||
+  if (iDeath != static_cast<Pos_index>(-1) || iiDeath == static_cast<Pos_index>(-1) ||
       _matrix()->reducedMatrixR_.is_zero_cell(iiDeath, _get_row_id_from_position(columnIndex + 1))) {
     _positive_transpose(columnIndex);
     return true;
@@ -414,10 +416,10 @@ inline bool RU_vine_swap<Master_matrix>::_positive_vine_swap(index columnIndex)
 }
 
 template <class Master_matrix>
-inline bool RU_vine_swap<Master_matrix>::_negative_vine_swap(index columnIndex) 
+inline bool RU_vine_swap<Master_matrix>::_negative_vine_swap(Index columnIndex) 
 {
-  const pos_index iBirth = _get_birth(columnIndex);
-  const pos_index iiBirth = _get_birth(columnIndex + 1);
+  const Pos_index iBirth = _get_birth(columnIndex);
+  const Pos_index iiBirth = _get_birth(columnIndex + 1);
 
   _add_to(columnIndex, columnIndex + 1);
   _swap_at_index(columnIndex);
@@ -433,7 +435,7 @@ inline bool RU_vine_swap<Master_matrix>::_negative_vine_swap(index columnIndex)
 }
 
 template <class Master_matrix>
-inline bool RU_vine_swap<Master_matrix>::_positive_negative_vine_swap(index columnIndex) 
+inline bool RU_vine_swap<Master_matrix>::_positive_negative_vine_swap(Index columnIndex) 
 {
   _matrix()->mirrorMatrixU_.zero_cell(columnIndex, _get_row_id_from_position(columnIndex + 1));
 
@@ -444,7 +446,7 @@ inline bool RU_vine_swap<Master_matrix>::_positive_negative_vine_swap(index colu
 }
 
 template <class Master_matrix>
-inline bool RU_vine_swap<Master_matrix>::_negative_positive_vine_swap(index columnIndex) 
+inline bool RU_vine_swap<Master_matrix>::_negative_positive_vine_swap(Index columnIndex) 
 {
   _add_to(columnIndex, columnIndex + 1);  // useless for R?
   _swap_at_index(columnIndex);      // if additions not made for R, do not swap R columns, just rows
@@ -454,7 +456,7 @@ inline bool RU_vine_swap<Master_matrix>::_negative_positive_vine_swap(index colu
 }
 
 template <class Master_matrix>
-inline typename RU_vine_swap<Master_matrix>::pos_index& RU_vine_swap<Master_matrix>::_death(pos_index simplexIndex) 
+inline typename RU_vine_swap<Master_matrix>::Pos_index& RU_vine_swap<Master_matrix>::_death(Pos_index simplexIndex) 
 {
   static_assert(Master_matrix::Option_list::has_column_pairings, "Pairing necessary to modify death value.");
 
@@ -466,7 +468,7 @@ inline typename RU_vine_swap<Master_matrix>::pos_index& RU_vine_swap<Master_matr
 }
 
 template <class Master_matrix>
-inline typename RU_vine_swap<Master_matrix>::pos_index& RU_vine_swap<Master_matrix>::_birth(pos_index simplexIndex) 
+inline typename RU_vine_swap<Master_matrix>::Pos_index& RU_vine_swap<Master_matrix>::_birth(Pos_index simplexIndex) 
 {
   static_assert(Master_matrix::Option_list::has_column_pairings, "Pairing necessary to modify birth value.");
 
@@ -478,7 +480,7 @@ inline typename RU_vine_swap<Master_matrix>::pos_index& RU_vine_swap<Master_matr
 }
 
 template <class Master_matrix>
-inline typename RU_vine_swap<Master_matrix>::pos_index RU_vine_swap<Master_matrix>::_get_death(index simplexIndex) 
+inline typename RU_vine_swap<Master_matrix>::Pos_index RU_vine_swap<Master_matrix>::_get_death(Index simplexIndex) 
 {
   if constexpr (Master_matrix::Option_list::has_column_pairings) {
     if constexpr (Master_matrix::Option_list::has_removable_columns) {
@@ -501,8 +503,8 @@ inline typename RU_vine_swap<Master_matrix>::pos_index RU_vine_swap<Master_matri
 }
 
 template <class Master_matrix>
-inline typename RU_vine_swap<Master_matrix>::pos_index RU_vine_swap<Master_matrix>::_get_birth(
-    index negativeSimplexIndex) 
+inline typename RU_vine_swap<Master_matrix>::Pos_index RU_vine_swap<Master_matrix>::_get_birth(
+    Index negativeSimplexIndex) 
 {
   if constexpr (Master_matrix::Option_list::has_column_pairings) {
     if constexpr (Master_matrix::Option_list::has_removable_columns) {
@@ -516,8 +518,8 @@ inline typename RU_vine_swap<Master_matrix>::pos_index RU_vine_swap<Master_matri
 }
 
 template <class Master_matrix>
-inline typename RU_vine_swap<Master_matrix>::id_index RU_vine_swap<Master_matrix>::_get_row_id_from_position(
-    pos_index position)
+inline typename RU_vine_swap<Master_matrix>::ID_index RU_vine_swap<Master_matrix>::_get_row_id_from_position(
+    Pos_index position)
 {
   auto it = _positionToRowIdx().find(position);
   return it == _positionToRowIdx().end() ? position : it->second;

--- a/src/Persistence_matrix/include/gudhi/matrix.h
+++ b/src/Persistence_matrix/include/gudhi/matrix.h
@@ -143,11 +143,11 @@ namespace persistence_matrix {
 template <class PersistenceMatrixOptions = Default_options<> >
 class Matrix {
  public:
-  using Option_list = PersistenceMatrixOptions; //to make it accessible from the other classes
-  using index = typename PersistenceMatrixOptions::index_type;                 /**< Type of @ref MatIdx index. */
-  using id_index = typename PersistenceMatrixOptions::index_type;              /**< Type of @ref IDIdx index. */
-  using pos_index = typename PersistenceMatrixOptions::index_type;             /**< Type of @ref PosIdx index. */
-  using dimension_type = typename PersistenceMatrixOptions::dimension_type;    /**< Type for dimension value. */
+  using Option_list = PersistenceMatrixOptions;     //to make it accessible from the other classes
+  using Index = typename PersistenceMatrixOptions::Index;         /**< Type of @ref MatIdx index. */
+  using ID_index = typename PersistenceMatrixOptions::Index;      /**< Type of @ref IDIdx index. */
+  using Pos_index = typename PersistenceMatrixOptions::Index;     /**< Type of @ref PosIdx index. */
+  using Dimension = typename PersistenceMatrixOptions::Dimension; /**< Type for dimension value. */
 
   /**
    * @brief coefficients field type.
@@ -160,42 +160,42 @@ class Matrix {
   /**
    * @brief Type of a field element.
    */
-  using element_type = typename Field_operators::element_type;
-  using characteristic_type = typename Field_operators::characteristic_type;
+  using Element = typename Field_operators::Element;
+  using Characteristic = typename Field_operators::Characteristic;
   
   /**
    * @brief Type for a bar in the computed barcode. Stores the birth, death and dimension of the bar.
    */
-  using Bar = Persistence_interval<dimension_type, pos_index>;
+  using Bar = Persistence_interval<Dimension, Pos_index>;
 
   //tags for boost to associate a row and a column to a same cell
-  struct matrix_row_tag;
-  struct matrix_column_tag;
+  struct Matrix_row_tag;
+  struct Matrix_column_tag;
 
-  using base_hook_matrix_row =
-      boost::intrusive::list_base_hook<boost::intrusive::tag<matrix_row_tag>,
+  using Base_hook_matrix_row =
+      boost::intrusive::list_base_hook<boost::intrusive::tag<Matrix_row_tag>,
                                        boost::intrusive::link_mode<boost::intrusive::auto_unlink> >;
-  using base_hook_matrix_list_column =
-      boost::intrusive::list_base_hook<boost::intrusive::tag<matrix_column_tag>,
+  using Base_hook_matrix_list_column =
+      boost::intrusive::list_base_hook<boost::intrusive::tag<Matrix_column_tag>,
                                        boost::intrusive::link_mode<boost::intrusive::safe_link> >;
-  using base_hook_matrix_set_column =
-      boost::intrusive::set_base_hook<boost::intrusive::tag<matrix_column_tag>,
+  using Base_hook_matrix_set_column =
+      boost::intrusive::set_base_hook<boost::intrusive::tag<Matrix_column_tag>,
                                       boost::intrusive::link_mode<boost::intrusive::safe_link> >;
 
   //Two dummies are necessary to avoid double inheritance as a cell can inherit both a row and a column hook.
   struct Dummy_row_hook {};
   struct Dummy_column_hook {};
 
-  using row_hook_type = typename std::conditional<PersistenceMatrixOptions::has_row_access &&
-                                                      PersistenceMatrixOptions::has_intrusive_rows,
-                                                  base_hook_matrix_row, 
-                                                  Dummy_row_hook
-                                                 >::type;
-  using column_hook_type = typename std::conditional<
+  using Row_hook = typename std::conditional<PersistenceMatrixOptions::has_row_access &&
+                                                 PersistenceMatrixOptions::has_intrusive_rows,
+                                             Base_hook_matrix_row,
+                                             Dummy_row_hook
+                                            >::type;
+  using Column_hook = typename std::conditional<
       PersistenceMatrixOptions::column_type == Column_types::INTRUSIVE_LIST, 
-      base_hook_matrix_list_column,
+      Base_hook_matrix_list_column,
       typename std::conditional<PersistenceMatrixOptions::column_type == Column_types::INTRUSIVE_SET,
-                                base_hook_matrix_set_column, 
+                                Base_hook_matrix_set_column, 
                                 Dummy_column_hook
                                >::type
     >::type;
@@ -203,7 +203,7 @@ class Matrix {
   //Option to store the column index within the cell (additionally to the row index). Necessary only with row access.
   using Cell_column_index_option =
       typename std::conditional<PersistenceMatrixOptions::has_row_access,
-                                Cell_column_index<index>,
+                                Cell_column_index<Index>,
                                 Dummy_cell_column_index_mixin
                                >::type;
   //Option to store the value of the cell. 
@@ -211,24 +211,24 @@ class Matrix {
   using Cell_field_element_option =
       typename std::conditional<PersistenceMatrixOptions::is_z2,
                                 Dummy_cell_field_element_mixin,
-                                Cell_field_element<element_type>
+                                Cell_field_element<Element>
                                >::type;
   /**
    * @brief Type of a matrix cell. See @ref Cell for a more detailed description.
    */
-  using Cell_type = Cell<Matrix<PersistenceMatrixOptions> >;
+  using Matrix_cell = Cell<Matrix<PersistenceMatrixOptions> >;
 
   /**
    * @brief Default cell constructor/destructor, using classic new and delete.
    * For now, only used as default value for columns constructed independently outside of the matrix by the user.
    * Could be used in the future when parallel options are implemented, as usual pools are not thread safe.
    */
-  inline static New_cell_constructor<Cell_type> defaultCellConstructor;
+  inline static New_cell_constructor<Matrix_cell> defaultCellConstructor;
   /**
    * @brief Cell constructor/destructor used by the matrix. Uses a pool of cells to accelerate memory management,
    * as cells are constructed and destroyed a lot during reduction, swaps or additions.
    */
-  using Cell_constructor = Pool_cell_constructor<Cell_type>;
+  using Cell_constructor = Pool_cell_constructor<Matrix_cell>;
 
   /**
    * @brief Type used to identify a cell, for example when inserting a boundary.
@@ -237,38 +237,38 @@ class Matrix {
    * whose first element is the row index of the cell and the second element is the value of the cell (which again is
    * assumed to be non-zero). The column index of the row is always deduced from the context in which the type is used.
    */
-  using cell_rep_type = typename std::conditional<PersistenceMatrixOptions::is_z2,
-                                                  id_index,
-                                                  std::pair<id_index, element_type>
+  using Cell_representative = typename std::conditional<PersistenceMatrixOptions::is_z2,
+                                                  ID_index,
+                                                  std::pair<ID_index, Element>
                                                  >::type;
 
   /**
    * @brief Compares two cells by their position in the row. They are assume to be in the same row.
    */
   struct RowCellComp {
-    bool operator()(const Cell_type& c1, const Cell_type& c2) const {
+    bool operator()(const Matrix_cell& c1, const Matrix_cell& c2) const {
       return c1.get_column_index() < c2.get_column_index();
     }
   };
 
   /**
-   * @brief Type of the rows stored in the matrix. Is either an intrusive list of @ref Cell_type (not ordered) if
-   * @ref PersistenceMatrixOptions::has_intrusive_rows is true, or a set of @ref Cell_type (ordered by
+   * @brief Type of the rows stored in the matrix. Is either an intrusive list of @ref Matrix_cell (not ordered) if
+   * @ref PersistenceMatrixOptions::has_intrusive_rows is true, or a set of @ref Matrix_cell (ordered by
    * column index) otherwise.
    */
-  using Row_type =
+  using Row =
       typename std::conditional<PersistenceMatrixOptions::has_intrusive_rows,
-                                boost::intrusive::list<Cell_type, 
+                                boost::intrusive::list<Matrix_cell, 
                                                        boost::intrusive::constant_time_size<false>,
-                                                       boost::intrusive::base_hook<base_hook_matrix_row>
+                                                       boost::intrusive::base_hook<Base_hook_matrix_row>
                                                       >,
-                                std::set<Cell_type, RowCellComp>
+                                std::set<Matrix_cell, RowCellComp>
                                >::type;
 
-  using row_container_type =
+  using Row_container =
       typename std::conditional<PersistenceMatrixOptions::has_removable_rows,
-                                std::map<id_index, Row_type>,
-                                std::vector<Row_type>
+                                std::map<ID_index, Row>,
+                                std::vector<Row>
                                >::type;
 
   //Row access at column level
@@ -280,15 +280,15 @@ class Matrix {
   //Row access at matrix level
   using Matrix_row_access_option =
       typename std::conditional<PersistenceMatrixOptions::has_row_access,
-                                Matrix_row_access<Row_type, 
-                                                  row_container_type, 
+                                Matrix_row_access<Row, 
+                                                  Row_container, 
                                                   PersistenceMatrixOptions::has_removable_rows, 
-                                                  id_index>,
+                                                  ID_index>,
                                 Dummy_matrix_row_access
                                >::type;
 
   template <typename value_type>
-  using dictionary_type =
+  using Dictionary =
       typename std::conditional<PersistenceMatrixOptions::has_map_column_container,
                                 std::unordered_map<unsigned int, value_type>,
                                 std::vector<value_type>
@@ -310,42 +310,42 @@ class Matrix {
                                 Dummy_chain_properties
                                >::type;
 
-  using Heap_column_type = Heap_column<Matrix<PersistenceMatrixOptions> >;
-  using List_column_type = List_column<Matrix<PersistenceMatrixOptions> >;
-  using Vector_column_type = Vector_column<Matrix<PersistenceMatrixOptions> >;
-  using Naive_vector_column_type = Naive_vector_column<Matrix<PersistenceMatrixOptions> >;
-  using Set_column_type = Set_column<Matrix<PersistenceMatrixOptions> >;
-  using Unordered_set_column_type = Unordered_set_column<Matrix<PersistenceMatrixOptions> >;
-  using Intrusive_list_column_type = Intrusive_list_column<Matrix<PersistenceMatrixOptions> >;
-  using Intrusive_set_column_type = Intrusive_set_column<Matrix<PersistenceMatrixOptions> >;
+  using Matrix_heap_column = Heap_column<Matrix<PersistenceMatrixOptions> >;
+  using Matrix_list_column = List_column<Matrix<PersistenceMatrixOptions> >;
+  using Matrix_vector_column = Vector_column<Matrix<PersistenceMatrixOptions> >;
+  using Matrix_naive_vector_column = Naive_vector_column<Matrix<PersistenceMatrixOptions> >;
+  using Matrix_set_column = Set_column<Matrix<PersistenceMatrixOptions> >;
+  using Matrix_unordered_set_column = Unordered_set_column<Matrix<PersistenceMatrixOptions> >;
+  using Matrix_intrusive_list_column = Intrusive_list_column<Matrix<PersistenceMatrixOptions> >;
+  using Matrix_intrusive_set_column = Intrusive_set_column<Matrix<PersistenceMatrixOptions> >;
 
   /**
    * @brief Type of the columns stored in the matrix. The type depends on the value of
    * @ref PersistenceMatrixOptions::column_type defined in the given options. See @ref Column_types for a more detailed
    * description. All columns follow the @ref PersistenceMatrixColumn concept.
    */
-  using Column_type = typename std::conditional<
+  using Column = typename std::conditional<
         PersistenceMatrixOptions::column_type == Column_types::HEAP, 
-        Heap_column_type,
+        Matrix_heap_column,
         typename std::conditional<
             PersistenceMatrixOptions::column_type == Column_types::LIST, 
-            List_column_type,
+            Matrix_list_column,
             typename std::conditional<
                 PersistenceMatrixOptions::column_type == Column_types::SET, 
-                Set_column_type,
+                Matrix_set_column,
                 typename std::conditional<
                     PersistenceMatrixOptions::column_type == Column_types::UNORDERED_SET, 
-                    Unordered_set_column_type,
+                    Matrix_unordered_set_column,
                     typename std::conditional<
                         PersistenceMatrixOptions::column_type == Column_types::VECTOR, 
-                        Vector_column_type,
+                        Matrix_vector_column,
                         typename std::conditional<
                             PersistenceMatrixOptions::column_type == Column_types::INTRUSIVE_LIST, 
-                            Intrusive_list_column_type,
+                            Matrix_intrusive_list_column,
                             typename std::conditional<
                                 PersistenceMatrixOptions::column_type == Column_types::NAIVE_VECTOR,
-                                Naive_vector_column_type, 
-                                Intrusive_set_column_type
+                                Matrix_naive_vector_column, 
+                                Matrix_intrusive_set_column
                                 >::type
                             >::type
                         >::type
@@ -356,7 +356,7 @@ class Matrix {
 
   struct Column_z2_settings{
     Column_z2_settings() : cellConstructor() {}
-    Column_z2_settings([[maybe_unused]] characteristic_type characteristic) : cellConstructor() {}
+    Column_z2_settings([[maybe_unused]] Characteristic characteristic) : cellConstructor() {}
     Column_z2_settings(const Column_z2_settings& toCopy) : cellConstructor() {}
 
     Cell_constructor cellConstructor;   //will be replaced by more specific allocators depending on the column type.
@@ -366,8 +366,8 @@ class Matrix {
     Column_zp_settings() : operators(), cellConstructor() {}
     //purposely triggers operators() instead of operators(characteristic) as the "dummy" values for the different
     //operators can be different from -1.
-    Column_zp_settings(characteristic_type characteristic) : operators(), cellConstructor() {
-      if (characteristic != static_cast<characteristic_type>(-1)) operators.set_characteristic(characteristic);
+    Column_zp_settings(Characteristic characteristic) : operators(), cellConstructor() {
+      if (characteristic != static_cast<Characteristic>(-1)) operators.set_characteristic(characteristic);
     }
     Column_zp_settings(const Column_zp_settings& toCopy)
         : operators(toCopy.operators.get_characteristic()), cellConstructor() {}
@@ -378,21 +378,21 @@ class Matrix {
 
   // struct Column_z2_with_rows_settings {
   //   Column_z2_with_rows_settings() : cellConstructor(), rows(nullptr) {}
-  //   Column_z2_with_rows_settings([[maybe_unused]] characteristic_type characteristic)
+  //   Column_z2_with_rows_settings([[maybe_unused]] Characteristic characteristic)
   //       : cellConstructor(), rows(nullptr) {}
 
   //   Cell_constructor cellConstructor;
-  //   row_container_type* rows;
+  //   Row_container* rows;
   // };
 
   // struct Column_zp_with_rows_settings {
   //   Column_zp_with_rows_settings() : operators(), cellConstructor(), rows(nullptr) {}
-  //   Column_zp_with_rows_settings(characteristic_type characteristic)
+  //   Column_zp_with_rows_settings(Characteristic characteristic)
   //       : operators(characteristic), cellConstructor(), rows(nullptr) {}
 
   //   Field_operators operators;
   //   Cell_constructor cellConstructor;
-  //   row_container_type* rows;
+  //   Row_container* rows;
   // };
 
   //To prepare a more flexible use of the column types later (custom allocators depending on the column type etc.)
@@ -414,10 +414,10 @@ class Matrix {
   //                              >::type
   //   >::type;
 
-  using column_container_type =
+  using Column_container =
       typename std::conditional<PersistenceMatrixOptions::has_map_column_container, 
-                                std::unordered_map<index, Column_type>,
-                                std::vector<Column_type>
+                                std::unordered_map<Index, Column>,
+                                std::vector<Column>
                                >::type;
 
   static const bool hasFixedBarcode = Option_list::is_of_boundary_type && !PersistenceMatrixOptions::has_vine_update;
@@ -425,31 +425,30 @@ class Matrix {
    * @brief Type of the computed barcode. It is either a list of @ref Matrix::Bar or a vector of @ref Matrix::Bar,
    * depending if bars need to be removed from the container as some point or not.
    */
-  using barcode_type =
-      typename std::conditional<hasFixedBarcode, 
-                                std::vector<Bar>, 
-                                typename std::conditional<PersistenceMatrixOptions::has_removable_columns, 
-                                  std::list<Bar>, 
-                                  std::vector<Bar>
-                                >::type
-                               >::type;
-  using bar_dictionary_type = 
+  using Barcode = typename std::conditional<hasFixedBarcode,
+                                            std::vector<Bar>,
+                                            typename std::conditional<PersistenceMatrixOptions::has_removable_columns,
+                                                                      std::list<Bar>,
+                                                                      std::vector<Bar>
+                                                                     >::type
+                                           >::type;
+  using Bar_dictionary = 
       typename std::conditional<hasFixedBarcode,
                                 typename std::conditional<PersistenceMatrixOptions::can_retrieve_representative_cycles,
-                                  std::vector<index>,                   //RU
-                                  std::unordered_map<pos_index, index>  //boundary
+                                  std::vector<Index>,                   //RU
+                                  std::unordered_map<Pos_index, Index>  //boundary
                                 >::type,
                                 typename std::conditional<PersistenceMatrixOptions::has_removable_columns,
-                                  std::unordered_map<pos_index, typename barcode_type::iterator>,
-                                  std::vector<index>
+                                  std::unordered_map<Pos_index, typename Barcode::iterator>,
+                                  std::vector<Index>
                                 >::type
                                >::type;
 
   //default type for boundaries to permit list initialization directly in function parameters
-  using boundary_type = typename std::conditional<PersistenceMatrixOptions::is_z2, 
-                                                  std::initializer_list<id_index>,
-                                                  std::initializer_list<std::pair<id_index, element_type> >
-                                                 >::type;
+  using Boundary = typename std::conditional<PersistenceMatrixOptions::is_z2,
+                                             std::initializer_list<ID_index>,
+                                             std::initializer_list<std::pair<ID_index, Element> >
+                                            >::type;
 
   //i.e. is simple @ref boundarymatrix "boundary matrix". Also, only needed because of the reduction algorithm. 
   //TODO: remove the necessity and recalculate when needed or keep it like that?
@@ -460,20 +459,20 @@ class Matrix {
   using Matrix_dimension_option = typename std::conditional<
       PersistenceMatrixOptions::has_matrix_maximal_dimension_access || maxDimensionIsNeeded,
       typename std::conditional<PersistenceMatrixOptions::has_removable_columns, 
-                                Matrix_all_dimension_holder<dimension_type>,
-                                Matrix_max_dimension_holder<dimension_type>
+                                Matrix_all_dimension_holder<Dimension>,
+                                Matrix_max_dimension_holder<Dimension>
                                >::type,
       Dummy_matrix_dimension_holder
     >::type;
 
-  using Base_matrix_type =
+  using Master_base_matrix =
       typename std::conditional<PersistenceMatrixOptions::has_column_compression, 
                                 Base_matrix_with_column_compression<Matrix<PersistenceMatrixOptions> >,
                                 Base_matrix<Matrix<PersistenceMatrixOptions> >
                                >::type;
-  using Boundary_matrix_type = Boundary_matrix<Matrix<PersistenceMatrixOptions> >;
-  using RU_matrix_type = RU_matrix<Matrix<PersistenceMatrixOptions> >;
-  using Chain_matrix_type = Chain_matrix<Matrix<PersistenceMatrixOptions> >;
+  using Master_boundary_matrix = Boundary_matrix<Matrix<PersistenceMatrixOptions> >;
+  using Master_RU_matrix = RU_matrix<Matrix<PersistenceMatrixOptions> >;
+  using Master_chain_matrix = Chain_matrix<Matrix<PersistenceMatrixOptions> >;
 
   template <class Base>
   using Base_swap_option =
@@ -526,30 +525,30 @@ class Matrix {
   /**
    * @brief Type of a representative cycle. Vector of @ref rowindex "row indices".
    */
-  using cycle_type = std::vector<id_index>; //TODO: add coefficients
+  using Cycle = std::vector<ID_index>; //TODO: add coefficients
 
   //Return types to factorize the corresponding methods
 
   //The returned column is `const` if the matrix uses column compression
-  using returned_column_type =
+  using Returned_column =
       typename std::conditional<!isNonBasic && PersistenceMatrixOptions::has_column_compression,
-                                const Column_type,
-                                Column_type
+                                const Column,
+                                Column
                                >::type;
   //The returned row is `const` if the matrix uses column compression
-  using returned_row_type =
+  using Returned_row =
       typename std::conditional<!isNonBasic && PersistenceMatrixOptions::has_column_compression,
-                                const Row_type,
-                                Row_type
+                                const Row,
+                                Row
                                >::type;
   //If the matrix is a chain matrix, the insertion method returns the pivots of its unpaired columns used to reduce the
   //inserted boundary. Otherwise, void.
-  using insertion_return_type =
+  using Insertion_return =
       typename std::conditional<PersistenceMatrixOptions::is_of_boundary_type || !isNonBasic ||
                                     PersistenceMatrixOptions::column_indexation_type ==
                                         Column_indexation_types::POSITION,
                                 void, 
-                                std::vector<cell_rep_type>
+                                std::vector<Cell_representative>
                                >::type;
 
   /**
@@ -557,14 +556,14 @@ class Matrix {
    */
   Matrix();
   /**
-   * @brief Constructs a new matrix from the given ranges of @ref cell_rep_type. Each range corresponds to a column (the
+   * @brief Constructs a new matrix from the given ranges of @ref Cell_representative. Each range corresponds to a column (the
    * order of the ranges are preserved). The content of the ranges is assumed to be sorted by increasing IDs. If the
    * columns are representing a boundary matrix, the IDs of the simplices are also assumed to be consecutive, ordered by
    * filtration value, starting with 0.
    *
    * See @ref mp_matrices "matrix descriptions" for further details on how the given matrix is handled.
    *
-   * @tparam Container_type Range type for @ref cell_rep_type ranges. Assumed to have a begin(), end() and size()
+   * @tparam Container Range type for @ref Cell_representative ranges. Assumed to have a begin(), end() and size()
    * method.
    * @param columns For a @ref basematrix "base matrix", the columns are copied as is. If options related to homology
    * are activated, @p columns is interpreted as a boundary matrix of a **simplicial** complex. In this case,
@@ -573,7 +572,7 @@ class Matrix {
    * to be consecutive and starting with 0 (an empty boundary is interpreted as a vertex boundary and not as a non
    * existing simplex). All dimensions up to the maximal dimension of interest have to be present. If only a higher
    * dimension is of interest and not everything should be stored, then use the @ref insert_boundary method instead
-   * (after creating the matrix with the @ref Matrix(unsigned int numberOfColumns, characteristic_type characteristic)
+   * (after creating the matrix with the @ref Matrix(unsigned int numberOfColumns, Characteristic characteristic)
    * constructor preferably). If the persistence barcode has to be computed from this matrix, the simplices are also
    * assumed to be ordered by appearance order in the filtration. Also, depending of the options, the matrix is
    * eventually reduced on the fly or converted into a chain complex base, so the new matrix is not always identical to
@@ -582,8 +581,8 @@ class Matrix {
    * @ref PersistenceMatrixOptions::is_z2 is false. Default value is 11. Ignored if
    * @ref PersistenceMatrixOptions::is_z2 is true.
    */
-  template <class Container_type = boundary_type>
-  Matrix(const std::vector<Container_type>& columns, characteristic_type characteristic = 11);
+  template <class Container = Boundary>
+  Matrix(const std::vector<Container>& columns, Characteristic characteristic = 11);
   /**
    * @brief Constructs a new empty matrix and reserves space for the given number of columns.
    *
@@ -593,7 +592,7 @@ class Matrix {
    * @ref set_characteristic before calling for the first time a method needing it. Ignored if
    * @ref PersistenceMatrixOptions::is_z2 is true.
    */
-  Matrix(unsigned int numberOfColumns, characteristic_type characteristic = static_cast<characteristic_type>(-1));
+  Matrix(unsigned int numberOfColumns, Characteristic characteristic = static_cast<Characteristic>(-1));
   /**
    * @brief Constructs a new empty matrix with the given comparator functions. Only available when those comparators
    * are necessary.
@@ -614,8 +613,8 @@ class Matrix {
    * @param deathComparator Method taking two @ref PosIdx indices as parameter and returns true if and only if the first
    * face is associated to a bar with strictly smaller death than the bar associated to the second one.
    */
-  Matrix(const std::function<bool(pos_index,pos_index)>& birthComparator, 
-         const std::function<bool(pos_index,pos_index)>& deathComparator);
+  Matrix(const std::function<bool(Pos_index,Pos_index)>& birthComparator, 
+         const std::function<bool(Pos_index,Pos_index)>& deathComparator);
   /**
    * @brief Constructs a new matrix from the given ranges with the given comparator functions.
    * Only available when those comparators are necessary.
@@ -625,12 +624,12 @@ class Matrix {
    *   - @ref PersistenceMatrixOptions::has_vine_update = true
    *   - @ref PersistenceMatrixOptions::has_column_pairings = false
    *
-   * See description of @ref Matrix(const std::vector<Container_type>& columns, characteristic_type characteristic)
+   * See description of @ref Matrix(const std::vector<Container>& columns, Characteristic characteristic)
    * for more information about  @p orderedBoundaries and
-   * @ref Matrix(const std::function<bool(pos_index,pos_index)>&, const std::function<bool(pos_index,pos_index)>&)
+   * @ref Matrix(const std::function<bool(Pos_index,Pos_index)>&, const std::function<bool(Pos_index,Pos_index)>&)
    * for more information about the comparators.
    *
-   * @tparam Boundary_type Range type for @ref cell_rep_type ranges. Assumed to have a begin(), end() and size() method.
+   * @tparam Boundary_container Range type for @ref Cell_representative ranges. Assumed to have a begin(), end() and size() method.
    * @param orderedBoundaries Vector of ordered boundaries in filtration order. Indexed continuously starting at 0.
    * @param birthComparator Method taking two @ref PosIdx indices as parameter and returns true if and only if the first
    * face is associated to a bar with strictly smaller birth than the bar associated to the second one.
@@ -640,11 +639,11 @@ class Matrix {
    * @ref PersistenceMatrixOptions::is_z2 is false. Default value is 11.
    * Ignored if @ref PersistenceMatrixOptions::is_z2 is true.
    */
-  template <class Boundary_type = boundary_type>
-  Matrix(const std::vector<Boundary_type>& orderedBoundaries, 
-         const std::function<bool(pos_index,pos_index)>& birthComparator,
-         const std::function<bool(pos_index,pos_index)>& deathComparator, 
-         characteristic_type characteristic = 11);
+  template <class Boundary_container = Boundary>
+  Matrix(const std::vector<Boundary_container>& orderedBoundaries, 
+         const std::function<bool(Pos_index,Pos_index)>& birthComparator,
+         const std::function<bool(Pos_index,Pos_index)>& deathComparator, 
+         Characteristic characteristic = 11);
   /**
    * @brief Constructs a new empty matrix and reserves space for the given number of columns.
    * Only available when those comparators are necessary.
@@ -655,7 +654,7 @@ class Matrix {
    *   - @ref PersistenceMatrixOptions::has_column_pairings = false
    *
    * See description of
-   * @ref Matrix(const std::function<bool(pos_index,pos_index)>&, const std::function<bool(pos_index,pos_index)>&)
+   * @ref Matrix(const std::function<bool(Pos_index,Pos_index)>&, const std::function<bool(Pos_index,Pos_index)>&)
    * for more information about the comparators.
    *
    * @param numberOfColumns Number of columns to reserve space for.
@@ -669,9 +668,9 @@ class Matrix {
    * Ignored if @ref PersistenceMatrixOptions::is_z2 is true.
    */
   Matrix(unsigned int numberOfColumns, 
-         const std::function<bool(pos_index,pos_index)>& birthComparator,
-         const std::function<bool(pos_index,pos_index)>& deathComparator, 
-         characteristic_type characteristic = static_cast<characteristic_type>(-1));
+         const std::function<bool(Pos_index,Pos_index)>& birthComparator,
+         const std::function<bool(Pos_index,Pos_index)>& deathComparator, 
+         Characteristic characteristic = static_cast<Characteristic>(-1));
   /**
    * @brief Copy constructor.
    * 
@@ -689,7 +688,7 @@ class Matrix {
   ~Matrix();
 
   //TODO: compatibility with multi fields:
-  //  - set_characteristic(characteristic_type min, characteristic_type max)
+  //  - set_characteristic(Characteristic min, Characteristic max)
   //  - readapt reduction?
   /**
    * @brief Sets the characteristic of the coefficient field if @ref PersistenceMatrixOptions::is_z2 is false,
@@ -702,35 +701,35 @@ class Matrix {
    * 
    * @param characteristic The characteristic to set.
    */
-  void set_characteristic(characteristic_type characteristic);
+  void set_characteristic(Characteristic characteristic);
 
   // (TODO: if there is no row access and the column type corresponds to the internal column type of the matrix, 
   // moving the column instead of copying it should be possible. Is it worth implementing it?)
   /**
-   * @brief Inserts a new ordered column at the end of the matrix by copying the given range of @ref cell_rep_type.
+   * @brief Inserts a new ordered column at the end of the matrix by copying the given range of @ref Cell_representative.
    * The content of the range is assumed to be sorted by increasing ID value. 
    *
    * Only available for @ref basematrix "base matrices".
    * Otherwise use @ref insert_boundary which will deduce a new column from the boundary given.
    * 
-   * @tparam Container_type Range of @ref cell_rep_type. Assumed to have a begin(), end() and size() method.
+   * @tparam Container Range of @ref Cell_representative. Assumed to have a begin(), end() and size() method.
    * @param column Column to be inserted.
    */
-  template <class Container_type>
-  void insert_column(const Container_type& column);
+  template <class Container>
+  void insert_column(const Container& column);
   /**
-   * @brief Inserts a new ordered column at the given index by copying the given range of @ref cell_rep_type.
+   * @brief Inserts a new ordered column at the given index by copying the given range of @ref Cell_representative.
    * There should not be any other column inserted at that index which was not explicitly removed before.
    * The content of the range is assumed to be sorted by increasing ID value. 
    *
    * Only available for @ref basematrix "base matrices" without column compression and without row access.
    * 
-   * @tparam Container_type Range of @ref cell_rep_type. Assumed to have a begin(), end() and size() method.
+   * @tparam Container Range of @ref Cell_representative. Assumed to have a begin(), end() and size() method.
    * @param column Column to be inserted.
    * @param columnIndex @ref MatIdx index to which the column has to be inserted.
    */
-  template <class Container_type>
-  void insert_column(const Container_type& column, index columnIndex);
+  template <class Container>
+  void insert_column(const Container& column, Index columnIndex);
   //TODO: for simple boundary matrices, add an index pointing to the first column inserted after the last call of 
   //get_current_barcode to enable several calls to get_current_barcode
   /**
@@ -738,7 +737,7 @@ class Matrix {
    * This means that it is assumed that this method is called on boundaries in the order of the filtration.
    * It also assumes that the faces in the given boundary are identified by their relative position in the filtration,
    * starting at 0. If it is not the case, use the other
-   * @ref insert_boundary(id_index faceIndex, const Boundary_type& boundary, dimension_type dim) "insert_boundary"
+   * @ref insert_boundary(ID_index faceIndex, const Boundary_container& boundary, Dimension dim) "insert_boundary"
    * instead by indicating the face ID used in the boundaries when the face is inserted.
    *
    * Different to the constructor, the boundaries do not have to come from a simplicial complex, but also from
@@ -757,15 +756,15 @@ class Matrix {
    * older column IDIdxs`, where the combination is deduced while reducing the given boundary. If the barcode is stored,
    * it will also be updated.
    *
-   * @tparam Boundary_type Range of @ref cell_rep_type. Assumed to have a begin(), end() and size() method.
+   * @tparam Boundary_container Range of @ref Cell_representative. Assumed to have a begin(), end() and size() method.
    * @param boundary Boundary generating the new column. The content should be ordered by ID.
    * @param dim Dimension of the face whose boundary is given. If the complex is simplicial,
    * this parameter can be omitted as it can be deduced from the size of the boundary.
    * @return If it is a @ref chainmatrix "chain matrix", the method returns the @ref MatIdx indices of the unpaired
    * chains used to reduce the boundary. Otherwise, nothing.
    */
-  template <class Boundary_type = boundary_type>
-  insertion_return_type insert_boundary(const Boundary_type& boundary, dimension_type dim = -1);
+  template <class Boundary_container = Boundary>
+  Insertion_return insert_boundary(const Boundary_container& boundary, Dimension dim = -1);
   /**
    * @brief Only available for @ref mp_matrices "non-basic matrices".
    * It does the same as the other version, but allows the boundary faces to be identified without restrictions
@@ -776,7 +775,7 @@ class Matrix {
    * for @ref mp_matrices "non-basic matrices", the faces are inserted by order of filtration), it is sufficient to
    * indicate the ID of the face being inserted.
    *
-   * @tparam Boundary_type Range of @ref cell_rep_type. Assumed to have a begin(), end() and size() method.
+   * @tparam Boundary_container Range of @ref Cell_representative. Assumed to have a begin(), end() and size() method.
    * @param faceIndex @ref IDIdx index to use to identify the new face.
    * @param boundary Boundary generating the new column. The indices of the boundary have to correspond to the
    * @p faceIndex values of precedent calls of the method for the corresponding faces and should be ordered in
@@ -786,19 +785,19 @@ class Matrix {
    * @return If it is a @ref chainmatrix "chain matrix", the method returns the @ref MatIdx indices of the unpaired
    * chains used to reduce the boundary. Otherwise, nothing.
    */
-  template <class Boundary_type = boundary_type>
-  insertion_return_type insert_boundary(id_index faceIndex, const Boundary_type& boundary, dimension_type dim = -1);
+  template <class Boundary_container = Boundary>
+  Insertion_return insert_boundary(ID_index faceIndex, const Boundary_container& boundary, Dimension dim = -1);
 
   /**
    * @brief Returns the column at the given @ref MatIdx index.
    * For @ref boundarymatrix "RU matrices", is equivalent to
-   * @ref get_column(index columnIndex, bool inR) "get_column(columnIndex, true)".
+   * @ref get_column(Index columnIndex, bool inR) "get_column(columnIndex, true)".
    * The type of the column depends on the choosen options, see @ref PersistenceMatrixOptions::column_type.
    *
    * @param columnIndex @ref MatIdx index of the column to return.
    * @return Reference to the column. Is `const` if the matrix has column compression.
    */
-  returned_column_type& get_column(index columnIndex);
+  Returned_column& get_column(Index columnIndex);
   /**
    * @brief Only available for @ref chainmatrix "chain matrices". Returns the column at the given @ref MatIdx index.
    * The type of the column depends on the choosen options, see @ref PersistenceMatrixOptions::column_type.
@@ -806,7 +805,7 @@ class Matrix {
    * @param columnIndex @ref MatIdx index of the column to return.
    * @return Const reference to the column.
    */
-  const Column_type& get_column(index columnIndex) const;
+  const Column& get_column(Index columnIndex) const;
   //TODO: there is no particular reason that this method is not available for identifier indexing,
   // just has to be added to the interface...
   /**
@@ -819,20 +818,20 @@ class Matrix {
    * @param inR If true, returns the column in \f$ R \f$, if false, returns the column in \f$ U \f$.
    * @return Const reference to the column.
    */
-  const Column_type& get_column(index columnIndex, bool inR);
+  const Column& get_column(Index columnIndex, bool inR);
 
   //TODO: update column indices when reordering rows (after lazy swap) such that always MatIdx are returned.
   /**
    * @brief Only available if @ref PersistenceMatrixOptions::has_row_access is true. Returns the row at the given
    * @ref rowindex "row index". For @ref boundarymatrix "RU matrices", is equivalent to
-   * @ref get_row(id_index rowIndex, bool inR) "get_row(columnIndex, true)". The type of the row depends on the
+   * @ref get_row(ID_index rowIndex, bool inR) "get_row(columnIndex, true)". The type of the row depends on the
    * choosen options, see @ref PersistenceMatrixOptions::has_intrusive_rows.
    *
    * @param rowIndex @ref rowindex "Row index" of the row to return: @ref IDIdx for @ref chainmatrix "chain matrices" or
    * updated @ref IDIdx for @ref boundarymatrix "boundary matrices" if swaps occurred.
    * @return Reference to the row. Is `const` if the matrix has column compression.
    */
-  returned_row_type& get_row(id_index rowIndex);
+  Returned_row& get_row(ID_index rowIndex);
   /**
    * @brief Only available for @ref chainmatrix "chain matrices" and matrices with column compression.
    * Returns the row at the given @ref rowindex "row index".
@@ -842,7 +841,7 @@ class Matrix {
    * or updated @ref IDIdx for @ref boundarymatrix "boundary matrices" if swaps occurred.
    * @return Const reference to the row.
    */
-  const Row_type& get_row(id_index rowIndex) const;
+  const Row& get_row(ID_index rowIndex) const;
   //TODO: there is no particular reason that this method is not available for identifier indexing,
   // just has to be added to the interface...
   /**
@@ -855,7 +854,7 @@ class Matrix {
    * @param inR If true, returns the row in \f$ R \f$, if false, returns the row in \f$ U \f$.
    * @return Const reference to the row.
    */
-  const Row_type& get_row(id_index rowIndex, bool inR);
+  const Row& get_row(ID_index rowIndex, bool inR);
 
   /**
    * @brief Only available for @ref basematrix "base matrices" without column compression and if
@@ -865,7 +864,7 @@ class Matrix {
    *
    * @param columnIndex @ref MatIdx index of the column to remove.
    */
-  void remove_column(index columnIndex);
+  void remove_column(Index columnIndex);
   //TODO: rename method to be less confusing.
   /**
    * @brief The effect varies depending on the matrices and the options:
@@ -889,7 +888,7 @@ class Matrix {
    *
    * @param rowIndex @ref rowindex "Row index" of the empty row to remove.
    */
-  void erase_empty_row(id_index rowIndex);
+  void erase_empty_row(ID_index rowIndex);
   //TODO: for chain matrices, replace IDIdx input with MatIdx input to homogenize.
   /**
    * @brief Only available for @ref boundarymatrix "RU" and @ref chainmatrix "chain matrices" and if
@@ -909,7 +908,7 @@ class Matrix {
    * @param columnIndex If @ref boundarymatrix "boundary matrix", @ref MatIdx index of the face to remove, otherwise the
    * @ref IDIdx index.
    */
-  void remove_maximal_face(index columnIndex);
+  void remove_maximal_face(Index columnIndex);
   //TODO: See if it would be better to use something more general than a vector for columnsToSwap, such that
   // the user do not have to construct the vector from scratch. Like passing iterators instead. But it would be nice,
   // to still be able to do (face, {})...
@@ -927,7 +926,7 @@ class Matrix {
    * the matrix. If the user has an easy access to the @ref IDIdx of the faces in the order of filtration, passing them
    * by argument with @p columnsToSwap allows to skip a linear search process. Typically, if the user knows that the
    * face he wants to remove is already the last face of the filtration, calling
-   * @ref remove_maximal_face(id_index faceIndex, const std::vector<id_index>& columnsToSwap)
+   * @ref remove_maximal_face(ID_index faceIndex, const std::vector<ID_index>& columnsToSwap)
    * "remove_maximal_face(faceID, {})" will be faster than @ref remove_last().
    *
    * See also @ref remove_last.
@@ -935,7 +934,7 @@ class Matrix {
    * @param faceIndex @ref IDIdx index of the face to remove
    * @param columnsToSwap Vector of @ref IDIdx indices of the faces coming after @p faceIndex in the filtration.
    */
-  void remove_maximal_face(id_index faceIndex, const std::vector<id_index>& columnsToSwap);
+  void remove_maximal_face(ID_index faceIndex, const std::vector<ID_index>& columnsToSwap);
   /**
    * @brief Removes the last inserted column/face from the matrix.
    * If the matrix is @ref mp_matrices "non basic", @ref PersistenceMatrixOptions::has_removable_columns has to be true
@@ -949,7 +948,7 @@ class Matrix {
    * For @ref chainmatrix "chain matrices", if @ref PersistenceMatrixOptions::has_vine_update is true, the last face
    * does not have to be at the end of the matrix and therefore has to be searched first. In this case, if the user
    * already knows the @ref IDIdx of the last face, calling
-   * @ref remove_maximal_face(id_index faceIndex, const std::vector<id_index>& columnsToSwap)
+   * @ref remove_maximal_face(ID_index faceIndex, const std::vector<ID_index>& columnsToSwap)
    * "remove_maximal_face(faceID, {})" instead allows to skip the search.
    */
   void remove_last();
@@ -961,20 +960,20 @@ class Matrix {
    *
    * @return The maximal dimension.
    */
-  dimension_type get_max_dimension() const;
+  Dimension get_max_dimension() const;
   /**
    * @brief Returns the current number of columns in the matrix.
    * 
    * @return The number of columns.
    */
-  index get_number_of_columns() const;
+  Index get_number_of_columns() const;
   /**
    * @brief Returns the dimension of the given face. Only available for @ref mp_matrices "non-basic matrices".
    * 
    * @param columnIndex @ref MatIdx index of the column representing the face.
    * @return Dimension of the face.
    */
-  dimension_type get_column_dimension(index columnIndex) const;
+  Dimension get_column_dimension(Index columnIndex) const;
 
   /**
    * @brief Adds column at @p sourceColumnIndex onto the column at @p targetColumnIndex in the matrix. Is available
@@ -985,12 +984,13 @@ class Matrix {
    * For @ref basematrix "basic matrices" with column compression, the representatives are summed together, which means
    * that all column compressed together with the target column are affected by the change, not only the target.
    * 
-   * @tparam Index_type Any signed or unsigned integer type.
+   * @tparam Integer_index Any signed or unsigned integer type.
    * @param sourceColumnIndex @ref MatIdx index of the column to add.
    * @param targetColumnIndex @ref MatIdx index of the target column.
    */
-  template <typename Index_type>
-  std::enable_if_t<std::is_integral_v<Index_type> > add_to(Index_type sourceColumnIndex, Index_type targetColumnIndex);
+  template <typename Integer_index>
+  std::enable_if_t<std::is_integral_v<Integer_index> > add_to(Integer_index sourceColumnIndex,
+                                                              Integer_index targetColumnIndex);
   /**
    * @brief Adds the given range of @ref Cell onto the column at @p targetColumnIndex in the matrix. Only available 
    * for @ref basematrix "basic matrices".
@@ -1004,7 +1004,7 @@ class Matrix {
    * @param targetColumnIndex @ref MatIdx index of the target column.
    */
   template <class Cell_range>
-  std::enable_if_t<!std::is_integral_v<Cell_range> > add_to(const Cell_range& sourceColumn, index targetColumnIndex);
+  std::enable_if_t<!std::is_integral_v<Cell_range> > add_to(const Cell_range& sourceColumn, Index targetColumnIndex);
 
   /**
    * @brief Multiplies the target column with the coefficient and then adds the source column to it.
@@ -1017,15 +1017,15 @@ class Matrix {
    * For @ref basematrix "basic matrices" with column compression, the representatives are summed together, which means
    * that all column compressed together with the target column are affected by the change, not only the target.
    * 
-   * @tparam Index_type Any signed or unsigned integer type.
+   * @tparam Integer_index Any signed or unsigned integer type.
    * @param sourceColumnIndex @ref MatIdx index of the column to add.
    * @param coefficient Value to multiply.
    * @param targetColumnIndex @ref MatIdx index of the target column.
    */
-  template <typename Index_type>
-  std::enable_if_t<std::is_integral_v<Index_type> > multiply_target_and_add_to(Index_type sourceColumnIndex,
+  template <typename Integer_index>
+  std::enable_if_t<std::is_integral_v<Integer_index> > multiply_target_and_add_to(Integer_index sourceColumnIndex,
                                                                                int coefficient,
-                                                                               Index_type targetColumnIndex);
+                                                                               Integer_index targetColumnIndex);
   /**
    * @brief Multiplies the target column with the coefficient and then adds the given range of @ref Cell to it.
    * That is: `targetColumn = (targetColumn * coefficient) + sourceColumn`. Only available for
@@ -1043,7 +1043,7 @@ class Matrix {
   template <class Cell_range>
   std::enable_if_t<!std::is_integral_v<Cell_range> > multiply_target_and_add_to(const Cell_range& sourceColumn,
                                                                                 int coefficient,
-                                                                                index targetColumnIndex);
+                                                                                Index targetColumnIndex);
 
   /**
    * @brief Multiplies the source column with the coefficient before adding it to the target column.
@@ -1056,15 +1056,15 @@ class Matrix {
    * For @ref basematrix "basic matrices" with column compression, the representatives are summed together, which means
    * that all column compressed together with the target column are affected by the change, not only the target.
    * 
-   * @tparam Index_type Any signed or unsigned integer type.
+   * @tparam Integer_index Any signed or unsigned integer type.
    * @param coefficient Value to multiply.
    * @param sourceColumnIndex @ref MatIdx index of the column to add.
    * @param targetColumnIndex @ref MatIdx index of the target column.
    */
-  template <typename Index_type>
-  std::enable_if_t<std::is_integral_v<Index_type> > multiply_source_and_add_to(int coefficient,
-                                                                               Index_type sourceColumnIndex,
-                                                                               Index_type targetColumnIndex);
+  template <typename Integer_index>
+  std::enable_if_t<std::is_integral_v<Integer_index> > multiply_source_and_add_to(int coefficient,
+                                                                               Integer_index sourceColumnIndex,
+                                                                               Integer_index targetColumnIndex);
   /**
    * @brief Multiplies the source column with the coefficient before adding it to the target column.
    * That is: `targetColumn += (coefficient * sourceColumn)`. The source column will **not** be modified.
@@ -1082,7 +1082,7 @@ class Matrix {
   template <class Cell_range>
   std::enable_if_t<!std::is_integral_v<Cell_range> > multiply_source_and_add_to(int coefficient,
                                                                                 const Cell_range& sourceColumn,
-                                                                                index targetColumnIndex);
+                                                                                Index targetColumnIndex);
 
   /**
    * @brief Zeroes the cell at the given coordinates. Not available for @ref chainmatrix "chain matrices" and for
@@ -1091,12 +1091,12 @@ class Matrix {
    * matrix.
    *
    * For @ref boundarymatrix "RU matrices", equivalent to
-   * @ref zero_cell(index columnIndex, id_index rowIndex, bool inR) "zero_cell(columnIndex, rowIndex, true)".
+   * @ref zero_cell(Index columnIndex, ID_index rowIndex, bool inR) "zero_cell(columnIndex, rowIndex, true)".
    *
    * @param columnIndex @ref MatIdx index of the column of the cell.
    * @param rowIndex @ref rowindex "Row index" of the row of the cell.
    */
-  void zero_cell(index columnIndex, id_index rowIndex);
+  void zero_cell(Index columnIndex, ID_index rowIndex);
   /**
    * @brief Only available for @ref boundarymatrix "RU matrices". Zeroes the cell at the given coordinates in \f$ R \f$
    * if @p inR is true or in \f$ U \f$ if @p inR is false. Should be used with care to not destroy the validity of the
@@ -1106,7 +1106,7 @@ class Matrix {
    * @param rowIndex @ref rowindex "Row index" of the row of the cell.
    * @param inR Boolean indicating in which matrix to zero: if true in \f$ R \f$ and if false in \f$ U \f$.
    */
-  void zero_cell(index columnIndex, id_index rowIndex, bool inR);
+  void zero_cell(Index columnIndex, ID_index rowIndex, bool inR);
   /**
    * @brief Zeroes the column at the given index. Not available for @ref chainmatrix "chain matrices" and for
    * @ref basematrix "base matrices" with column compression. In general, should be used with care with
@@ -1114,11 +1114,11 @@ class Matrix {
    * matrix.
    *
    * For @ref boundarymatrix "RU matrices", equivalent to
-   * @ref zero_column(index columnIndex, bool inR) "zero_column(columnIndex, true)".
+   * @ref zero_column(Index columnIndex, bool inR) "zero_column(columnIndex, true)".
    *
    * @param columnIndex @ref MatIdx index of the column to zero.
    */
-  void zero_column(index columnIndex);
+  void zero_column(Index columnIndex);
   /**
    * @brief Only available for @ref boundarymatrix "RU matrices". Zeroes the column at the given index in \f$ R \f$ if
    * @p inR is true or in \f$ U \f$ if @p inR is false. Should be used with care to not destroy the validity of the
@@ -1127,12 +1127,12 @@ class Matrix {
    * @param columnIndex @ref MatIdx index of the column to zero.
    * @param inR Boolean indicating in which matrix to zero: if true in \f$ R \f$ and if false in \f$ U \f$.
    */
-  void zero_column(index columnIndex, bool inR);
+  void zero_column(Index columnIndex, bool inR);
   /**
    * @brief Indicates if the cell at given coordinates has value zero.
    *
    * For @ref boundarymatrix "RU matrices", equivalent to
-   * @ref is_zero_cell(index columnIndex, id_index rowIndex, bool inR) const
+   * @ref is_zero_cell(Index columnIndex, ID_index rowIndex, bool inR) const
    * "is_zero_cell(columnIndex, rowIndex, true)".
    *
    * @param columnIndex @ref MatIdx index of the column of the cell.
@@ -1140,7 +1140,7 @@ class Matrix {
    * @return true If the cell has value zero.
    * @return false Otherwise.
    */
-  bool is_zero_cell(index columnIndex, id_index rowIndex);
+  bool is_zero_cell(Index columnIndex, ID_index rowIndex);
   /**
    * @brief Only available for @ref boundarymatrix "RU matrices". Indicates if the cell at given coordinates has value
    * zero in \f$ R \f$ if @p inR is true or in \f$ U \f$ if @p inR is false.
@@ -1151,12 +1151,12 @@ class Matrix {
    * @return true If the cell has value zero.
    * @return false Otherwise.
    */
-  bool is_zero_cell(index columnIndex, id_index rowIndex, bool inR) const;
+  bool is_zero_cell(Index columnIndex, ID_index rowIndex, bool inR) const;
   /**
    * @brief Indicates if the column at given index has value zero.
    *
    * For @ref boundarymatrix "RU matrices", equivalent to
-   * @ref is_zero_column(index columnIndex, bool inR) "is_zero_column(columnIndex, true)".
+   * @ref is_zero_column(Index columnIndex, bool inR) "is_zero_column(columnIndex, true)".
    *
    * Note that for @ref chainmatrix "chain matrices", this method should always return false, as a valid
    * @ref chainmatrix "chain matrix" never has empty columns.
@@ -1165,7 +1165,7 @@ class Matrix {
    * @return true If the column has value zero.
    * @return false Otherwise.
    */
-  bool is_zero_column(index columnIndex);
+  bool is_zero_column(Index columnIndex);
   /**
    * @brief Only available for @ref boundarymatrix "RU matrices". Indicates if the column at given index has value zero
    * in \f$ R \f$ if @p inR is true or in \f$ U \f$ if @p inR is false.
@@ -1177,7 +1177,7 @@ class Matrix {
    * @return true If the column has value zero.
    * @return false Otherwise.
    */
-  bool is_zero_column(index columnIndex, bool inR);
+  bool is_zero_column(Index columnIndex, bool inR);
 
   /**
    * @brief Returns the @ref MatIdx index of the column which has the given @ref rowindex "row index" as pivot. Only
@@ -1191,7 +1191,7 @@ class Matrix {
    * @param faceIndex @ref rowindex "Row index" of the pivot.
    * @return @ref MatIdx index of the column with the given pivot.
    */
-  index get_column_with_pivot(id_index faceIndex) const;
+  Index get_column_with_pivot(ID_index faceIndex) const;
   /**
    * @brief Returns the @ref rowindex "row index" of the pivot of the given column. Only available for
    * @ref mp_matrices "non-basic matrices".
@@ -1199,7 +1199,7 @@ class Matrix {
    * @param columnIndex @ref MatIdx index of the column
    * @return The @ref rowindex "row index" of the pivot.
    */
-  id_index get_pivot(index columnIndex);
+  ID_index get_pivot(Index columnIndex);
 
   /**
    * @brief Assign operator.
@@ -1234,7 +1234,7 @@ class Matrix {
    * @return A reference to the barcode. The barcode is a vector of @ref Matrix::Bar. A bar stores three informations:
    * the @ref PosIdx birth index, the @ref PosIdx death index and the dimension of the bar.
    */
-  const barcode_type& get_current_barcode();
+  const Barcode& get_current_barcode();
   /**
    * @brief Returns the current barcode of the matrix. Available only if
    * @ref PersistenceMatrixOptions::has_column_pairings is true.
@@ -1247,7 +1247,7 @@ class Matrix {
    * @return A const reference to the barcode. The barcode is a vector of @ref Matrix::Bar. A bar stores three
    * informations: the @ref PosIdx birth index, the @ref PosIdx death index and the dimension of the bar.
    */
-  const barcode_type& get_current_barcode() const;
+  const Barcode& get_current_barcode() const;
 
   /**
    * @brief Only available for @ref basematrix "base matrices" without column compression and simple
@@ -1259,7 +1259,7 @@ class Matrix {
    * @param columnIndex1 First column @ref MatIdx index to swap.
    * @param columnIndex2 Second column @ref MatIdx index to swap.
    */
-  void swap_columns(index columnIndex1, index columnIndex2);
+  void swap_columns(Index columnIndex1, Index columnIndex2);
   /**
    * @brief Only available for @ref basematrix "base matrices" without column compression and simple
    * @ref boundarymatrix "boundary matrices" (only storing \f$ R \f$) and if
@@ -1270,7 +1270,7 @@ class Matrix {
    * @param rowIndex1 First @ref rowindex "row index" to swap.
    * @param rowIndex2 Second @ref rowindex "row index" to swap.
    */
-  void swap_rows(index rowIndex1, index rowIndex2);
+  void swap_rows(Index rowIndex1, Index rowIndex2);
   //TODO: find better name. And benchmark also to verify if it is really worth it to have this extra version in addition
   //to vine_swap.
   /**
@@ -1284,7 +1284,7 @@ class Matrix {
    * @return true If the barcode changed from the swap.
    * @return false Otherwise.
    */
-  bool vine_swap_with_z_eq_1_case(pos_index index);
+  bool vine_swap_with_z_eq_1_case(Pos_index index);
   /**
    * @brief Only available if @ref PersistenceMatrixOptions::has_vine_update is true and if it is either a
    * @ref chainmatrix "chain matrix" or @ref PersistenceMatrixOptions::column_indexation_type is set to
@@ -1298,7 +1298,7 @@ class Matrix {
    * @p columnIndex2. The method returns the @ref MatIdx of the column which has now, after the swap, the @ref PosIdx
    * \f$ max(pos1, pos2) \f$.
    */
-  index vine_swap_with_z_eq_1_case(index columnIndex1, index columnIndex2);
+  Index vine_swap_with_z_eq_1_case(Index columnIndex1, Index columnIndex2);
   /**
    * @brief Only available if @ref PersistenceMatrixOptions::has_vine_update is true and if it is either a
    * @ref boundarymatrix "boundary matrix" or @ref PersistenceMatrixOptions::column_indexation_type is set to
@@ -1314,7 +1314,7 @@ class Matrix {
    * @return true If the barcode changed from the swap.
    * @return false Otherwise.
    */
-  bool vine_swap(pos_index index);
+  bool vine_swap(Pos_index index);
   /**
    * @brief Only available if @ref PersistenceMatrixOptions::has_vine_update is true and if it is either a
    * @ref chainmatrix "chain matrix" or @ref PersistenceMatrixOptions::column_indexation_type is set to
@@ -1332,7 +1332,7 @@ class Matrix {
    * @p columnIndex2. The method returns the @ref MatIdx of the column which has now, after the swap, the @ref PosIdx
    * \f$ max(pos1, pos2) \f$.
    */
-  index vine_swap(index columnIndex1, index columnIndex2);
+  Index vine_swap(Index columnIndex1, Index columnIndex2);
 
   //TODO: Rethink the interface for representative cycles
   /**
@@ -1349,7 +1349,7 @@ class Matrix {
    * 
    * @return A const reference to the vector of representative cycles.
    */
-  const std::vector<cycle_type>& get_representative_cycles();
+  const std::vector<Cycle>& get_representative_cycles();
   /**
    * @brief Only available if @ref PersistenceMatrixOptions::can_retrieve_representative_cycles is true.
    * Returns the cycle representing the given bar.
@@ -1357,10 +1357,10 @@ class Matrix {
    * @param bar A bar from the current barcode.
    * @return A const reference to the cycle representing @p bar.
    */
-  const cycle_type& get_representative_cycle(const Bar& bar);
+  const Cycle& get_representative_cycle(const Bar& bar);
 
  private:
-  using Matrix_type = 
+  using Underlying_matrix = 
     typename std::conditional<
         isNonBasic,
         typename std::conditional<
@@ -1371,32 +1371,32 @@ class Matrix {
                 typename std::conditional<
                     PersistenceMatrixOptions::column_indexation_type == Column_indexation_types::CONTAINER || 
                       PersistenceMatrixOptions::column_indexation_type == Column_indexation_types::POSITION,
-                    RU_matrix_type, Id_to_index_overlay<RU_matrix_type, Matrix<PersistenceMatrixOptions> >
+                    Master_RU_matrix, Id_to_index_overlay<Master_RU_matrix, Matrix<PersistenceMatrixOptions> >
                 >::type,
                 typename std::conditional<
                     PersistenceMatrixOptions::column_indexation_type == Column_indexation_types::CONTAINER || 
                       PersistenceMatrixOptions::column_indexation_type == Column_indexation_types::POSITION,
-                    Boundary_matrix_type,
-                    Id_to_index_overlay<Boundary_matrix_type, Matrix<PersistenceMatrixOptions> >
+                    Master_boundary_matrix,
+                    Id_to_index_overlay<Master_boundary_matrix, Matrix<PersistenceMatrixOptions> >
                 >::type
             >::type,
             typename std::conditional<
                 PersistenceMatrixOptions::column_indexation_type == Column_indexation_types::CONTAINER, 
-                Chain_matrix_type,
+                Master_chain_matrix,
                 typename std::conditional<
                     PersistenceMatrixOptions::column_indexation_type == Column_indexation_types::POSITION,
-                    Position_to_index_overlay<Chain_matrix_type, Matrix<PersistenceMatrixOptions> >,
-                    Id_to_index_overlay<Chain_matrix_type, Matrix<PersistenceMatrixOptions> >
+                    Position_to_index_overlay<Master_chain_matrix, Matrix<PersistenceMatrixOptions> >,
+                    Id_to_index_overlay<Master_chain_matrix, Matrix<PersistenceMatrixOptions> >
                 >::type
             >::type
         >::type,
-        Base_matrix_type
+        Master_base_matrix
     >::type;
 
   // Field_operators* operators_;
   // Cell_constructor* cellPool_;
   Column_settings* colSettings_;  //pointer because the of swap operator on matrix_ which also stores the pointer
-  Matrix_type matrix_;
+  Underlying_matrix matrix_;
 
   static constexpr void _assert_options();
 };
@@ -1413,9 +1413,9 @@ inline Matrix<PersistenceMatrixOptions>::Matrix()
 }
 
 template <class PersistenceMatrixOptions>
-template <class Container_type>
-inline Matrix<PersistenceMatrixOptions>::Matrix(const std::vector<Container_type>& columns,
-                                                characteristic_type characteristic)
+template <class Container>
+inline Matrix<PersistenceMatrixOptions>::Matrix(const std::vector<Container>& columns,
+                                                Characteristic characteristic)
     : colSettings_(new Column_settings(characteristic)),
       matrix_(columns, colSettings_) 
 {
@@ -1427,7 +1427,7 @@ inline Matrix<PersistenceMatrixOptions>::Matrix(const std::vector<Container_type
 }
 
 template <class PersistenceMatrixOptions>
-inline Matrix<PersistenceMatrixOptions>::Matrix(unsigned int numberOfColumns, characteristic_type characteristic)
+inline Matrix<PersistenceMatrixOptions>::Matrix(unsigned int numberOfColumns, Characteristic characteristic)
     : colSettings_(new Column_settings(characteristic)),
       matrix_(numberOfColumns, colSettings_) 
 {
@@ -1439,8 +1439,8 @@ inline Matrix<PersistenceMatrixOptions>::Matrix(unsigned int numberOfColumns, ch
 }
 
 template <class PersistenceMatrixOptions>
-inline Matrix<PersistenceMatrixOptions>::Matrix(const std::function<bool(pos_index,pos_index)>& birthComparator,
-                                                const std::function<bool(pos_index,pos_index)>& deathComparator)
+inline Matrix<PersistenceMatrixOptions>::Matrix(const std::function<bool(Pos_index,Pos_index)>& birthComparator,
+                                                const std::function<bool(Pos_index,Pos_index)>& deathComparator)
     : colSettings_(new Column_settings()),
       matrix_(colSettings_, birthComparator, deathComparator) 
 {
@@ -1452,13 +1452,13 @@ inline Matrix<PersistenceMatrixOptions>::Matrix(const std::function<bool(pos_ind
 }
 
 template <class PersistenceMatrixOptions>
-template <class Boundary_type>
-inline Matrix<PersistenceMatrixOptions>::Matrix(const std::vector<Boundary_type>& orderedBoundaries,
-                               const std::function<bool(pos_index,pos_index)>& birthComparator, 
-                               const std::function<bool(pos_index,pos_index)>& deathComparator,
-                               characteristic_type characteristic)
+template <class Boundary_container>
+inline Matrix<PersistenceMatrixOptions>::Matrix(const std::vector<Boundary_container>& orderedBoundaries,
+                                                const std::function<bool(Pos_index, Pos_index)>& birthComparator,
+                                                const std::function<bool(Pos_index, Pos_index)>& deathComparator,
+                                                Characteristic characteristic)
     : colSettings_(new Column_settings(characteristic)),
-      matrix_(orderedBoundaries, colSettings_, birthComparator, deathComparator) 
+      matrix_(orderedBoundaries, colSettings_, birthComparator, deathComparator)
 {
   static_assert(
       !PersistenceMatrixOptions::is_of_boundary_type && PersistenceMatrixOptions::has_vine_update &&
@@ -1468,12 +1468,12 @@ inline Matrix<PersistenceMatrixOptions>::Matrix(const std::vector<Boundary_type>
 }
 
 template <class PersistenceMatrixOptions>
-inline Matrix<PersistenceMatrixOptions>::Matrix(unsigned int numberOfColumns, 
-                               const std::function<bool(pos_index,pos_index)>& birthComparator,
-                               const std::function<bool(pos_index,pos_index)>& deathComparator, 
-                               characteristic_type characteristic)
+inline Matrix<PersistenceMatrixOptions>::Matrix(unsigned int numberOfColumns,
+                                                const std::function<bool(Pos_index, Pos_index)>& birthComparator,
+                                                const std::function<bool(Pos_index, Pos_index)>& deathComparator,
+                                                Characteristic characteristic)
     : colSettings_(new Column_settings(characteristic)),
-      matrix_(numberOfColumns, colSettings_, birthComparator, deathComparator) 
+      matrix_(numberOfColumns, colSettings_, birthComparator, deathComparator)
 {
   static_assert(
       !PersistenceMatrixOptions::is_of_boundary_type && PersistenceMatrixOptions::has_vine_update &&
@@ -1506,10 +1506,10 @@ inline Matrix<PersistenceMatrixOptions>::~Matrix()
 }
 
 template <class PersistenceMatrixOptions>
-inline void Matrix<PersistenceMatrixOptions>::set_characteristic(characteristic_type characteristic) 
+inline void Matrix<PersistenceMatrixOptions>::set_characteristic(Characteristic characteristic) 
 {
   if constexpr (!PersistenceMatrixOptions::is_z2) {
-    if (colSettings_->operators.get_characteristic() != static_cast<characteristic_type>(-1)) {
+    if (colSettings_->operators.get_characteristic() != static_cast<Characteristic>(-1)) {
       std::cerr << "Warning: Characteristic already initialised. Changing it could lead to incoherences in the matrix "
                    "as the modulo was already applied to values in existing columns.";
     }
@@ -1519,11 +1519,11 @@ inline void Matrix<PersistenceMatrixOptions>::set_characteristic(characteristic_
 }
 
 template <class PersistenceMatrixOptions>
-template <class Container_type>
-inline void Matrix<PersistenceMatrixOptions>::insert_column(const Container_type& column) 
+template <class Container>
+inline void Matrix<PersistenceMatrixOptions>::insert_column(const Container& column) 
 {
   if constexpr (!PersistenceMatrixOptions::is_z2){
-    GUDHI_CHECK(colSettings_->operators.get_characteristic() != static_cast<characteristic_type>(-1),
+    GUDHI_CHECK(colSettings_->operators.get_characteristic() != static_cast<Characteristic>(-1),
                 std::logic_error("Matrix::insert_column - Columns cannot be initialized if the coefficient field "
                                  "characteristic is not specified."));
   }
@@ -1535,11 +1535,11 @@ inline void Matrix<PersistenceMatrixOptions>::insert_column(const Container_type
 }
 
 template <class PersistenceMatrixOptions>
-template <class Container_type>
-inline void Matrix<PersistenceMatrixOptions>::insert_column(const Container_type& column, index columnIndex) 
+template <class Container>
+inline void Matrix<PersistenceMatrixOptions>::insert_column(const Container& column, Index columnIndex) 
 {
   if constexpr (!PersistenceMatrixOptions::is_z2){
-    GUDHI_CHECK(colSettings_->operators.get_characteristic() != static_cast<characteristic_type>(-1),
+    GUDHI_CHECK(colSettings_->operators.get_characteristic() != static_cast<Characteristic>(-1),
                 std::logic_error("Matrix::insert_column - Columns cannot be initialized if the coefficient field "
                                  "characteristic is not specified."));
   }
@@ -1552,12 +1552,12 @@ inline void Matrix<PersistenceMatrixOptions>::insert_column(const Container_type
 }
 
 template <class PersistenceMatrixOptions>
-template <class Boundary_type>
-inline typename Matrix<PersistenceMatrixOptions>::insertion_return_type
-Matrix<PersistenceMatrixOptions>::insert_boundary(const Boundary_type& boundary, dimension_type dim)
+template <class Boundary_container>
+inline typename Matrix<PersistenceMatrixOptions>::Insertion_return
+Matrix<PersistenceMatrixOptions>::insert_boundary(const Boundary_container& boundary, Dimension dim)
 {
   if constexpr (!PersistenceMatrixOptions::is_z2){
-    GUDHI_CHECK(colSettings_->operators.get_characteristic() != static_cast<characteristic_type>(-1),
+    GUDHI_CHECK(colSettings_->operators.get_characteristic() != static_cast<Characteristic>(-1),
                 std::logic_error("Matrix::insert_boundary - Columns cannot be initialized if the coefficient field "
                                  "characteristic is not specified."));
   }
@@ -1570,14 +1570,14 @@ Matrix<PersistenceMatrixOptions>::insert_boundary(const Boundary_type& boundary,
 }
 
 template <class PersistenceMatrixOptions>
-template <class Boundary_type>
-inline typename Matrix<PersistenceMatrixOptions>::insertion_return_type
-Matrix<PersistenceMatrixOptions>::insert_boundary(id_index faceIndex, 
-                                                  const Boundary_type& boundary,
-                                                  dimension_type dim)
+template <class Boundary_container>
+inline typename Matrix<PersistenceMatrixOptions>::Insertion_return
+Matrix<PersistenceMatrixOptions>::insert_boundary(ID_index faceIndex,
+                                                  const Boundary_container& boundary,
+                                                  Dimension dim)
 {
   if constexpr (!PersistenceMatrixOptions::is_z2){
-    GUDHI_CHECK(colSettings_->operators.get_characteristic() != static_cast<characteristic_type>(-1),
+    GUDHI_CHECK(colSettings_->operators.get_characteristic() != static_cast<Characteristic>(-1),
                 std::logic_error("Matrix::insert_boundary - Columns cannot be initialized if the coefficient field "
                                  "characteristic is not specified."));
   }
@@ -1591,22 +1591,22 @@ Matrix<PersistenceMatrixOptions>::insert_boundary(id_index faceIndex,
 }
 
 template <class PersistenceMatrixOptions>
-inline typename Matrix<PersistenceMatrixOptions>::returned_column_type& Matrix<PersistenceMatrixOptions>::get_column(
-    index columnIndex)
+inline typename Matrix<PersistenceMatrixOptions>::Returned_column& Matrix<PersistenceMatrixOptions>::get_column(
+    Index columnIndex)
 {
   return matrix_.get_column(columnIndex);
 }
 
 template <class PersistenceMatrixOptions>
-inline const typename Matrix<PersistenceMatrixOptions>::Column_type& Matrix<PersistenceMatrixOptions>::get_column(
-    index columnIndex) const 
+inline const typename Matrix<PersistenceMatrixOptions>::Column& Matrix<PersistenceMatrixOptions>::get_column(
+    Index columnIndex) const 
 {
   return matrix_.get_column(columnIndex);
 }
 
 template <class PersistenceMatrixOptions>
-inline const typename Matrix<PersistenceMatrixOptions>::Column_type& Matrix<PersistenceMatrixOptions>::get_column(
-    index columnIndex, bool inR)
+inline const typename Matrix<PersistenceMatrixOptions>::Column& Matrix<PersistenceMatrixOptions>::get_column(
+    Index columnIndex, bool inR)
 {
   // TODO: I don't think there is a particular reason why the indexation is forced, should be removed.
   static_assert(
@@ -1619,8 +1619,8 @@ inline const typename Matrix<PersistenceMatrixOptions>::Column_type& Matrix<Pers
 }
 
 template <class PersistenceMatrixOptions>
-inline typename Matrix<PersistenceMatrixOptions>::returned_row_type& Matrix<PersistenceMatrixOptions>::get_row(
-    id_index rowIndex)
+inline typename Matrix<PersistenceMatrixOptions>::Returned_row& Matrix<PersistenceMatrixOptions>::get_row(
+    ID_index rowIndex)
 {
   static_assert(PersistenceMatrixOptions::has_row_access, "'get_row' is not available for the chosen options.");
 
@@ -1628,8 +1628,8 @@ inline typename Matrix<PersistenceMatrixOptions>::returned_row_type& Matrix<Pers
 }
 
 template <class PersistenceMatrixOptions>
-inline const typename Matrix<PersistenceMatrixOptions>::Row_type& Matrix<PersistenceMatrixOptions>::get_row(
-    id_index rowIndex) const
+inline const typename Matrix<PersistenceMatrixOptions>::Row& Matrix<PersistenceMatrixOptions>::get_row(
+    ID_index rowIndex) const
 {
   static_assert(PersistenceMatrixOptions::has_row_access, "'get_row' is not available for the chosen options.");
 
@@ -1637,8 +1637,8 @@ inline const typename Matrix<PersistenceMatrixOptions>::Row_type& Matrix<Persist
 }
 
 template <class PersistenceMatrixOptions>
-inline const typename Matrix<PersistenceMatrixOptions>::Row_type& Matrix<PersistenceMatrixOptions>::get_row(
-    id_index rowIndex, bool inR)
+inline const typename Matrix<PersistenceMatrixOptions>::Row& Matrix<PersistenceMatrixOptions>::get_row(
+    ID_index rowIndex, bool inR)
 {
   static_assert(PersistenceMatrixOptions::has_row_access, "'get_row' is not available for the chosen options.");
   // TODO: I don't think there is a particular reason why the indexation is forced, should be removed.
@@ -1652,7 +1652,7 @@ inline const typename Matrix<PersistenceMatrixOptions>::Row_type& Matrix<Persist
 }
 
 template <class PersistenceMatrixOptions>
-inline void Matrix<PersistenceMatrixOptions>::remove_column(index columnIndex) 
+inline void Matrix<PersistenceMatrixOptions>::remove_column(Index columnIndex) 
 {
   static_assert(PersistenceMatrixOptions::has_map_column_container && !isNonBasic &&
                     !PersistenceMatrixOptions::has_column_compression,
@@ -1662,7 +1662,7 @@ inline void Matrix<PersistenceMatrixOptions>::remove_column(index columnIndex)
 }
 
 template <class PersistenceMatrixOptions>
-inline void Matrix<PersistenceMatrixOptions>::erase_empty_row(id_index rowIndex) 
+inline void Matrix<PersistenceMatrixOptions>::erase_empty_row(ID_index rowIndex) 
 {
   static_assert(
       !isNonBasic || PersistenceMatrixOptions::is_of_boundary_type || PersistenceMatrixOptions::has_removable_rows,
@@ -1672,29 +1672,29 @@ inline void Matrix<PersistenceMatrixOptions>::erase_empty_row(id_index rowIndex)
 }
 
 template <class PersistenceMatrixOptions>
-inline void Matrix<PersistenceMatrixOptions>::remove_maximal_face(index columnIndex) 
+inline void Matrix<PersistenceMatrixOptions>::remove_maximal_face(Index columnIndex) 
 {
   static_assert(PersistenceMatrixOptions::has_removable_columns,
-                "'remove_maximal_face(id_index)' is not available for the chosen options.");
+                "'remove_maximal_face(ID_index)' is not available for the chosen options.");
   static_assert(isNonBasic && PersistenceMatrixOptions::has_vine_update,
-                "'remove_maximal_face(id_index)' is not available for the chosen options.");
+                "'remove_maximal_face(ID_index)' is not available for the chosen options.");
   static_assert(PersistenceMatrixOptions::is_of_boundary_type || (PersistenceMatrixOptions::has_map_column_container &&
                                                                   PersistenceMatrixOptions::has_column_pairings),
-                "'remove_maximal_face(id_index)' is not available for the chosen options.");
+                "'remove_maximal_face(ID_index)' is not available for the chosen options.");
 
   matrix_.remove_maximal_face(columnIndex);
 }
 
 template <class PersistenceMatrixOptions>
-inline void Matrix<PersistenceMatrixOptions>::remove_maximal_face(id_index faceIndex,
-                                                                  const std::vector<id_index>& columnsToSwap)
+inline void Matrix<PersistenceMatrixOptions>::remove_maximal_face(ID_index faceIndex,
+                                                                  const std::vector<ID_index>& columnsToSwap)
 {
   static_assert(PersistenceMatrixOptions::has_removable_columns,
-                "'remove_maximal_face(id_index,const std::vector<index>&)' is not available for the chosen options.");
+                "'remove_maximal_face(ID_index,const std::vector<Index>&)' is not available for the chosen options.");
   static_assert(isNonBasic && !PersistenceMatrixOptions::is_of_boundary_type,
-                "'remove_maximal_face(id_index,const std::vector<index>&)' is not available for the chosen options.");
+                "'remove_maximal_face(ID_index,const std::vector<Index>&)' is not available for the chosen options.");
   static_assert(PersistenceMatrixOptions::has_map_column_container && PersistenceMatrixOptions::has_vine_update,
-                "'remove_maximal_face(id_index,const std::vector<index>&)' is not available for the chosen options.");
+                "'remove_maximal_face(ID_index,const std::vector<Index>&)' is not available for the chosen options.");
 
   matrix_.remove_maximal_face(faceIndex, columnsToSwap);
 }
@@ -1714,7 +1714,7 @@ inline void Matrix<PersistenceMatrixOptions>::remove_last()
 }
 
 template <class PersistenceMatrixOptions>
-inline typename Matrix<PersistenceMatrixOptions>::dimension_type Matrix<PersistenceMatrixOptions>::get_max_dimension()
+inline typename Matrix<PersistenceMatrixOptions>::Dimension Matrix<PersistenceMatrixOptions>::get_max_dimension()
     const
 {
   static_assert(isNonBasic, "'get_max_dimension' is not available for the chosen options.");
@@ -1723,14 +1723,14 @@ inline typename Matrix<PersistenceMatrixOptions>::dimension_type Matrix<Persiste
 }
 
 template <class PersistenceMatrixOptions>
-inline typename Matrix<PersistenceMatrixOptions>::index Matrix<PersistenceMatrixOptions>::get_number_of_columns() const 
+inline typename Matrix<PersistenceMatrixOptions>::Index Matrix<PersistenceMatrixOptions>::get_number_of_columns() const 
 {
   return matrix_.get_number_of_columns();
 }
 
 template <class PersistenceMatrixOptions>
-inline typename Matrix<PersistenceMatrixOptions>::dimension_type Matrix<PersistenceMatrixOptions>::get_column_dimension(
-    index columnIndex) const
+inline typename Matrix<PersistenceMatrixOptions>::Dimension Matrix<PersistenceMatrixOptions>::get_column_dimension(
+    Index columnIndex) const
 {
   static_assert(isNonBasic, "'get_column_dimension' is not available for the chosen options.");
 
@@ -1738,9 +1738,9 @@ inline typename Matrix<PersistenceMatrixOptions>::dimension_type Matrix<Persiste
 }
 
 template <class PersistenceMatrixOptions>
-template <typename Index_type>
-inline std::enable_if_t<std::is_integral_v<Index_type> > Matrix<PersistenceMatrixOptions>::add_to(
-    Index_type sourceColumnIndex, Index_type targetColumnIndex)
+template <typename Integer_index>
+inline std::enable_if_t<std::is_integral_v<Integer_index> > Matrix<PersistenceMatrixOptions>::add_to(
+    Integer_index sourceColumnIndex, Integer_index targetColumnIndex)
 {
   matrix_.add_to(sourceColumnIndex, targetColumnIndex);
 }
@@ -1748,7 +1748,7 @@ inline std::enable_if_t<std::is_integral_v<Index_type> > Matrix<PersistenceMatri
 template <class PersistenceMatrixOptions>
 template <class Cell_range>
 inline std::enable_if_t<!std::is_integral_v<Cell_range> > Matrix<PersistenceMatrixOptions>::add_to(
-    const Cell_range& sourceColumn, index targetColumnIndex)
+    const Cell_range& sourceColumn, Index targetColumnIndex)
 {
   static_assert(!isNonBasic,
                 "For boundary or chain matrices, only additions with columns inside the matrix is allowed to maintain "
@@ -1758,12 +1758,12 @@ inline std::enable_if_t<!std::is_integral_v<Cell_range> > Matrix<PersistenceMatr
 }
 
 template <class PersistenceMatrixOptions>
-template <typename Index_type>
-inline std::enable_if_t<std::is_integral_v<Index_type> > Matrix<PersistenceMatrixOptions>::multiply_target_and_add_to(
-    Index_type sourceColumnIndex, int coefficient, Index_type targetColumnIndex) 
+template <typename Integer_index>
+inline std::enable_if_t<std::is_integral_v<Integer_index> > Matrix<PersistenceMatrixOptions>::multiply_target_and_add_to(
+    Integer_index sourceColumnIndex, int coefficient, Integer_index targetColumnIndex) 
 {
   if constexpr (PersistenceMatrixOptions::is_z2) {
-    // coef will be converted to bool, because of element_type
+    // coef will be converted to bool, because of Element
     matrix_.multiply_target_and_add_to(sourceColumnIndex, coefficient % 2, targetColumnIndex);
   } else {
     matrix_.multiply_target_and_add_to(sourceColumnIndex, colSettings_->operators.get_value(coefficient), targetColumnIndex);
@@ -1773,14 +1773,14 @@ inline std::enable_if_t<std::is_integral_v<Index_type> > Matrix<PersistenceMatri
 template <class PersistenceMatrixOptions>
 template <class Cell_range>
 inline std::enable_if_t<!std::is_integral_v<Cell_range> > Matrix<PersistenceMatrixOptions>::multiply_target_and_add_to(
-    const Cell_range& sourceColumn, int coefficient, index targetColumnIndex) 
+    const Cell_range& sourceColumn, int coefficient, Index targetColumnIndex) 
 {
   static_assert(!isNonBasic,
                 "For boundary or chain matrices, only additions with columns inside the matrix is allowed to maintain "
                 "algebraic consistency.");
 
   if constexpr (PersistenceMatrixOptions::is_z2) {
-    // coef will be converted to bool, because of element_type
+    // coef will be converted to bool, because of Element
     matrix_.multiply_target_and_add_to(sourceColumn, coefficient % 2, targetColumnIndex);
   } else {
     matrix_.multiply_target_and_add_to(sourceColumn, colSettings_->operators.get_value(coefficient), targetColumnIndex);
@@ -1788,12 +1788,12 @@ inline std::enable_if_t<!std::is_integral_v<Cell_range> > Matrix<PersistenceMatr
 }
 
 template <class PersistenceMatrixOptions>
-template <typename Index_type>
-inline std::enable_if_t<std::is_integral_v<Index_type> > Matrix<PersistenceMatrixOptions>::multiply_source_and_add_to(
-    int coefficient, Index_type sourceColumnIndex, Index_type targetColumnIndex) 
+template <typename Integer_index>
+inline std::enable_if_t<std::is_integral_v<Integer_index> > Matrix<PersistenceMatrixOptions>::multiply_source_and_add_to(
+    int coefficient, Integer_index sourceColumnIndex, Integer_index targetColumnIndex) 
 {
   if constexpr (PersistenceMatrixOptions::is_z2) {
-    // coef will be converted to bool, because of element_type
+    // coef will be converted to bool, because of Element
     matrix_.multiply_source_and_add_to(coefficient % 2, sourceColumnIndex, targetColumnIndex);
   } else {
     matrix_.multiply_source_and_add_to(colSettings_->operators.get_value(coefficient), sourceColumnIndex, targetColumnIndex);
@@ -1803,14 +1803,14 @@ inline std::enable_if_t<std::is_integral_v<Index_type> > Matrix<PersistenceMatri
 template <class PersistenceMatrixOptions>
 template <class Cell_range>
 inline std::enable_if_t<!std::is_integral_v<Cell_range> > Matrix<PersistenceMatrixOptions>::multiply_source_and_add_to(
-    int coefficient, const Cell_range& sourceColumn, index targetColumnIndex) 
+    int coefficient, const Cell_range& sourceColumn, Index targetColumnIndex) 
 {
   static_assert(!isNonBasic,
                 "For boundary or chain matrices, only additions with columns inside the matrix is allowed to maintain "
                 "algebraic consistency.");
 
   if constexpr (PersistenceMatrixOptions::is_z2) {
-    // coef will be converted to bool, because of element_type
+    // coef will be converted to bool, because of Element
     matrix_.multiply_source_and_add_to(coefficient % 2, sourceColumn, targetColumnIndex);
   } else {
     matrix_.multiply_source_and_add_to(colSettings_->operators.get_value(coefficient), sourceColumn, targetColumnIndex);
@@ -1818,7 +1818,7 @@ inline std::enable_if_t<!std::is_integral_v<Cell_range> > Matrix<PersistenceMatr
 }
 
 template <class PersistenceMatrixOptions>
-inline void Matrix<PersistenceMatrixOptions>::zero_cell(index columnIndex, id_index rowIndex) 
+inline void Matrix<PersistenceMatrixOptions>::zero_cell(Index columnIndex, ID_index rowIndex) 
 {
   static_assert(PersistenceMatrixOptions::is_of_boundary_type && !PersistenceMatrixOptions::has_column_compression,
                 "'zero_cell' is not available for the chosen options.");
@@ -1827,7 +1827,7 @@ inline void Matrix<PersistenceMatrixOptions>::zero_cell(index columnIndex, id_in
 }
 
 template <class PersistenceMatrixOptions>
-inline void Matrix<PersistenceMatrixOptions>::zero_cell(index columnIndex, id_index rowIndex, bool inR) 
+inline void Matrix<PersistenceMatrixOptions>::zero_cell(Index columnIndex, ID_index rowIndex, bool inR) 
 {
   // TODO: I don't think there is a particular reason why the indexation is forced, should be removed.
   static_assert(
@@ -1840,7 +1840,7 @@ inline void Matrix<PersistenceMatrixOptions>::zero_cell(index columnIndex, id_in
 }
 
 template <class PersistenceMatrixOptions>
-inline void Matrix<PersistenceMatrixOptions>::zero_column(index columnIndex) 
+inline void Matrix<PersistenceMatrixOptions>::zero_column(Index columnIndex) 
 {
   static_assert(PersistenceMatrixOptions::is_of_boundary_type && !PersistenceMatrixOptions::has_column_compression,
                 "'zero_column' is not available for the chosen options.");
@@ -1849,7 +1849,7 @@ inline void Matrix<PersistenceMatrixOptions>::zero_column(index columnIndex)
 }
 
 template <class PersistenceMatrixOptions>
-inline void Matrix<PersistenceMatrixOptions>::zero_column(index columnIndex, bool inR) 
+inline void Matrix<PersistenceMatrixOptions>::zero_column(Index columnIndex, bool inR) 
 {
   // TODO: I don't think there is a particular reason why the indexation is forced, should be removed.
   static_assert(
@@ -1862,13 +1862,13 @@ inline void Matrix<PersistenceMatrixOptions>::zero_column(index columnIndex, boo
 }
 
 template <class PersistenceMatrixOptions>
-inline bool Matrix<PersistenceMatrixOptions>::is_zero_cell(index columnIndex, id_index rowIndex) 
+inline bool Matrix<PersistenceMatrixOptions>::is_zero_cell(Index columnIndex, ID_index rowIndex) 
 {
   return matrix_.is_zero_cell(columnIndex, rowIndex);
 }
 
 template <class PersistenceMatrixOptions>
-inline bool Matrix<PersistenceMatrixOptions>::is_zero_cell(index columnIndex, id_index rowIndex, bool inR) const 
+inline bool Matrix<PersistenceMatrixOptions>::is_zero_cell(Index columnIndex, ID_index rowIndex, bool inR) const 
 {
   // TODO: I don't think there is a particular reason why the indexation is forced, should be removed.
   static_assert(
@@ -1881,13 +1881,13 @@ inline bool Matrix<PersistenceMatrixOptions>::is_zero_cell(index columnIndex, id
 }
 
 template <class PersistenceMatrixOptions>
-inline bool Matrix<PersistenceMatrixOptions>::is_zero_column(index columnIndex) 
+inline bool Matrix<PersistenceMatrixOptions>::is_zero_column(Index columnIndex) 
 {
   return matrix_.is_zero_column(columnIndex);
 }
 
 template <class PersistenceMatrixOptions>
-inline bool Matrix<PersistenceMatrixOptions>::is_zero_column(index columnIndex, bool inR) 
+inline bool Matrix<PersistenceMatrixOptions>::is_zero_column(Index columnIndex, bool inR) 
 {
   // TODO: I don't think there is a particular reason why the indexation is forced, should be removed.
   static_assert(
@@ -1900,8 +1900,8 @@ inline bool Matrix<PersistenceMatrixOptions>::is_zero_column(index columnIndex, 
 }
 
 template <class PersistenceMatrixOptions>
-inline typename Matrix<PersistenceMatrixOptions>::index Matrix<PersistenceMatrixOptions>::get_column_with_pivot(
-    id_index faceIndex) const
+inline typename Matrix<PersistenceMatrixOptions>::Index Matrix<PersistenceMatrixOptions>::get_column_with_pivot(
+    ID_index faceIndex) const
 {
   static_assert(isNonBasic && (!PersistenceMatrixOptions::is_of_boundary_type ||
                                (PersistenceMatrixOptions::has_vine_update ||
@@ -1912,8 +1912,8 @@ inline typename Matrix<PersistenceMatrixOptions>::index Matrix<PersistenceMatrix
 }
 
 template <class PersistenceMatrixOptions>
-inline typename Matrix<PersistenceMatrixOptions>::id_index Matrix<PersistenceMatrixOptions>::get_pivot(
-    index columnIndex)
+inline typename Matrix<PersistenceMatrixOptions>::ID_index Matrix<PersistenceMatrixOptions>::get_pivot(
+    Index columnIndex)
 {
   static_assert(isNonBasic, "'get_pivot' is not available for the chosen options.");
 
@@ -1936,7 +1936,7 @@ inline void Matrix<PersistenceMatrixOptions>::print()
 }
 
 template <class PersistenceMatrixOptions>
-inline const typename Matrix<PersistenceMatrixOptions>::barcode_type&
+inline const typename Matrix<PersistenceMatrixOptions>::Barcode&
 Matrix<PersistenceMatrixOptions>::get_current_barcode()
 {
   static_assert(PersistenceMatrixOptions::has_column_pairings, "This method was not enabled.");
@@ -1945,7 +1945,7 @@ Matrix<PersistenceMatrixOptions>::get_current_barcode()
 }
 
 template <class PersistenceMatrixOptions>
-inline const typename Matrix<PersistenceMatrixOptions>::barcode_type&
+inline const typename Matrix<PersistenceMatrixOptions>::Barcode&
 Matrix<PersistenceMatrixOptions>::get_current_barcode() const
 {
   static_assert(PersistenceMatrixOptions::has_column_pairings, "This method was not enabled.");
@@ -1959,7 +1959,7 @@ Matrix<PersistenceMatrixOptions>::get_current_barcode() const
 }
 
 template <class PersistenceMatrixOptions>
-inline void Matrix<PersistenceMatrixOptions>::swap_columns(index columnIndex1, index columnIndex2) 
+inline void Matrix<PersistenceMatrixOptions>::swap_columns(Index columnIndex1, Index columnIndex2) 
 {
   static_assert(
       (!isNonBasic && !PersistenceMatrixOptions::has_column_compression) ||
@@ -1970,7 +1970,7 @@ inline void Matrix<PersistenceMatrixOptions>::swap_columns(index columnIndex1, i
 }
 
 template <class PersistenceMatrixOptions>
-inline void Matrix<PersistenceMatrixOptions>::swap_rows(index rowIndex1, index rowIndex2) 
+inline void Matrix<PersistenceMatrixOptions>::swap_rows(Index rowIndex1, Index rowIndex2) 
 {
   static_assert(
       (!isNonBasic && !PersistenceMatrixOptions::has_column_compression) ||
@@ -1981,7 +1981,7 @@ inline void Matrix<PersistenceMatrixOptions>::swap_rows(index rowIndex1, index r
 }
 
 template <class PersistenceMatrixOptions>
-inline bool Matrix<PersistenceMatrixOptions>::vine_swap_with_z_eq_1_case(pos_index index) 
+inline bool Matrix<PersistenceMatrixOptions>::vine_swap_with_z_eq_1_case(Pos_index index) 
 {
   static_assert(PersistenceMatrixOptions::has_vine_update, "This method was not enabled.");
   static_assert(PersistenceMatrixOptions::column_indexation_type == Column_indexation_types::POSITION ||
@@ -1992,8 +1992,8 @@ inline bool Matrix<PersistenceMatrixOptions>::vine_swap_with_z_eq_1_case(pos_ind
 }
 
 template <class PersistenceMatrixOptions>
-inline typename Matrix<PersistenceMatrixOptions>::index Matrix<PersistenceMatrixOptions>::vine_swap_with_z_eq_1_case(
-    index columnIndex1, index columnIndex2)
+inline typename Matrix<PersistenceMatrixOptions>::Index Matrix<PersistenceMatrixOptions>::vine_swap_with_z_eq_1_case(
+    Index columnIndex1, Index columnIndex2)
 {
   static_assert(PersistenceMatrixOptions::has_vine_update, "This method was not enabled.");
   static_assert(PersistenceMatrixOptions::column_indexation_type == Column_indexation_types::IDENTIFIER ||
@@ -2005,7 +2005,7 @@ inline typename Matrix<PersistenceMatrixOptions>::index Matrix<PersistenceMatrix
 }
 
 template <class PersistenceMatrixOptions>
-inline bool Matrix<PersistenceMatrixOptions>::vine_swap(pos_index index) 
+inline bool Matrix<PersistenceMatrixOptions>::vine_swap(Pos_index index) 
 {
   static_assert(PersistenceMatrixOptions::has_vine_update, "This method was not enabled.");
   static_assert(PersistenceMatrixOptions::column_indexation_type == Column_indexation_types::POSITION ||
@@ -2016,8 +2016,8 @@ inline bool Matrix<PersistenceMatrixOptions>::vine_swap(pos_index index)
 }
 
 template <class PersistenceMatrixOptions>
-inline typename Matrix<PersistenceMatrixOptions>::index Matrix<PersistenceMatrixOptions>::vine_swap(
-    index columnIndex1, index columnIndex2)
+inline typename Matrix<PersistenceMatrixOptions>::Index Matrix<PersistenceMatrixOptions>::vine_swap(
+    Index columnIndex1, Index columnIndex2)
 {
   static_assert(PersistenceMatrixOptions::has_vine_update, "This method was not enabled.");
   static_assert(PersistenceMatrixOptions::column_indexation_type == Column_indexation_types::IDENTIFIER ||
@@ -2035,7 +2035,7 @@ inline void Matrix<PersistenceMatrixOptions>::update_representative_cycles()
 }
 
 template <class PersistenceMatrixOptions>
-inline const std::vector<typename Matrix<PersistenceMatrixOptions>::cycle_type>&
+inline const std::vector<typename Matrix<PersistenceMatrixOptions>::Cycle>&
 Matrix<PersistenceMatrixOptions>::get_representative_cycles()
 {
   static_assert(PersistenceMatrixOptions::can_retrieve_representative_cycles, "This method was not enabled.");
@@ -2043,7 +2043,7 @@ Matrix<PersistenceMatrixOptions>::get_representative_cycles()
 }
 
 template <class PersistenceMatrixOptions>
-inline const typename Matrix<PersistenceMatrixOptions>::cycle_type&
+inline const typename Matrix<PersistenceMatrixOptions>::Cycle&
 Matrix<PersistenceMatrixOptions>::get_representative_cycle(const Bar& bar)
 {
   static_assert(PersistenceMatrixOptions::can_retrieve_representative_cycles, "This method was not enabled.");

--- a/src/Persistence_matrix/include/gudhi/persistence_interval.h
+++ b/src/Persistence_matrix/include/gudhi/persistence_interval.h
@@ -32,55 +32,59 @@ namespace persistence_matrix {
  * @brief Type for an interval in a persistent diagram or barcode. Stores the birth, death and dimension of the
  * interval. It can be used as a tuple with `get`/`std::get` (birth, death and dimension in this order),
  * `std::tuple_element` and `std::tuple_size`, as well as structured binding.
- * 
- * @tparam dimension_type Type of the dimension value.
- * @tparam event_value_type Type of the birth and death value.
+ *
+ * @tparam Dimension Type of the dimension value.
+ * @tparam Event_value Type of the birth and death value.
  */
-template <typename dimension_type, typename event_value_type>
+template <typename Dimension, typename Event_value>
 struct Persistence_interval {
   /**
    * @brief Stores the infinity value for birth and death events. Its value depends on the template parameter
-   * `event_value_type`:
-   * - if `event_value_type` has a native infinity value, it takes this value,
-   * - otherwise, if `event_value_type` is a signed type, it takes value -1,
-   * - otherwise, if `event_value_type` is a unsigned type, it takes the maximal possible value.
+   * `Event_value`:
+   * - if `Event_value` has a native infinity value, it takes this value,
+   * - otherwise, if `Event_value` is a signed type, it takes value -1,
+   * - otherwise, if `Event_value` is a unsigned type, it takes the maximal possible value.
    *
    * Is also used as default value for birth and death attributes when not initialized.
    */
-  static constexpr event_value_type inf = std::numeric_limits<event_value_type>::has_infinity
-                                              ? std::numeric_limits<event_value_type>::infinity()
-                                              : static_cast<event_value_type>(-1);
+  static constexpr Event_value inf = std::numeric_limits<Event_value>::has_infinity
+                                         ? std::numeric_limits<Event_value>::infinity()
+                                         : static_cast<Event_value>(-1);
 
   /**
    * @brief Constructor.
-   * 
+   *
    * @param birth Birth value of the cycle. Default value: @ref inf.
    * @param death Death value of the cycle. Default value: @ref inf.
    * @param dim Dimension of the cycle. Default value: -1.
    */
-  Persistence_interval(event_value_type birth = inf, event_value_type death = inf, dimension_type dim = -1)
+  Persistence_interval(Event_value birth = inf, Event_value death = inf, Dimension dim = -1)
       : dim(dim), birth(birth), death(death) {}
 
-  dimension_type dim;     /**< Dimension of the cycle.*/
-  event_value_type birth; /**< Birth value of the cycle. */
-  event_value_type death; /**< Death value of the cycle. */
+  Dimension dim;     /**< Dimension of the cycle.*/
+  Event_value birth; /**< Birth value of the cycle. */
+  Event_value death; /**< Death value of the cycle. */
 
   /**
    * @brief operator<<
-   * 
+   *
    * @param stream outstream
    * @param interval interval to stream
    */
-  inline friend std::ostream &operator<<(std::ostream &stream, const Persistence_interval &interval) {
+  inline friend std::ostream& operator<<(std::ostream& stream, const Persistence_interval& interval) {
     stream << "[" << interval.dim << "] ";
-    if constexpr (std::numeric_limits<event_value_type>::has_infinity) {
+    if constexpr (std::numeric_limits<Event_value>::has_infinity) {
       stream << interval.birth << " - " << interval.death;
     } else {
-      if (interval.birth == inf) stream << "inf";
-      else stream << interval.birth;
+      if (interval.birth == inf)
+        stream << "inf";
+      else
+        stream << interval.birth;
       stream << " - ";
-      if (interval.death == inf) stream << "inf";
-      else stream << interval.death;
+      if (interval.death == inf)
+        stream << "inf";
+      else
+        stream << interval.death;
     }
     return stream;
   }
@@ -90,15 +94,15 @@ struct Persistence_interval {
  * @ingroup persistence_matrix
  *
  * @brief Partial specialization of `get` for @ref Gudhi::persistence_matrix::Persistence_interval.
- * 
+ *
  * @tparam I Index of the value to return: 0 for the birth value, 1 for the death value and 2 for the dimension.
- * @tparam dimension_type First template parameter of @ref Gudhi::persistence_matrix::Persistence_interval.
- * @tparam event_value_type Second template parameter of @ref Gudhi::persistence_matrix::Persistence_interval.
+ * @tparam Dimension First template parameter of @ref Gudhi::persistence_matrix::Persistence_interval.
+ * @tparam Event_value Second template parameter of @ref Gudhi::persistence_matrix::Persistence_interval.
  * @param i Interval from which the value should be returned.
  * @return Either the birth value if @p I == 0, the death value if @p I == 1 or the dimension if @p I == 2.
  */
-template <size_t I, typename dimension_type, typename event_value_type>
-constexpr auto& get(Gudhi::persistence_matrix::Persistence_interval<dimension_type, event_value_type>& i) noexcept {
+template <std::size_t I, typename Dimension, typename Event_value>
+constexpr auto& get(Gudhi::persistence_matrix::Persistence_interval<Dimension, Event_value>& i) noexcept {
   static_assert(I < 3, "Value mismatch at argument 1 in template parameter list. Maximal possible value is 2.");
 
   if constexpr (I == 0) return i.birth;
@@ -110,16 +114,15 @@ constexpr auto& get(Gudhi::persistence_matrix::Persistence_interval<dimension_ty
  * @ingroup persistence_matrix
  *
  * @brief Partial specialization of `get` for @ref Gudhi::persistence_matrix::Persistence_interval.
- * 
+ *
  * @tparam I Index of the value to return: 0 for the birth value, 1 for the death value and 2 for the dimension.
- * @tparam dimension_type First template parameter of @ref Gudhi::persistence_matrix::Persistence_interval.
- * @tparam event_value_type Second template parameter of @ref Gudhi::persistence_matrix::Persistence_interval.
+ * @tparam Dimension First template parameter of @ref Gudhi::persistence_matrix::Persistence_interval.
+ * @tparam Event_value Second template parameter of @ref Gudhi::persistence_matrix::Persistence_interval.
  * @param i Interval from which the value should be returned.
  * @return Either the birth value if @p I == 0, the death value if @p I == 1 or the dimension if @p I == 2.
  */
-template <size_t I, typename dimension_type, typename event_value_type>
-constexpr const auto& get(
-    const Gudhi::persistence_matrix::Persistence_interval<dimension_type, event_value_type>& i) noexcept {
+template <std::size_t I, typename Dimension, typename Event_value>
+constexpr const auto& get(const Gudhi::persistence_matrix::Persistence_interval<Dimension, Event_value>& i) noexcept {
   static_assert(I < 3, "Value mismatch at argument 1 in template parameter list. Maximal possible value is 2.");
 
   if constexpr (I == 0) return i.birth;
@@ -131,15 +134,15 @@ constexpr const auto& get(
  * @ingroup persistence_matrix
  *
  * @brief Partial specialization of `get` for @ref Gudhi::persistence_matrix::Persistence_interval.
- * 
+ *
  * @tparam I Index of the value to return: 0 for the birth value, 1 for the death value and 2 for the dimension.
- * @tparam dimension_type First template parameter of @ref Gudhi::persistence_matrix::Persistence_interval.
- * @tparam event_value_type Second template parameter of @ref Gudhi::persistence_matrix::Persistence_interval.
+ * @tparam Dimension First template parameter of @ref Gudhi::persistence_matrix::Persistence_interval.
+ * @tparam Event_value Second template parameter of @ref Gudhi::persistence_matrix::Persistence_interval.
  * @param i Interval from which the value should be returned.
  * @return Either the birth value if @p I == 0, the death value if @p I == 1 or the dimension if @p I == 2.
  */
-template <size_t I, typename dimension_type, typename event_value_type>
-constexpr auto&& get(Gudhi::persistence_matrix::Persistence_interval<dimension_type, event_value_type>&& i) noexcept {
+template <std::size_t I, typename Dimension, typename Event_value>
+constexpr auto&& get(Gudhi::persistence_matrix::Persistence_interval<Dimension, Event_value>&& i) noexcept {
   static_assert(I < 3, "Value mismatch at argument 1 in template parameter list. Maximal possible value is 2.");
 
   if constexpr (I == 0) return std::move(i.birth);
@@ -151,16 +154,15 @@ constexpr auto&& get(Gudhi::persistence_matrix::Persistence_interval<dimension_t
  * @ingroup persistence_matrix
  *
  * @brief Partial specialization of `get` for @ref Gudhi::persistence_matrix::Persistence_interval.
- * 
+ *
  * @tparam I Index of the value to return: 0 for the birth value, 1 for the death value and 2 for the dimension.
- * @tparam dimension_type First template parameter of @ref Gudhi::persistence_matrix::Persistence_interval.
- * @tparam event_value_type Second template parameter of @ref Gudhi::persistence_matrix::Persistence_interval.
+ * @tparam Dimension First template parameter of @ref Gudhi::persistence_matrix::Persistence_interval.
+ * @tparam Event_value Second template parameter of @ref Gudhi::persistence_matrix::Persistence_interval.
  * @param i Interval from which the value should be returned.
  * @return Either the birth value if @p I == 0, the death value if @p I == 1 or the dimension if @p I == 2.
  */
-template <size_t I, typename dimension_type, typename event_value_type>
-constexpr const auto&& get(
-    const Gudhi::persistence_matrix::Persistence_interval<dimension_type, event_value_type>&& i) noexcept {
+template <std::size_t I, typename Dimension, typename Event_value>
+constexpr const auto&& get(const Gudhi::persistence_matrix::Persistence_interval<Dimension, Event_value>&& i) noexcept {
   static_assert(I < 3, "Value mismatch at argument 1 in template parameter list. Maximal possible value is 2.");
 
   if constexpr (I == 0) return std::move(i.birth);
@@ -177,51 +179,49 @@ namespace std {
  * @ingroup persistence_matrix
  *
  * @brief Partial specialization of `std::tuple_size` for @ref Gudhi::persistence_matrix::Persistence_interval.
- * 
- * @tparam dimension_type First template parameter of @ref Gudhi::persistence_matrix::Persistence_interval.
- * @tparam event_value_type Second template parameter of @ref Gudhi::persistence_matrix::Persistence_interval.
+ *
+ * @tparam Dimension First template parameter of @ref Gudhi::persistence_matrix::Persistence_interval.
+ * @tparam Event_value Second template parameter of @ref Gudhi::persistence_matrix::Persistence_interval.
  */
-template <typename dimension_type, typename event_value_type>
-struct tuple_size<Gudhi::persistence_matrix::Persistence_interval<dimension_type, event_value_type> >
-    : std::integral_constant<std::size_t, 3> {};
+template <typename Dimension, typename Event_value>
+struct tuple_size<Gudhi::persistence_matrix::Persistence_interval<Dimension, Event_value> >
+    : integral_constant<size_t, 3> {};
 
 /**
  * @ingroup persistence_matrix
  *
  * @brief Partial specialization of `std::tuple_element` for @ref Gudhi::persistence_matrix::Persistence_interval.
- * 
+ *
  * @tparam I Index of the type to store: 0 for the birth value type, 1 for the death value type and 2 for the
  * dimension value type.
- * @tparam dimension_type First template parameter of @ref Gudhi::persistence_matrix::Persistence_interval.
- * @tparam event_value_type Second template parameter of @ref Gudhi::persistence_matrix::Persistence_interval.
+ * @tparam Dimension First template parameter of @ref Gudhi::persistence_matrix::Persistence_interval.
+ * @tparam Event_value Second template parameter of @ref Gudhi::persistence_matrix::Persistence_interval.
  */
-template <std::size_t I, typename dimension_type, typename event_value_type>
-struct tuple_element<I, Gudhi::persistence_matrix::Persistence_interval<dimension_type, event_value_type> > {
+template <size_t I, typename Dimension, typename Event_value>
+struct tuple_element<I, Gudhi::persistence_matrix::Persistence_interval<Dimension, Event_value> > {
   static_assert(I < 3, "Value mismatch at argument 1 in template parameter list. Maximal possible value is 2.");
 
-  using type = typename std::conditional<I < 2, event_value_type, dimension_type>::type;
+  using type = typename conditional <I < 2, Event_value, Dimension>::type;
 };
 
-template <size_t I, typename dimension_type, typename event_value_type>
-constexpr auto& get(Gudhi::persistence_matrix::Persistence_interval<dimension_type, event_value_type>& i) noexcept {
+template <size_t I, typename Dimension, typename Event_value>
+constexpr auto& get(Gudhi::persistence_matrix::Persistence_interval<Dimension, Event_value>& i) noexcept {
   return Gudhi::persistence_matrix::get<I>(i);
 }
 
-template <size_t I, typename dimension_type, typename event_value_type>
-constexpr const auto& get(
-    const Gudhi::persistence_matrix::Persistence_interval<dimension_type, event_value_type>& i) noexcept {
+template <size_t I, typename Dimension, typename Event_value>
+constexpr const auto& get(const Gudhi::persistence_matrix::Persistence_interval<Dimension, Event_value>& i) noexcept {
   return Gudhi::persistence_matrix::get<I>(i);
 }
 
-template <size_t I, typename dimension_type, typename event_value_type>
-constexpr auto&& get(Gudhi::persistence_matrix::Persistence_interval<dimension_type, event_value_type>&& i) noexcept {
-  return Gudhi::persistence_matrix::get<I>(std::move(i));
+template <size_t I, typename Dimension, typename Event_value>
+constexpr auto&& get(Gudhi::persistence_matrix::Persistence_interval<Dimension, Event_value>&& i) noexcept {
+  return Gudhi::persistence_matrix::get<I>(move(i));
 }
 
-template <size_t I, typename dimension_type, typename event_value_type>
-constexpr const auto&& get(
-    const Gudhi::persistence_matrix::Persistence_interval<dimension_type, event_value_type>&& i) noexcept {
-  return Gudhi::persistence_matrix::get<I>(std::move(i));
+template <size_t I, typename Dimension, typename Event_value>
+constexpr const auto&& get(const Gudhi::persistence_matrix::Persistence_interval<Dimension, Event_value>&& i) noexcept {
+  return Gudhi::persistence_matrix::get<I>(move(i));
 }
 
 }  // namespace std

--- a/src/Persistence_matrix/include/gudhi/persistence_matrix_options.h
+++ b/src/Persistence_matrix/include/gudhi/persistence_matrix_options.h
@@ -76,8 +76,8 @@ template <Column_types col_type = Column_types::INTRUSIVE_SET,
 struct Default_options 
 {
   using Field_coeff_operators = FieldOperators;
-  using dimension_type = int;
-  using index_type = unsigned int;
+  using Dimension = int;
+  using Index = unsigned int;
 
   static const bool is_z2 = is_z2_only;
   static const Column_types column_type = col_type;

--- a/src/Persistence_matrix/test/Persistence_matrix_column_tests_base.cpp
+++ b/src/Persistence_matrix/test/Persistence_matrix_column_tests_base.cpp
@@ -54,14 +54,14 @@ using z2_only_row_access_columns = columns_list<z2_only_ra_option_list<option_na
 #endif
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(Base_z2_column_with_row_access_content_access, Column, z2_only_row_access_columns) {
-  typename Column::Master::row_container_type rows;  // do not destroy before matrix
+  typename Column::Master::Row_container rows;  // do not destroy before matrix
   typename Column::Column_settings settings;
   std::vector<Column> matrix = build_column_matrix<Column>(rows, settings);
   column_test_common_z2_content_access(matrix);
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(Base_z2_column_with_row_access_operators, Column, z2_only_row_access_columns) {
-  typename Column::Master::row_container_type rows;  // do not destroy before matrix
+  typename Column::Master::Row_container rows;  // do not destroy before matrix
   typename Column::Column_settings settings;
   std::vector<Column> matrix = build_column_matrix<Column>(rows, settings);
   column_test_common_z2_operators(matrix);
@@ -73,7 +73,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(Base_z2_column_with_row_access_operators, Column, 
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(Base_column_row_access_constructors, Column, z2_only_row_access_columns) {
-  typename Column::Master::row_container_type rows;  // do not destroy before matrix
+  typename Column::Master::Row_container rows;  // do not destroy before matrix
   typename Column::Column_settings settings;
   std::vector<Column> matrix = build_column_matrix<Column>(rows, settings);
 
@@ -125,14 +125,14 @@ using z5_only_row_access_columns = columns_list<z5_only_ra_option_list<option_na
 #endif
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(Base_z5_column_with_row_access_content_access, Column, z5_only_row_access_columns) {
-  typename Column::Master::row_container_type rows;  // do not destroy before matrix
+  typename Column::Master::Row_container rows;  // do not destroy before matrix
   typename Column::Column_settings settings(5);
   std::vector<Column> matrix = build_column_matrix<Column>(rows, settings);
   column_test_common_z5_content_access(matrix);
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(Base_z5_column_with_row_access_operators, Column, z5_only_row_access_columns) {
-  typename Column::Master::row_container_type rows;  // do not destroy before matrix
+  typename Column::Master::Row_container rows;  // do not destroy before matrix
   typename Column::Column_settings settings(5);
   std::vector<Column> matrix = build_column_matrix<Column>(rows, settings);
   column_test_common_z5_operators(matrix);
@@ -144,7 +144,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(Base_z5_column_with_row_access_operators, Column, 
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(Base_column_row_access_constructors, Column, z5_only_row_access_columns) {
-  typename Column::Master::row_container_type rows;  // do not destroy before matrix
+  typename Column::Master::Row_container rows;  // do not destroy before matrix
   typename Column::Column_settings settings(5);
   std::vector<Column> matrix = build_column_matrix<Column>(rows, settings);
 

--- a/src/Persistence_matrix/test/Persistence_matrix_column_tests_boundary.cpp
+++ b/src/Persistence_matrix/test/Persistence_matrix_column_tests_boundary.cpp
@@ -61,14 +61,14 @@ using z2_only_row_access_columns = columns_list<z2_only_ra_option_list<option_na
 #endif
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(Boundary_z2_column_with_row_access_content_access, Column, z2_only_row_access_columns) {
-  typename Column::Master::row_container_type rows;  // do not destroy before matrix
+  typename Column::Master::Row_container rows;  // do not destroy before matrix
   typename Column::Column_settings settings;
   std::vector<Column> matrix = build_column_matrix<Column>(rows, settings);
   column_test_common_z2_content_access(matrix);
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(Boundary_z2_column_with_row_access_operators, Column, z2_only_row_access_columns) {
-  typename Column::Master::row_container_type rows;  // do not destroy before matrix
+  typename Column::Master::Row_container rows;  // do not destroy before matrix
   typename Column::Column_settings settings;
   std::vector<Column> matrix = build_column_matrix<Column>(rows, settings);
   column_test_common_z2_operators(matrix);
@@ -80,7 +80,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(Boundary_z2_column_with_row_access_operators, Colu
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(Boundary_column_row_access_constructors, Column, z2_only_row_access_columns) {
-  typename Column::Master::row_container_type rows;  // do not destroy before matrix
+  typename Column::Master::Row_container rows;  // do not destroy before matrix
   typename Column::Column_settings settings;
   std::vector<Column> matrix = build_column_matrix<Column>(rows, settings);
 
@@ -90,7 +90,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(Boundary_column_row_access_constructors, Column, z
 BOOST_AUTO_TEST_CASE_TEMPLATE(Boundary_z2_column_with_row_access_other, Column, z2_only_row_access_columns) {
   column_test_base_boundary_z2_methods<Column>();
 
-  typename Column::Master::row_container_type rows;  // do not destroy before matrix
+  typename Column::Master::Row_container rows;  // do not destroy before matrix
   typename Column::Column_settings settings;
   std::vector<Column> matrix = build_base_boundary_column_matrix<Column>(rows, settings);
   column_test_boundary_methods<Column>(matrix);
@@ -149,14 +149,14 @@ using z5_only_row_access_columns = columns_list<z5_only_ra_option_list<option_na
 #endif
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(Boundary_z5_column_with_row_access_content_access, Column, z5_only_row_access_columns) {
-  typename Column::Master::row_container_type rows;  // do not destroy before matrix
+  typename Column::Master::Row_container rows;  // do not destroy before matrix
   typename Column::Column_settings settings(5);
   std::vector<Column> matrix = build_column_matrix<Column>(rows, settings);
   column_test_common_z5_content_access(matrix);
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(Boundary_z5_column_with_row_access_operators, Column, z5_only_row_access_columns) {
-  typename Column::Master::row_container_type rows;  // do not destroy before matrix
+  typename Column::Master::Row_container rows;  // do not destroy before matrix
   typename Column::Column_settings settings(5);
   std::vector<Column> matrix = build_column_matrix<Column>(rows, settings);
   column_test_common_z5_operators(matrix);
@@ -168,7 +168,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(Boundary_z5_column_with_row_access_operators, Colu
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(Boundary_column_row_access_constructors, Column, z5_only_row_access_columns) {
-  typename Column::Master::row_container_type rows;  // do not destroy before matrix
+  typename Column::Master::Row_container rows;  // do not destroy before matrix
   typename Column::Column_settings settings(5);
   std::vector<Column> matrix = build_column_matrix<Column>(rows, settings);
 
@@ -179,7 +179,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(Boundary_z5_column_with_row_access_other, Column, 
   typename Column::Column_settings settings(5);
   column_test_base_boundary_z5_methods<Column>();
 
-  typename Column::Master::row_container_type rows;  // do not destroy before matrix
+  typename Column::Master::Row_container rows;  // do not destroy before matrix
   std::vector<Column> matrix = build_base_boundary_column_matrix<Column>(rows, settings);
   column_test_boundary_methods<Column>(matrix);
 

--- a/src/Persistence_matrix/test/Persistence_matrix_column_tests_chain.cpp
+++ b/src/Persistence_matrix/test/Persistence_matrix_column_tests_chain.cpp
@@ -54,21 +54,21 @@ using z2_only_row_access_columns = columns_list<z2_only_ra_option_list<option_na
 #endif
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(Chain_z2_column_with_row_access_content_access, Column, z2_only_row_access_columns) {
-  typename Column::Master::row_container_type rows;  // do not destroy before matrix
+  typename Column::Master::Row_container rows;  // do not destroy before matrix
   typename Column::Column_settings settings;
   std::vector<Column> matrix = build_column_matrix<Column>(rows, settings);
   column_test_common_z2_content_access(matrix);
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(Chain_z2_column_with_row_access_operators, Column, z2_only_row_access_columns) {
-  typename Column::Master::row_container_type rows;  // do not destroy before matrix
+  typename Column::Master::Row_container rows;  // do not destroy before matrix
   typename Column::Column_settings settings;
   std::vector<Column> matrix = build_column_matrix<Column>(rows, settings);
   column_test_common_z2_operators(matrix);
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(Chain_column_row_access_constructors, Column, z2_only_row_access_columns) {
-  typename Column::Master::row_container_type rows;  // do not destroy before matrix
+  typename Column::Master::Row_container rows;  // do not destroy before matrix
   typename Column::Column_settings settings;
   std::vector<Column> matrix = build_column_matrix<Column>(rows, settings);
 
@@ -76,7 +76,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(Chain_column_row_access_constructors, Column, z2_o
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(Chain_column_with_row_access_other, Column, z2_only_row_access_columns) {
-  typename Column::Master::row_container_type rows;  // do not destroy before matrix
+  typename Column::Master::Row_container rows;  // do not destroy before matrix
   typename Column::Column_settings settings;
   std::vector<Column> matrix = build_column_matrix<Column>(rows, settings);
 
@@ -125,21 +125,21 @@ using z5_only_row_access_columns = columns_list<z5_only_ra_option_list<option_na
 #endif
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(Chain_z5_column_with_row_access_content_access, Column, z5_only_row_access_columns) {
-  typename Column::Master::row_container_type rows;  // do not destroy before matrix
+  typename Column::Master::Row_container rows;  // do not destroy before matrix
   typename Column::Column_settings settings(5);
   std::vector<Column> matrix = build_column_matrix<Column>(rows, settings);
   column_test_common_z5_content_access(matrix);
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(Chain_z5_column_with_row_access_operators, Column, z5_only_row_access_columns) {
-  typename Column::Master::row_container_type rows;  // do not destroy before matrix
+  typename Column::Master::Row_container rows;  // do not destroy before matrix
   typename Column::Column_settings settings(5);
   std::vector<Column> matrix = build_column_matrix<Column>(rows, settings);
   column_test_common_z5_operators(matrix);
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(Chain_column_row_access_constructors, Column, z5_only_row_access_columns) {
-  typename Column::Master::row_container_type rows;  // do not destroy before matrix
+  typename Column::Master::Row_container rows;  // do not destroy before matrix
   typename Column::Column_settings settings(5);
   std::vector<Column> matrix = build_column_matrix<Column>(rows, settings);
 
@@ -147,7 +147,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(Chain_column_row_access_constructors, Column, z5_o
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(Chain_column_with_row_access_other, Column, z5_only_row_access_columns) {
-  typename Column::Master::row_container_type rows;  // do not destroy before matrix
+  typename Column::Master::Row_container rows;  // do not destroy before matrix
   typename Column::Column_settings settings(5);
   std::vector<Column> matrix = build_column_matrix<Column>(rows, settings);
 

--- a/src/Persistence_matrix/test/Persistence_matrix_field_operators_tests.cpp
+++ b/src/Persistence_matrix/test/Persistence_matrix_field_operators_tests.cpp
@@ -26,7 +26,7 @@ using Gudhi::persistence_fields::Zp_field_operators;
 
 template <class Z2>
 void test_z2_standart_field_operators(Z2& op) {
-  using T = typename Z2::element_type;
+  using T = typename Z2::Element;
 
   unsigned int z21 = 7u;
   unsigned int z22 = 2u;
@@ -150,7 +150,7 @@ void test_z5_standart_field_operators(Z5& op) {
 
 template <class Z2>
 void test_z2_standart_field_inplace_operators(Z2& op) {
-  using T = typename Z2::element_type;
+  using T = typename Z2::Element;
 
   T z23 = op.get_value(7u);
   T z24 = op.get_value(2u);
@@ -226,7 +226,7 @@ void test_z2_standart_field_inplace_operators(Z2& op) {
 
 template <class Z5>
 void test_z5_standart_field_inplace_operators(Z5& op) {
-  using T = typename Z5::element_type;
+  using T = typename Z5::Element;
 
   T z53 = op.get_value(7);
   T z54 = op.get_value(3);
@@ -308,8 +308,8 @@ void test_z2_standart_field_properties(Z2& op) {
 
   BOOST_CHECK_EQUAL(op.get_inverse(z21), 1);
   BOOST_CHECK_EQUAL(op.get_inverse(z22), 0);
-  BOOST_CHECK(op.get_partial_inverse(z21, 35) == std::make_pair(typename Z2::element_type(1), 35u));
-  BOOST_CHECK(op.get_partial_inverse(z22, 35) == std::make_pair(typename Z2::element_type(0), 35u));
+  BOOST_CHECK(op.get_partial_inverse(z21, 35) == std::make_pair(typename Z2::Element(1), 35u));
+  BOOST_CHECK(op.get_partial_inverse(z22, 35) == std::make_pair(typename Z2::Element(0), 35u));
 
   BOOST_CHECK_EQUAL(op.get_additive_identity(), 0);
   BOOST_CHECK_EQUAL(op.get_multiplicative_identity(), 1);
@@ -392,7 +392,7 @@ BOOST_AUTO_TEST_CASE(Field_operators_properties) {
 
 template <class MF>
 void test_multi_field_operators(MF& op) {
-  using T = typename MF::element_type;
+  using T = typename MF::Element;
 
   T m1(5005);
   T m2(5007);
@@ -445,7 +445,7 @@ void test_multi_field_operators(MF& op) {
 
 template <class MF>
 void test_multi_field_inplace_operators(MF& op) {
-  using T = typename MF::element_type;
+  using T = typename MF::Element;
 
   T m1(5005);
   T m2(5007);
@@ -521,7 +521,7 @@ void test_multi_field_inplace_operators(MF& op) {
 
 template <class MF>
 void test_multi_field_properties(MF& op) {
-  using T = typename MF::element_type;
+  using T = typename MF::Element;
 
   T m1(1);
   T m2(7);

--- a/src/Persistence_matrix/test/Persistence_matrix_field_tests.cpp
+++ b/src/Persistence_matrix/test/Persistence_matrix_field_tests.cpp
@@ -355,7 +355,7 @@ BOOST_AUTO_TEST_CASE(Shared_Field_properties) {
 
 template <class MF>
 void test_multi_field_constructors() {
-  using T = typename MF::element_type;
+  using T = typename MF::Element;
 
   // default constructor
   MF m_d;
@@ -388,7 +388,7 @@ void test_multi_field_constructors() {
 
 template <class MF>
 void test_multi_field_operators() {
-  using T = typename MF::element_type;
+  using T = typename MF::Element;
 
   MF m1(5005);
   MF m2(5007);
@@ -442,7 +442,7 @@ void test_multi_field_operators() {
 
 template <class MF>
 void test_multi_field_properties() {
-  using T = typename MF::element_type;
+  using T = typename MF::Element;
 
   MF m1(1);
   MF m2(7);

--- a/src/Persistence_matrix/test/Persistence_matrix_matrix_tests_z2_boundary.cpp
+++ b/src/Persistence_matrix/test/Persistence_matrix_matrix_tests_z2_boundary.cpp
@@ -43,7 +43,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(Boundary_matrix_z2_access, Matrix, full_matrices) 
 BOOST_AUTO_TEST_CASE_TEMPLATE(Boundary_matrix_z2_zeroing, Matrix, full_matrices) { test_zeroing<Matrix>(); }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(Boundary_matrix_z2_row_access, Matrix, row_access_matrices) {
-  auto columns = build_simple_boundary_matrix<typename Matrix::Column_type>();
+  auto columns = build_simple_boundary_matrix<typename Matrix::Column>();
   Matrix m(columns);
   test_non_base_row_access<Matrix>(m);
 }
@@ -57,7 +57,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(Boundary_matrix_z2_column_removal, Matrix, removab
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(Boundary_matrix_z2_max_dimension, Matrix, max_dim_matrices) {
-  auto columns = build_simple_boundary_matrix<typename Matrix::Column_type>();
+  auto columns = build_simple_boundary_matrix<typename Matrix::Column>();
   Matrix m(columns);
   test_maximal_dimension<Matrix>(m);
 }

--- a/src/Persistence_matrix/test/Persistence_matrix_matrix_tests_z2_chain_barcode.cpp
+++ b/src/Persistence_matrix/test/Persistence_matrix_matrix_tests_z2_chain_barcode.cpp
@@ -40,7 +40,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(Chain_matrix_z2_barcode_constructors, Matrix, full
 BOOST_AUTO_TEST_CASE_TEMPLATE(Chain_matrix_z2_barcode_insertion, Matrix, full_matrices) {
   Matrix m1;
 
-  auto orderedBoundaries = build_simple_boundary_matrix<typename Matrix::Column_type>();
+  auto orderedBoundaries = build_simple_boundary_matrix<typename Matrix::Column>();
   orderedBoundaries.pop_back();
   orderedBoundaries.pop_back();
 
@@ -50,39 +50,39 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(Chain_matrix_z2_barcode_insertion, Matrix, full_ma
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(Chain_matrix_z2_barcode_access, Matrix, full_matrices) {
-  auto columns = build_simple_boundary_matrix<typename Matrix::Column_type>();
+  auto columns = build_simple_boundary_matrix<typename Matrix::Column>();
   Matrix m(columns);
   test_chain_access<Matrix>(m);
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(Chain_matrix_z2_barcode_row_access, Matrix, row_access_matrices) {
-  auto columns = build_simple_boundary_matrix<typename Matrix::Column_type>();
+  auto columns = build_simple_boundary_matrix<typename Matrix::Column>();
   Matrix m(columns);
   test_non_base_row_access<Matrix>(m);
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(Chain_matrix_z2_barcode_row_removal, Matrix, removable_rows_matrices) {
-  auto columns = build_simple_boundary_matrix<typename Matrix::Column_type>();
+  auto columns = build_simple_boundary_matrix<typename Matrix::Column>();
   Matrix m(columns);
   test_chain_row_removal<Matrix>(m);
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(Chain_matrix_z2_barcode_column_removal, Matrix, removable_columns_matrices) {
-  auto columns = build_simple_boundary_matrix<typename Matrix::Column_type>();
+  auto columns = build_simple_boundary_matrix<typename Matrix::Column>();
   Matrix m(columns);
   test_chain_maximal_simplex_removal<Matrix>(m);
 }
 
 #ifdef PM_TEST_MAX_DIM
 BOOST_AUTO_TEST_CASE_TEMPLATE(Chain_matrix_z2_barcode_max_dimension, Matrix, full_matrices) {
-  auto columns = build_simple_boundary_matrix<typename Matrix::Column_type>();
+  auto columns = build_simple_boundary_matrix<typename Matrix::Column>();
   Matrix m(columns);
   test_maximal_dimension<Matrix>(m);
 }
 #endif
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(Chain_matrix_z2_barcode_operation, Matrix, full_matrices) {
-  auto columns = build_simple_boundary_matrix<typename Matrix::Column_type>();
+  auto columns = build_simple_boundary_matrix<typename Matrix::Column>();
   Matrix m(columns);
   test_chain_operation<Matrix>(m);
 }

--- a/src/Persistence_matrix/test/Persistence_matrix_matrix_tests_z2_chain_rep.cpp
+++ b/src/Persistence_matrix/test/Persistence_matrix_matrix_tests_z2_chain_rep.cpp
@@ -39,7 +39,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(Chain_matrix_z2_rep_constructors, Matrix, full_mat
 BOOST_AUTO_TEST_CASE_TEMPLATE(Chain_matrix_z2_rep_insertion, Matrix, full_matrices) {
   Matrix m1;
 
-  auto orderedBoundaries = build_simple_boundary_matrix<typename Matrix::Column_type>();
+  auto orderedBoundaries = build_simple_boundary_matrix<typename Matrix::Column>();
   orderedBoundaries.pop_back();
   orderedBoundaries.pop_back();
 
@@ -49,39 +49,39 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(Chain_matrix_z2_rep_insertion, Matrix, full_matric
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(Chain_matrix_z2_rep_access, Matrix, full_matrices) {
-  auto orderedBoundaries = build_simple_boundary_matrix<typename Matrix::Column_type>();
+  auto orderedBoundaries = build_simple_boundary_matrix<typename Matrix::Column>();
   Matrix m(orderedBoundaries);
   test_chain_access<Matrix>(m);
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(Chain_matrix_z2_rep_row_access, Matrix, row_access_matrices) {
-  auto columns = build_simple_boundary_matrix<typename Matrix::Column_type>();
+  auto columns = build_simple_boundary_matrix<typename Matrix::Column>();
   Matrix m(columns);
   test_non_base_row_access<Matrix>(m);
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(Chain_matrix_z2_rep_row_removal, Matrix, removable_rows_matrices) {
-  auto columns = build_simple_boundary_matrix<typename Matrix::Column_type>();
+  auto columns = build_simple_boundary_matrix<typename Matrix::Column>();
   Matrix m(columns);
   test_chain_row_removal<Matrix>(m);
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(Chain_matrix_z2_rep_column_removal, Matrix, removable_columns_matrices) {
-  auto columns = build_simple_boundary_matrix<typename Matrix::Column_type>();
+  auto columns = build_simple_boundary_matrix<typename Matrix::Column>();
   Matrix m(columns);
   test_chain_maximal_simplex_removal<Matrix>(m);
 }
 
 #ifdef PM_TEST_MAX_DIM
 BOOST_AUTO_TEST_CASE_TEMPLATE(Chain_matrix_z2_rep_max_dimension, Matrix, full_matrices) {
-  auto columns = build_simple_boundary_matrix<typename Matrix::Column_type>();
+  auto columns = build_simple_boundary_matrix<typename Matrix::Column>();
   Matrix m(columns);
   test_maximal_dimension<Matrix>(m);
 }
 #endif
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(Chain_matrix_z2_rep_operation, Matrix, full_matrices) {
-  auto columns = build_simple_boundary_matrix<typename Matrix::Column_type>();
+  auto columns = build_simple_boundary_matrix<typename Matrix::Column>();
   Matrix m(columns);
   test_chain_operation<Matrix>(m);
 }
@@ -92,7 +92,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(Chain_matrix_z2_rep_barcode, Matrix, barcode_matri
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(Chain_matrix_z2_rep_representative_cycles, Matrix, full_matrices) {
-  auto columns = build_longer_boundary_matrix<typename Matrix::Column_type>();
+  auto columns = build_longer_boundary_matrix<typename Matrix::Column>();
   Matrix m(columns);
   test_representative_cycles<Matrix>(m);
 }

--- a/src/Persistence_matrix/test/Persistence_matrix_matrix_tests_z2_chain_vine.cpp
+++ b/src/Persistence_matrix/test/Persistence_matrix_matrix_tests_z2_chain_vine.cpp
@@ -55,7 +55,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(Chain_matrix_z2_vine_constructors, Matrix, full_ma
 BOOST_AUTO_TEST_CASE_TEMPLATE(Chain_matrix_z2_vine_insertion, Matrix, full_matrices) {
   Matrix m1;
 
-  auto orderedBoundaries = build_simple_boundary_matrix<typename Matrix::Column_type>();
+  auto orderedBoundaries = build_simple_boundary_matrix<typename Matrix::Column>();
   orderedBoundaries.pop_back();
   orderedBoundaries.pop_back();
 
@@ -65,26 +65,26 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(Chain_matrix_z2_vine_insertion, Matrix, full_matri
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(Chain_matrix_z2_vine_access, Matrix, full_matrices) {
-  auto orderedBoundaries = build_simple_boundary_matrix<typename Matrix::Column_type>();
+  auto orderedBoundaries = build_simple_boundary_matrix<typename Matrix::Column>();
   Matrix m(orderedBoundaries);
   test_chain_access<Matrix>(m);
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(Chain_matrix_z2_vine_row_access, Matrix, row_access_matrices) {
-  auto columns = build_simple_boundary_matrix<typename Matrix::Column_type>();
+  auto columns = build_simple_boundary_matrix<typename Matrix::Column>();
   Matrix m(columns);
   test_non_base_row_access<Matrix>(m);
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(Chain_matrix_z2_vine_row_removal, Matrix, removable_rows_matrices) {
-  auto columns = build_simple_boundary_matrix<typename Matrix::Column_type>();
+  auto columns = build_simple_boundary_matrix<typename Matrix::Column>();
   Matrix m(columns);
   test_chain_row_removal<Matrix>(m);
 }
 
 #ifdef PM_TEST_REM_COL
 BOOST_AUTO_TEST_CASE_TEMPLATE(Chain_matrix_z2_vine_column_removal, Matrix, full_matrices) {
-  auto columns = build_simple_boundary_matrix<typename Matrix::Column_type>();
+  auto columns = build_simple_boundary_matrix<typename Matrix::Column>();
   Matrix m(columns);
   test_chain_maximal_simplex_removal<Matrix>(m);
 }
@@ -92,14 +92,14 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(Chain_matrix_z2_vine_column_removal, Matrix, full_
 
 #ifdef PM_TEST_MAX_DIM
 BOOST_AUTO_TEST_CASE_TEMPLATE(Chain_matrix_z2_vine_max_dimension, Matrix, full_matrices) {
-  auto columns = build_simple_boundary_matrix<typename Matrix::Column_type>();
+  auto columns = build_simple_boundary_matrix<typename Matrix::Column>();
   Matrix m(columns);
   test_maximal_dimension<Matrix>(m);
 }
 #endif
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(Chain_matrix_z2_vine_operation, Matrix, full_matrices) {
-  auto columns = build_simple_boundary_matrix<typename Matrix::Column_type>();
+  auto columns = build_simple_boundary_matrix<typename Matrix::Column>();
   Matrix m(columns);
   test_chain_operation<Matrix>(m);
 }
@@ -110,7 +110,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(Chain_matrix_z2_vine_barcode, Matrix, full_matrice
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(Chain_matrix_z2_vine, Matrix, full_matrices) {
-  auto columns = build_longer_boundary_matrix<typename Matrix::Column_type>();
+  auto columns = build_longer_boundary_matrix<typename Matrix::Column>();
   Matrix m(columns);
 #ifdef PM_TEST_ID_IDX
   test_vine_swap_with_id_index(m);
@@ -120,7 +120,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(Chain_matrix_z2_vine, Matrix, full_matrices) {
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(Chain_matrix_z2_vine_representative_cycles, Matrix, rep_matrices) {
-  auto columns = build_longer_boundary_matrix<typename Matrix::Column_type>();
+  auto columns = build_longer_boundary_matrix<typename Matrix::Column>();
   Matrix m(columns);
   test_representative_cycles<Matrix>(m);
 }
@@ -147,7 +147,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(Chain_matrix_z2_vine_constructors, Matrix, full_ma
 BOOST_AUTO_TEST_CASE_TEMPLATE(Chain_matrix_z2_vine_insertion, Matrix, full_matrices) {
   Matrix m1(birth_comparator, Gudhi::persistence_matrix::_no_G_death_comparator);
 
-  auto orderedBoundaries = build_simple_boundary_matrix<typename Matrix::Column_type>();
+  auto orderedBoundaries = build_simple_boundary_matrix<typename Matrix::Column>();
   orderedBoundaries.pop_back();
   orderedBoundaries.pop_back();
 
@@ -157,26 +157,26 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(Chain_matrix_z2_vine_insertion, Matrix, full_matri
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(Chain_matrix_z2_vine_access, Matrix, full_matrices) {
-  auto orderedBoundaries = build_simple_boundary_matrix<typename Matrix::Column_type>();
+  auto orderedBoundaries = build_simple_boundary_matrix<typename Matrix::Column>();
   Matrix m(orderedBoundaries, birth_comparator, Gudhi::persistence_matrix::_no_G_death_comparator);
   test_chain_access<Matrix>(m);
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(Chain_matrix_z2_vine_row_access, Matrix, row_access_matrices) {
-  auto columns = build_simple_boundary_matrix<typename Matrix::Column_type>();
+  auto columns = build_simple_boundary_matrix<typename Matrix::Column>();
   Matrix m(columns, birth_comparator, Gudhi::persistence_matrix::_no_G_death_comparator);
   test_non_base_row_access<Matrix>(m);
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(Chain_matrix_z2_vine_row_removal, Matrix, removable_rows_matrices) {
-  auto columns = build_simple_boundary_matrix<typename Matrix::Column_type>();
+  auto columns = build_simple_boundary_matrix<typename Matrix::Column>();
   Matrix m(columns, birth_comparator, Gudhi::persistence_matrix::_no_G_death_comparator);
   test_chain_row_removal<Matrix>(m);
 }
 
 #ifdef PM_TEST_REM_COL
 BOOST_AUTO_TEST_CASE_TEMPLATE(Chain_matrix_z2_vine_column_removal, Matrix, full_matrices) {
-  auto columns = build_simple_boundary_matrix<typename Matrix::Column_type>();
+  auto columns = build_simple_boundary_matrix<typename Matrix::Column>();
   Matrix m(columns, birth_comparator, Gudhi::persistence_matrix::_no_G_death_comparator);
   test_chain_maximal_simplex_removal<Matrix>(m);
 }
@@ -184,34 +184,34 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(Chain_matrix_z2_vine_column_removal, Matrix, full_
 
 #ifdef PM_TEST_MAX_DIM
 BOOST_AUTO_TEST_CASE_TEMPLATE(Chain_matrix_z2_vine_max_dimension, Matrix, full_matrices) {
-  auto columns = build_simple_boundary_matrix<typename Matrix::Column_type>();
+  auto columns = build_simple_boundary_matrix<typename Matrix::Column>();
   Matrix m(columns, birth_comparator, Gudhi::persistence_matrix::_no_G_death_comparator);
   test_maximal_dimension<Matrix>(m);
 }
 #endif
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(Chain_matrix_z2_vine_operation, Matrix, full_matrices) {
-  auto columns = build_simple_boundary_matrix<typename Matrix::Column_type>();
+  auto columns = build_simple_boundary_matrix<typename Matrix::Column>();
   Matrix m(columns, birth_comparator, Gudhi::persistence_matrix::_no_G_death_comparator);
   test_chain_operation<Matrix>(m);
 }
 
 #ifdef PM_TEST_ID_IDX
 BOOST_AUTO_TEST_CASE_TEMPLATE(Chain_matrix_z2_vine_without_barcode, Matrix, full_matrices) {
-  auto columns = build_longer_boundary_matrix<typename Matrix::Column_type>();
+  auto columns = build_longer_boundary_matrix<typename Matrix::Column>();
   Matrix m(columns, birth_comparator, Gudhi::persistence_matrix::_no_G_death_comparator);
   test_vine_swap_with_id_index(m);
 }
 #else
 BOOST_AUTO_TEST_CASE_TEMPLATE(Chain_matrix_z2_vine_without_barcode, Matrix, full_matrices) {
-  auto columns = build_longer_boundary_matrix<typename Matrix::Column_type>();
+  auto columns = build_longer_boundary_matrix<typename Matrix::Column>();
   Matrix m(columns, birth_comparator, Gudhi::persistence_matrix::_no_G_death_comparator);
   test_vine_swap_with_position_index(m);
 }
 #endif
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(Chain_matrix_z2_vine_representative_cycles, Matrix, rep_matrices) {
-  auto columns = build_longer_boundary_matrix<typename Matrix::Column_type>();
+  auto columns = build_longer_boundary_matrix<typename Matrix::Column>();
   Matrix m(columns, birth_comparator, Gudhi::persistence_matrix::_no_G_death_comparator);
   test_representative_cycles<Matrix>(m);
 }

--- a/src/Persistence_matrix/test/Persistence_matrix_matrix_tests_z2_ru_rep.cpp
+++ b/src/Persistence_matrix/test/Persistence_matrix_matrix_tests_z2_ru_rep.cpp
@@ -65,7 +65,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(RU_matrix_z2_rep_column_removal, Matrix, removable
 
 #ifdef PM_TEST_MAX_DIM
 BOOST_AUTO_TEST_CASE_TEMPLATE(RU_matrix_z2_rep_max_dimension, Matrix, full_matrices) {
-  auto columns = build_simple_boundary_matrix<typename Matrix::Column_type>();
+  auto columns = build_simple_boundary_matrix<typename Matrix::Column>();
   Matrix m(columns);
   test_maximal_dimension<Matrix>(m);
 }
@@ -81,7 +81,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(RU_matrix_z2_rep_barcode, Matrix, full_matrices) {
 #endif
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(RU_matrix_z2_rep_representative_cycles, Matrix, full_matrices) {
-  auto columns = build_longer_boundary_matrix<typename Matrix::Column_type>();
+  auto columns = build_longer_boundary_matrix<typename Matrix::Column>();
   Matrix m(columns);
   test_representative_cycles<Matrix>(m);
 }
@@ -90,7 +90,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(RU_matrix_z2_rep_representative_cycles, Matrix, fu
 BOOST_AUTO_TEST_CASE_TEMPLATE(RU_matrix_z2_rep_access, Matrix, full_matrices) { test_boundary_access<Matrix>(); }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(RU_matrix_z2_rep_row_access, Matrix, row_access_matrices) {
-  auto columns = build_simple_boundary_matrix<typename Matrix::Column_type>();
+  auto columns = build_simple_boundary_matrix<typename Matrix::Column>();
   Matrix m(columns);
   test_non_base_row_access<Matrix>(m);
 }
@@ -101,7 +101,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(RU_matrix_z2_rep_access, Matrix, full_matrices) {
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(RU_matrix_z2_rep_row_access, Matrix, row_access_matrices) {
-  auto columns = build_simple_boundary_matrix<typename Matrix::Column_type>();
+  auto columns = build_simple_boundary_matrix<typename Matrix::Column>();
   Matrix m(columns);
   test_non_base_row_access<Matrix>(m);
   test_ru_u_row_access<Matrix>();

--- a/src/Persistence_matrix/test/Persistence_matrix_matrix_tests_z2_ru_vine.cpp
+++ b/src/Persistence_matrix/test/Persistence_matrix_matrix_tests_z2_ru_vine.cpp
@@ -66,7 +66,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(RU_matrix_z2_vine_column_removal, Matrix, removabl
 
 #ifdef PM_TEST_MAX_DIM
 BOOST_AUTO_TEST_CASE_TEMPLATE(RU_matrix_z2_vine_max_dimension, Matrix, full_matrices) {
-  auto columns = build_simple_boundary_matrix<typename Matrix::Column_type>();
+  auto columns = build_simple_boundary_matrix<typename Matrix::Column>();
   Matrix m(columns);
   test_maximal_dimension<Matrix>(m);
 }
@@ -82,7 +82,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(RU_matrix_z2_vine_barcode, Matrix, full_matrices) 
 #endif
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(RU_matrix_z2_vine_representative_cycles, Matrix, rep_matrices) {
-  auto columns = build_longer_boundary_matrix<typename Matrix::Column_type>();
+  auto columns = build_longer_boundary_matrix<typename Matrix::Column>();
   Matrix m(columns);
   test_representative_cycles<Matrix>(m);
 }
@@ -91,13 +91,13 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(RU_matrix_z2_vine_representative_cycles, Matrix, r
 BOOST_AUTO_TEST_CASE_TEMPLATE(RU_matrix_z2_vine_access, Matrix, full_matrices) { test_boundary_access<Matrix>(); }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(RU_matrix_z2_vine_row_access, Matrix, row_access_matrices) {
-  auto columns = build_simple_boundary_matrix<typename Matrix::Column_type>();
+  auto columns = build_simple_boundary_matrix<typename Matrix::Column>();
   Matrix m(columns);
   test_non_base_row_access<Matrix>(m);
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(RU_matrix_z2_vine, Matrix, full_matrices) {
-  auto columns = build_longer_boundary_matrix<typename Matrix::Column_type>();
+  auto columns = build_longer_boundary_matrix<typename Matrix::Column>();
   Matrix m(columns);
   test_vine_swap_with_id_index(m);
 }
@@ -108,14 +108,14 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(RU_matrix_z2_vine_access, Matrix, full_matrices) {
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(RU_matrix_z2_vine_row_access, Matrix, row_access_matrices) {
-  auto columns = build_simple_boundary_matrix<typename Matrix::Column_type>();
+  auto columns = build_simple_boundary_matrix<typename Matrix::Column>();
   Matrix m(columns);
   test_non_base_row_access<Matrix>(m);
   test_ru_u_row_access<Matrix>();
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(RU_matrix_z2_vine, Matrix, full_matrices) {
-  auto columns = build_longer_boundary_matrix<typename Matrix::Column_type>();
+  auto columns = build_longer_boundary_matrix<typename Matrix::Column>();
   Matrix m(columns);
   test_vine_swap_with_position_index(m);
 }

--- a/src/Persistence_matrix/test/Persistence_matrix_matrix_tests_zp_boundary.cpp
+++ b/src/Persistence_matrix/test/Persistence_matrix_matrix_tests_zp_boundary.cpp
@@ -43,7 +43,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(Boundary_matrix_zp_access, Matrix, full_matrices) 
 BOOST_AUTO_TEST_CASE_TEMPLATE(Boundary_matrix_zp_zeroing, Matrix, full_matrices) { test_zeroing<Matrix>(); }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(Boundary_matrix_zp_row_access, Matrix, row_access_matrices) {
-  auto columns = build_simple_boundary_matrix<typename Matrix::Column_type>();
+  auto columns = build_simple_boundary_matrix<typename Matrix::Column>();
   Matrix m(columns, 5);
   test_non_base_row_access<Matrix>(m);
 }
@@ -57,7 +57,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(Boundary_matrix_zp_column_removal, Matrix, removab
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(Boundary_matrix_zp_max_dimension, Matrix, max_dim_matrices) {
-  auto columns = build_simple_boundary_matrix<typename Matrix::Column_type>();
+  auto columns = build_simple_boundary_matrix<typename Matrix::Column>();
   Matrix m(columns, 5);
   test_maximal_dimension<Matrix>(m);
 }

--- a/src/Persistence_matrix/test/Persistence_matrix_matrix_tests_zp_chain_barcode.cpp
+++ b/src/Persistence_matrix/test/Persistence_matrix_matrix_tests_zp_chain_barcode.cpp
@@ -41,7 +41,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(Chain_matrix_zp_barcode_insertion, Matrix, full_ma
   Matrix m1;
   m1.set_characteristic(5);
 
-  auto orderedBoundaries = build_simple_boundary_matrix<typename Matrix::Column_type>();
+  auto orderedBoundaries = build_simple_boundary_matrix<typename Matrix::Column>();
   orderedBoundaries.pop_back();
   orderedBoundaries.pop_back();
 
@@ -51,39 +51,39 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(Chain_matrix_zp_barcode_insertion, Matrix, full_ma
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(Chain_matrix_zp_barcode_access, Matrix, full_matrices) {
-  auto columns = build_simple_boundary_matrix<typename Matrix::Column_type>();
+  auto columns = build_simple_boundary_matrix<typename Matrix::Column>();
   Matrix m(columns, 5);
   test_chain_access<Matrix>(m);
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(Chain_matrix_zp_barcode_row_access, Matrix, row_access_matrices) {
-  auto columns = build_simple_boundary_matrix<typename Matrix::Column_type>();
+  auto columns = build_simple_boundary_matrix<typename Matrix::Column>();
   Matrix m(columns, 5);
   test_non_base_row_access<Matrix>(m);
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(Chain_matrix_zp_barcode_row_removal, Matrix, removable_rows_matrices) {
-  auto columns = build_simple_boundary_matrix<typename Matrix::Column_type>();
+  auto columns = build_simple_boundary_matrix<typename Matrix::Column>();
   Matrix m(columns, 5);
   test_chain_row_removal<Matrix>(m);
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(Chain_matrix_zp_barcode_column_removal, Matrix, removable_columns_matrices) {
-  auto columns = build_simple_boundary_matrix<typename Matrix::Column_type>();
+  auto columns = build_simple_boundary_matrix<typename Matrix::Column>();
   Matrix m(columns, 5);
   test_chain_maximal_simplex_removal<Matrix>(m);
 }
 
 #ifdef PM_TEST_MAX_DIM
 BOOST_AUTO_TEST_CASE_TEMPLATE(Chain_matrix_zp_barcode_max_dimension, Matrix, full_matrices) {
-  auto columns = build_simple_boundary_matrix<typename Matrix::Column_type>();
+  auto columns = build_simple_boundary_matrix<typename Matrix::Column>();
   Matrix m(columns, 5);
   test_maximal_dimension<Matrix>(m);
 }
 #endif
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(Chain_matrix_zp_barcode_operation, Matrix, full_matrices) {
-  auto columns = build_simple_boundary_matrix<typename Matrix::Column_type>();
+  auto columns = build_simple_boundary_matrix<typename Matrix::Column>();
   Matrix m(columns, 5);
   test_chain_operation<Matrix>(m);
 }

--- a/src/Persistence_matrix/test/Persistence_matrix_matrix_tests_zp_chain_rep.cpp
+++ b/src/Persistence_matrix/test/Persistence_matrix_matrix_tests_zp_chain_rep.cpp
@@ -40,7 +40,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(Chain_matrix_zp_rep_insertion, Matrix, full_matric
   Matrix m1;
   m1.set_characteristic(5);
 
-  auto orderedBoundaries = build_simple_boundary_matrix<typename Matrix::Column_type>();
+  auto orderedBoundaries = build_simple_boundary_matrix<typename Matrix::Column>();
   orderedBoundaries.pop_back();
   orderedBoundaries.pop_back();
 
@@ -50,39 +50,39 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(Chain_matrix_zp_rep_insertion, Matrix, full_matric
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(Chain_matrix_zp_rep_access, Matrix, full_matrices) {
-  auto columns = build_simple_boundary_matrix<typename Matrix::Column_type>();
+  auto columns = build_simple_boundary_matrix<typename Matrix::Column>();
   Matrix m(columns, 5);
   test_chain_access<Matrix>(m);
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(Chain_matrix_zp_rep_row_access, Matrix, row_access_matrices) {
-  auto columns = build_simple_boundary_matrix<typename Matrix::Column_type>();
+  auto columns = build_simple_boundary_matrix<typename Matrix::Column>();
   Matrix m(columns, 5);
   test_non_base_row_access<Matrix>(m);
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(Chain_matrix_zp_rep_row_removal, Matrix, removable_rows_matrices) {
-  auto columns = build_simple_boundary_matrix<typename Matrix::Column_type>();
+  auto columns = build_simple_boundary_matrix<typename Matrix::Column>();
   Matrix m(columns, 5);
   test_chain_row_removal<Matrix>(m);
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(Chain_matrix_zp_rep_column_removal, Matrix, removable_columns_matrices) {
-  auto columns = build_simple_boundary_matrix<typename Matrix::Column_type>();
+  auto columns = build_simple_boundary_matrix<typename Matrix::Column>();
   Matrix m(columns, 5);
   test_chain_maximal_simplex_removal<Matrix>(m);
 }
 
 #ifdef PM_TEST_MAX_DIM
 BOOST_AUTO_TEST_CASE_TEMPLATE(Chain_matrix_zp_rep_max_dimension, Matrix, full_matrices) {
-  auto columns = build_simple_boundary_matrix<typename Matrix::Column_type>();
+  auto columns = build_simple_boundary_matrix<typename Matrix::Column>();
   Matrix m(columns, 5);
   test_maximal_dimension<Matrix>(m);
 }
 #endif
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(Chain_matrix_zp_rep_operation, Matrix, full_matrices) {
-  auto columns = build_simple_boundary_matrix<typename Matrix::Column_type>();
+  auto columns = build_simple_boundary_matrix<typename Matrix::Column>();
   Matrix m(columns, 5);
   test_chain_operation<Matrix>(m);
 }
@@ -93,7 +93,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(Chain_matrix_zp_rep_barcode, Matrix, barcode_matri
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(Chain_matrix_zp_rep_representative_cycles, Matrix, full_matrices) {
-  auto columns = build_longer_boundary_matrix<typename Matrix::Column_type>();
+  auto columns = build_longer_boundary_matrix<typename Matrix::Column>();
   Matrix m(columns, 5);
   test_representative_cycles<Matrix>(m);
 }

--- a/src/Persistence_matrix/test/Persistence_matrix_matrix_tests_zp_ru_rep.cpp
+++ b/src/Persistence_matrix/test/Persistence_matrix_matrix_tests_zp_ru_rep.cpp
@@ -65,7 +65,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(RU_matrix_zp_rep_column_removal, Matrix, removable
 
 #ifdef PM_TEST_MAX_DIM
 BOOST_AUTO_TEST_CASE_TEMPLATE(RU_matrix_zp_rep_max_dimension, Matrix, full_matrices) {
-  auto columns = build_simple_boundary_matrix<typename Matrix::Column_type>();
+  auto columns = build_simple_boundary_matrix<typename Matrix::Column>();
   Matrix m(columns, 5);
   test_maximal_dimension<Matrix>(m);
 }
@@ -81,7 +81,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(RU_matrix_zp_rep_barcode, Matrix, full_matrices) {
 #endif
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(RU_matrix_zp_rep_representative_cycles, Matrix, full_matrices) {
-  auto columns = build_longer_boundary_matrix<typename Matrix::Column_type>();
+  auto columns = build_longer_boundary_matrix<typename Matrix::Column>();
   Matrix m(columns, 5);
   test_representative_cycles<Matrix>(m);
 }
@@ -90,7 +90,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(RU_matrix_zp_rep_representative_cycles, Matrix, fu
 BOOST_AUTO_TEST_CASE_TEMPLATE(RU_matrix_zp_rep_access, Matrix, full_matrices) { test_boundary_access<Matrix>(); }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(RU_matrix_zp_rep_row_access, Matrix, row_access_matrices) {
-  auto columns = build_simple_boundary_matrix<typename Matrix::Column_type>();
+  auto columns = build_simple_boundary_matrix<typename Matrix::Column>();
   Matrix m(columns, 5);
   test_non_base_row_access<Matrix>(m);
 }
@@ -101,7 +101,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(RU_matrix_zp_rep_access, Matrix, full_matrices) {
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(RU_matrix_zp_rep_row_access, Matrix, row_access_matrices) {
-  auto columns = build_simple_boundary_matrix<typename Matrix::Column_type>();
+  auto columns = build_simple_boundary_matrix<typename Matrix::Column>();
   Matrix m(columns, 5);
   test_non_base_row_access<Matrix>(m);
   test_ru_u_row_access<Matrix>();

--- a/src/Persistence_matrix/test/pm_column_tests.h
+++ b/src/Persistence_matrix/test/pm_column_tests.h
@@ -24,7 +24,7 @@ template <class Column>
 std::vector<column_content<Column> > get_ordered_column_contents(std::vector<Column>& matrix) {
   std::vector<std::set<typename std::conditional<is_z2<Column>(),
                                                  unsigned int,
-                                                 std::pair<unsigned int, typename Column::Field_element_type>
+                                                 std::pair<unsigned int, typename Column::Field_element>
                                                 >::type> > ordCol(matrix.size());
   for (unsigned int i = 0; i < matrix.size(); ++i) {
     Column& col = matrix[i];
@@ -44,7 +44,7 @@ template <class Column>
 std::vector<column_content<Column> > get_ordered_rows(std::vector<Column>& matrix) {
   std::vector<std::set<typename std::conditional<is_z2<Column>(),
                                                  unsigned int,
-                                                 std::pair<unsigned int, typename Column::Field_element_type>
+                                                 std::pair<unsigned int, typename Column::Field_element>
                                                 >::type> > rows;
   for (Column& col : matrix) {
     for (auto& cell : col) {
@@ -73,7 +73,7 @@ std::vector<Column> build_column_matrix(typename Column::Column_settings& settin
     matrix.emplace_back(cont{0, 1, 3, 5}, 4, &settings);
     matrix.emplace_back(matrix[1]);
   } else {
-    using cont = std::vector<std::pair<unsigned int, typename Column::Field_element_type> >;
+    using cont = std::vector<std::pair<unsigned int, typename Column::Field_element> >;
     matrix.emplace_back(cont{{0, 1}, {1, 2}, {3, 3}, {5, 4}}, 4, &settings);
     matrix.emplace_back(cont{{0, 4}, {1, 2}, {2, 1}, {5, 1}, {6, 1}}, 4, &settings);
     matrix.emplace_back(cont{{0, 1}, {1, 3}, {2, 4}, {5, 4}, {6, 4}}, 4, &settings);
@@ -98,7 +98,7 @@ std::vector<Column> build_column_matrix(Rows& rows, typename Column::Column_sett
     matrix.emplace_back(4, cont{0, 1, 3, 5}, 4, &rows, &settings);
     matrix.emplace_back(matrix[1], 5, &rows);
   } else {
-    using cont = std::vector<std::pair<unsigned int, typename Column::Field_element_type> >;
+    using cont = std::vector<std::pair<unsigned int, typename Column::Field_element> >;
     matrix.emplace_back(0, cont{{0, 1}, {1, 2}, {3, 3}, {5, 4}}, 4, &rows, &settings);
     matrix.emplace_back(1, cont{{0, 4}, {1, 2}, {2, 1}, {5, 1}, {6, 1}}, 4, &rows, &settings);
     matrix.emplace_back(2, cont{{0, 1}, {1, 3}, {2, 4}, {5, 4}, {6, 4}}, 4, &rows, &settings);
@@ -123,7 +123,7 @@ std::vector<Column> build_base_boundary_column_matrix(Rows& rows, typename Colum
     matrix.emplace_back(4, cont{0, 1, 3, 5}, &rows, &settings);
     matrix.emplace_back(matrix[1], 5, &rows);
   } else {
-    using cont = std::vector<std::pair<unsigned int, typename Column::Field_element_type> >;
+    using cont = std::vector<std::pair<unsigned int, typename Column::Field_element> >;
     matrix.emplace_back(0, cont{{0, 1}, {1, 2}, {3, 3}, {5, 4}}, &rows, &settings);
     matrix.emplace_back(1, cont{{0, 4}, {1, 2}, {2, 1}, {5, 1}, {6, 1}}, &rows, &settings);
     matrix.emplace_back(2, cont{{0, 1}, {1, 3}, {2, 4}, {5, 4}, {6, 4}}, &rows, &settings);
@@ -148,7 +148,7 @@ std::vector<Column> build_base_boundary_column_matrix(typename Column::Column_se
     matrix.emplace_back(cont{0, 1, 3, 5}, &settings);
     matrix.emplace_back(matrix[1]);
   } else {
-    using cont = std::vector<std::pair<unsigned int, typename Column::Field_element_type> >;
+    using cont = std::vector<std::pair<unsigned int, typename Column::Field_element> >;
     matrix.emplace_back(cont{{0, 1}, {1, 2}, {3, 3}, {5, 4}}, &settings);
     matrix.emplace_back(cont{{0, 4}, {1, 2}, {2, 1}, {5, 1}, {6, 1}}, &settings);
     matrix.emplace_back(cont{{0, 1}, {1, 3}, {2, 4}, {5, 4}, {6, 4}}, &settings);
@@ -164,14 +164,14 @@ template <class Column>
 std::vector<std::vector<typename std::conditional<
     is_z2<Column>(),
     unsigned int,
-    std::pair<unsigned int, typename Column::Field_element_type>
+    std::pair<unsigned int, typename Column::Field_element>
    >::type> > build_rows() {
   using cell_type = typename std::conditional<is_z2<Column>(),
                                               unsigned int,
-                                              std::pair<unsigned int, typename Column::Field_element_type>
+                                              std::pair<unsigned int, typename Column::Field_element>
                                              >::type;
-  using container_type = std::vector<cell_type>;
-  std::vector<container_type> rows(7);
+  using Container = std::vector<cell_type>;
+  std::vector<Container> rows(7);
 
   if constexpr (is_z2<Column>()) {
     rows[0] = {0, 1, 2, 4, 5};
@@ -198,14 +198,14 @@ template <class Column>
 std::vector<std::vector<typename std::conditional<
     is_z2<Column>(),
     unsigned int,
-    std::pair<unsigned int, typename Column::Field_element_type>
+    std::pair<unsigned int, typename Column::Field_element>
    >::type> > build_column_values() {
   using cell_type = typename std::conditional<is_z2<Column>(),
                                               unsigned int,
-                                              std::pair<unsigned int, typename Column::Field_element_type>
+                                              std::pair<unsigned int, typename Column::Field_element>
                                              >::type;
-  using container_type = std::vector<cell_type>;
-  std::vector<container_type> columns(6);
+  using Container = std::vector<cell_type>;
+  std::vector<Container> columns(6);
 
   if constexpr (is_z2<Column>()) {
     columns[0] = {0, 1, 3, 5};
@@ -230,11 +230,11 @@ template <class Column>
 void column_test_common_constructors() {
   using cell_type = typename std::conditional<is_z2<Column>(),
                                               unsigned int,
-                                              std::pair<unsigned int, typename Column::Field_element_type>
+                                              std::pair<unsigned int, typename Column::Field_element>
                                              >::type;
-  using container_type = std::vector<cell_type>;
+  using Container = std::vector<cell_type>;
 
-  container_type cont1, cont2;
+  Container cont1, cont2;
   typename Column::Column_settings settings(5);
 
   if constexpr (is_z2<Column>()) {
@@ -281,7 +281,7 @@ void column_test_common_constructors() {
 template <class Column, typename cell_type>
 void column_test_common_content_access(Column& col,
                                        const std::set<cell_type>& setcont,
-                                       const std::vector<typename Column::Field_element_type>& veccont) {
+                                       const std::vector<typename Column::Field_element>& veccont) {
   BOOST_CHECK(get_column_content_via_iterators(col) == setcont);
   BOOST_CHECK(col.get_content(veccont.size()) == veccont);
   if constexpr (Column::Master::Option_list::column_type != Column_types::HEAP) {
@@ -304,8 +304,8 @@ void column_test_common_content_access(Column& col,
 // assumes that matrix was build with build_column_matrix and was not modified since.
 template <class Column>
 void column_test_common_z5_content_access(std::vector<Column>& matrix) {
-  std::set<std::pair<unsigned int, typename Column::Field_element_type> > setcont;
-  std::vector<typename Column::Field_element_type> veccont;
+  std::set<std::pair<unsigned int, typename Column::Field_element> > setcont;
+  std::vector<typename Column::Field_element> veccont;
 
   setcont = {{0, 1}, {1, 2}, {3, 3}, {5, 4}};
   veccont = {1, 2, 0, 3, 0, 4};
@@ -336,7 +336,7 @@ void column_test_common_z5_content_access(std::vector<Column>& matrix) {
 template <class Column>
 void column_test_common_z2_content_access(std::vector<Column>& matrix) {
   std::set<unsigned int> setcont;
-  std::vector<typename Column::Field_element_type> veccont;
+  std::vector<typename Column::Field_element> veccont;
 
   setcont = {0, 1, 3, 5};
   veccont = {1, 1, 0, 1, 0, 1};
@@ -366,8 +366,8 @@ void column_test_common_z2_content_access(std::vector<Column>& matrix) {
 // assumes that matrix was build with build_column_matrix and was not modified since.
 template <class Column>
 void column_test_common_z5_operators(std::vector<Column>& matrix) {
-  std::set<std::pair<unsigned int, typename Column::Field_element_type> > setcont;
-  std::vector<typename Column::Field_element_type> veccont;
+  std::set<std::pair<unsigned int, typename Column::Field_element> > setcont;
+  std::vector<typename Column::Field_element> veccont;
 
   matrix[0] += matrix[1];
   matrix[1] += matrix[2];
@@ -442,7 +442,7 @@ void column_test_common_z5_operators(std::vector<Column>& matrix) {
 template <class Column>
 void column_test_common_z2_operators(std::vector<Column>& matrix) {
   std::set<unsigned int> setcont;
-  std::vector<typename Column::Field_element_type> veccont;
+  std::vector<typename Column::Field_element> veccont;
 
   matrix[0] += matrix[1];
   matrix[1] += matrix[2];
@@ -510,8 +510,8 @@ void column_test_common_z2_operators(std::vector<Column>& matrix) {
 // common: assumes that matrix was build with build_column_matrix(rows) and not modified since.
 // base/boundary special: assumes that matrix was build with build_base_boundary_column_matrix(rows) and not modified
 // since.
-template <class Column, class row_container_type>
-void column_test_row_access_constructors(std::vector<Column>& matrix, row_container_type& rows) {
+template <class Column, class Row_container>
+void column_test_row_access_constructors(std::vector<Column>& matrix, Row_container& rows) {
   test_matrix_equality<Column>(build_rows<Column>(), get_ordered_rows(matrix));
   test_matrix_equality<Column>(build_column_values<Column>(), get_ordered_column_contents(matrix));
 
@@ -589,13 +589,13 @@ template <class Column>
 void column_test_base_boundary_constructors() {
   using cell_type = typename std::conditional<is_z2<Column>(),
                                               unsigned int,
-                                              std::pair<unsigned int, typename Column::Field_element_type>
+                                              std::pair<unsigned int, typename Column::Field_element>
                                              >::type;
-  using container_type = std::vector<cell_type>;
+  using Container = std::vector<cell_type>;
 
   typename Column::Column_settings settings(5);
 
-  container_type cont1, cont2;
+  Container cont1, cont2;
 
   if constexpr (is_z2<Column>()) {
     cont1 = {0, 2, 4};
@@ -617,11 +617,11 @@ void column_test_base_boundary_constructors() {
 
 template <class Column>
 void column_test_base_boundary_z5_methods() {
-  std::vector<typename Column::Field_element_type> veccont;
+  std::vector<typename Column::Field_element> veccont;
   typename Column::Column_settings settings(5);
 
   Column col(
-      std::vector<std::pair<unsigned int, typename Column::Field_element_type> >{
+      std::vector<std::pair<unsigned int, typename Column::Field_element> >{
           {0, 4}, {1, 2}, {2, 1}, {5, 1}, {6, 1}},
       &settings);
   veccont = {4, 2, 1, 0, 0, 1, 1};
@@ -648,7 +648,7 @@ void column_test_base_boundary_z5_methods() {
 
 template <class Column>
 void column_test_base_boundary_z2_methods() {
-  std::vector<typename Column::Field_element_type> veccont;
+  std::vector<typename Column::Field_element> veccont;
   typename Column::Column_settings settings;
 
   Column col(std::vector<unsigned int>{0, 1, 2, 5, 6}, &settings);
@@ -679,7 +679,7 @@ template <class Column>
 void column_test_base_z5_operators(std::vector<Column>& matrix) {
   using Cell = typename Column::Cell;
   std::set<Cell> setcont;
-  std::vector<typename Column::Field_element_type> veccont;
+  std::vector<typename Column::Field_element> veccont;
 
   Cell cell(0);
   cell.set_element(4);
@@ -890,9 +890,9 @@ void column_test_boundary_methods(std::vector<Column>& matrix) {
 // assumes that matrix was build with build_column_matrix and was not modified since.
 template <class Column>
 void column_test_boundary_z5_operators(std::vector<Column>& matrix) {
-  using cont = std::vector<std::pair<unsigned int, typename Column::Field_element_type> >;
+  using cont = std::vector<std::pair<unsigned int, typename Column::Field_element> >;
 
-  std::vector<typename Column::Field_element_type> veccont;
+  std::vector<typename Column::Field_element> veccont;
   typename Column::Column_settings settings(5);
 
   const Column col0(cont{{0, 4}, {1, 2}, {2, 1}, {5, 1}, {6, 1}}, &settings);
@@ -1010,11 +1010,11 @@ void column_test_chain_methods() {
   Column col(&settings);
 
   BOOST_CHECK(!col.is_paired());
-  BOOST_CHECK(col.get_paired_chain_index() == static_cast<typename Column::index>(-1));
+  BOOST_CHECK(col.get_paired_chain_index() == static_cast<typename Column::Index>(-1));
 
   col.unassign_paired_chain();
   BOOST_CHECK(!col.is_paired());
-  BOOST_CHECK(col.get_paired_chain_index() == static_cast<typename Column::index>(-1));
+  BOOST_CHECK(col.get_paired_chain_index() == static_cast<typename Column::Index>(-1));
 
   col.assign_paired_chain(2);
   BOOST_CHECK(col.is_paired());
@@ -1022,7 +1022,7 @@ void column_test_chain_methods() {
 
   col.unassign_paired_chain();
   BOOST_CHECK(!col.is_paired());
-  BOOST_CHECK(col.get_paired_chain_index() == static_cast<typename Column::index>(-1));
+  BOOST_CHECK(col.get_paired_chain_index() == static_cast<typename Column::Index>(-1));
 }
 
 #endif  // PM_COLUMN_TESTS_H

--- a/src/Persistence_matrix/test/pm_matrix_tests.h
+++ b/src/Persistence_matrix/test/pm_matrix_tests.h
@@ -292,8 +292,8 @@ std::vector<witness_content<Column> > build_longer_chain_row_matrix() {
 
 template <class Matrix>
 void test_constructors() {
-  std::vector<witness_content<typename Matrix::Column_type> > empty;
-  auto columns = build_simple_boundary_matrix<typename Matrix::Column_type>();
+  std::vector<witness_content<typename Matrix::Column> > empty;
+  auto columns = build_simple_boundary_matrix<typename Matrix::Column>();
 
   // default constructor
   Matrix m;
@@ -305,7 +305,7 @@ void test_constructors() {
   if constexpr (is_RU<Matrix>()) {
     columns[5].clear();
   } else if constexpr (is_Chain<Matrix>()) {
-    columns = build_simple_chain_matrix<typename Matrix::Column_type>();
+    columns = build_simple_chain_matrix<typename Matrix::Column>();
   }
 
   BOOST_CHECK_EQUAL(mb.get_number_of_columns(), 7);
@@ -344,7 +344,7 @@ inline bool death_comp(unsigned int columnIndex1, unsigned int columnIndex2) { r
 
 template <class Matrix>
 void test_chain_constructors() {
-  auto ordered_boundaries = build_simple_boundary_matrix<typename Matrix::Column_type>();
+  auto ordered_boundaries = build_simple_boundary_matrix<typename Matrix::Column>();
 
   // default constructor
   Matrix m(birth_comp, death_comp);
@@ -388,7 +388,7 @@ void test_chain_constructors() {
 // for base and base comp
 template <class Matrix>
 void test_general_insertion() {
-  auto columns = build_general_matrix<typename Matrix::Column_type>();
+  auto columns = build_general_matrix<typename Matrix::Column>();
   auto col2 = columns.back();
   columns.pop_back();
   auto col1 = columns.back();
@@ -432,7 +432,7 @@ void test_general_insertion() {
 // for boundary and ru
 template <class Matrix>
 void test_boundary_insertion() {
-  auto orderedBoundaries = build_simple_boundary_matrix<typename Matrix::Column_type>();
+  auto orderedBoundaries = build_simple_boundary_matrix<typename Matrix::Column>();
   auto boundary2 = orderedBoundaries.back();
   orderedBoundaries.pop_back();
   auto boundary1 = orderedBoundaries.back();
@@ -474,13 +474,13 @@ void test_boundary_insertion() {
   BOOST_CHECK_EQUAL(m.get_column_dimension(5), 1);
   BOOST_CHECK_EQUAL(m.get_column_dimension(6), 2);
 
-  BOOST_CHECK_EQUAL(m.get_pivot(0), static_cast<typename Matrix::id_index>(-1));
-  BOOST_CHECK_EQUAL(m.get_pivot(1), static_cast<typename Matrix::id_index>(-1));
-  BOOST_CHECK_EQUAL(m.get_pivot(2), static_cast<typename Matrix::id_index>(-1));
+  BOOST_CHECK_EQUAL(m.get_pivot(0), static_cast<typename Matrix::ID_index>(-1));
+  BOOST_CHECK_EQUAL(m.get_pivot(1), static_cast<typename Matrix::ID_index>(-1));
+  BOOST_CHECK_EQUAL(m.get_pivot(2), static_cast<typename Matrix::ID_index>(-1));
   BOOST_CHECK_EQUAL(m.get_pivot(3), 1);
   BOOST_CHECK_EQUAL(m.get_pivot(4), 2);
   if constexpr (is_RU<Matrix>()) {
-    BOOST_CHECK_EQUAL(m.get_pivot(5), static_cast<typename Matrix::id_index>(-1));  // was reduced
+    BOOST_CHECK_EQUAL(m.get_pivot(5), static_cast<typename Matrix::ID_index>(-1));  // was reduced
   } else {
     BOOST_CHECK_EQUAL(m.get_pivot(5), 2);  // not reduced
   }
@@ -533,7 +533,7 @@ void test_chain_boundary_insertion(Matrix& m1, Matrix& m2) {
     BOOST_CHECK_EQUAL(m.get_column_with_pivot(6), 6);
   };
 
-  auto orderedBoundaries = build_simple_boundary_matrix<typename Matrix::Column_type>();
+  auto orderedBoundaries = build_simple_boundary_matrix<typename Matrix::Column>();
 
   for (unsigned int i = 0; i < orderedBoundaries.size(); ++i) {
     if constexpr (is_indexed_by_position<Matrix>())
@@ -568,7 +568,7 @@ void test_chain_boundary_insertion(Matrix& m1, Matrix& m2) {
 
 template <class Matrix>
 void test_base_access() {
-  auto columns = build_general_matrix<typename Matrix::Column_type>();
+  auto columns = build_general_matrix<typename Matrix::Column>();
   auto col2 = columns.back();
   columns.pop_back();
   auto col1 = columns.back();
@@ -588,7 +588,7 @@ void test_base_access() {
 
 template <class Matrix>
 void test_boundary_access() {
-  auto orderedBoundaries = build_simple_boundary_matrix<typename Matrix::Column_type>();
+  auto orderedBoundaries = build_simple_boundary_matrix<typename Matrix::Column>();
   Matrix m(orderedBoundaries, 5);
 
   for (unsigned int i = 0; i < orderedBoundaries.size(); ++i) {
@@ -597,24 +597,24 @@ void test_boundary_access() {
         BOOST_CHECK(m.get_column(i).is_empty());  // reduced
       } else {
         const auto& col = m.get_column(i);  // to force the const version
-        test_column_equality<typename Matrix::Column_type>(orderedBoundaries[i], get_column_content_via_iterators(col));
+        test_column_equality<typename Matrix::Column>(orderedBoundaries[i], get_column_content_via_iterators(col));
       }
     } else {
       const auto& col = m.get_column(i);  // to force the const version
-      test_column_equality<typename Matrix::Column_type>(orderedBoundaries[i], get_column_content_via_iterators(col));
+      test_column_equality<typename Matrix::Column>(orderedBoundaries[i], get_column_content_via_iterators(col));
     }
   }
 }
 
 template <class Matrix>
 void test_chain_access(Matrix& m) {
-  auto columns = build_simple_chain_matrix<typename Matrix::Column_type>();
+  auto columns = build_simple_chain_matrix<typename Matrix::Column>();
   test_content_equality(columns, m);
 }
 
 template <class Matrix>
 void test_zeroing() {
-  auto orderedBoundaries = build_simple_boundary_matrix<typename Matrix::Column_type>();
+  auto orderedBoundaries = build_simple_boundary_matrix<typename Matrix::Column>();
 
   Matrix m(orderedBoundaries, 5);
 
@@ -630,10 +630,10 @@ void test_zeroing() {
 
 template <class Matrix>
 void test_ru_u_access() {
-  auto orderedBoundaries = build_simple_boundary_matrix<typename Matrix::Column_type>();
+  auto orderedBoundaries = build_simple_boundary_matrix<typename Matrix::Column>();
   Matrix m(orderedBoundaries, 5);
 
-  std::vector<witness_content<typename Matrix::Column_type> > uColumns(7);
+  std::vector<witness_content<typename Matrix::Column> > uColumns(7);
   if constexpr (Matrix::Option_list::is_z2) {
     if constexpr (Matrix::Option_list::has_vine_update) {
       uColumns[0] = {0};
@@ -665,7 +665,7 @@ void test_ru_u_access() {
   unsigned int i = 0;
   for (auto& c : uColumns) {
     const auto& col = m.get_column(i++, false);  // to force the const version
-    test_column_equality<typename Matrix::Column_type>(c, get_column_content_via_iterators(col));
+    test_column_equality<typename Matrix::Column>(c, get_column_content_via_iterators(col));
   }
 
   if constexpr (Matrix::Option_list::has_vine_update) {
@@ -691,7 +691,7 @@ void test_ru_u_access() {
 
 template <class Matrix>
 void test_base_z2_row_access() {
-  auto columns = build_general_matrix<typename Matrix::Column_type>();
+  auto columns = build_general_matrix<typename Matrix::Column>();
   Matrix m(columns, 5);
 
   std::vector<std::vector<unsigned int> > rows;
@@ -715,16 +715,16 @@ void test_base_z2_row_access() {
 
   unsigned int i = 0;
   for (auto& r : rows) {
-    test_column_equality<typename Matrix::Column_type>(r, get_ordered_row(m, i++));
+    test_column_equality<typename Matrix::Column>(r, get_ordered_row(m, i++));
   }
 }
 
 template <class Matrix>
 void test_base_z5_row_access() {
-  auto columns = build_general_matrix<typename Matrix::Column_type>();
+  auto columns = build_general_matrix<typename Matrix::Column>();
   Matrix m(columns, 5);
 
-  std::vector<std::vector<std::pair<unsigned int, typename Matrix::element_type> > > rows;
+  std::vector<std::vector<std::pair<unsigned int, typename Matrix::Element> > > rows;
   if constexpr (Matrix::Option_list::has_column_compression) {
     // if the union find structure changes, the column_index values of de cells could also change. Change the test with
     // all possibilities?
@@ -745,35 +745,35 @@ void test_base_z5_row_access() {
 
   unsigned int i = 0;
   for (auto& r : rows) {
-    test_column_equality<typename Matrix::Column_type>(r, get_ordered_row(m, i++));
+    test_column_equality<typename Matrix::Column>(r, get_ordered_row(m, i++));
   }
 }
 
 template <class Matrix>
 void test_non_base_row_access(Matrix& m) {
-  std::vector<witness_content<typename Matrix::Column_type> > rows;
+  std::vector<witness_content<typename Matrix::Column> > rows;
   if constexpr (Matrix::Option_list::is_of_boundary_type) {
     if constexpr (is_RU<Matrix>()) {
-      rows = build_simple_reduced_row_matrix<typename Matrix::Column_type>();
+      rows = build_simple_reduced_row_matrix<typename Matrix::Column>();
     } else {
-      rows = build_simple_row_matrix<typename Matrix::Column_type>();
+      rows = build_simple_row_matrix<typename Matrix::Column>();
     }
   } else {
-    rows = build_simple_chain_row_matrix<typename Matrix::Column_type>();
+    rows = build_simple_chain_row_matrix<typename Matrix::Column>();
   }
 
   unsigned int i = 0;
   for (auto& r : rows) {
-    test_column_equality<typename Matrix::Column_type>(r, get_ordered_row(m, i++));
+    test_column_equality<typename Matrix::Column>(r, get_ordered_row(m, i++));
   }
 }
 
 template <class Matrix>
 void test_ru_u_row_access() {
-  auto columns = build_simple_boundary_matrix<typename Matrix::Column_type>();
+  auto columns = build_simple_boundary_matrix<typename Matrix::Column>();
   Matrix m(columns, 5);
 
-  std::vector<witness_content<typename Matrix::Column_type> > rows;
+  std::vector<witness_content<typename Matrix::Column> > rows;
   if constexpr (Matrix::Option_list::is_z2) {
     if constexpr (Matrix::Option_list::has_vine_update) {
       rows.push_back({0});
@@ -802,7 +802,7 @@ void test_ru_u_row_access() {
     rows.push_back({{6, 1}});
   }
 
-  column_content<typename Matrix::Column_type> orderedRows;
+  column_content<typename Matrix::Column> orderedRows;
   unsigned int i = 0;
   for (auto& r : rows) {
     orderedRows.clear();
@@ -813,13 +813,13 @@ void test_ru_u_row_access() {
         orderedRows.insert({cell.get_column_index(), cell.get_element()});
       }
     }
-    test_column_equality<typename Matrix::Column_type>(r, orderedRows);
+    test_column_equality<typename Matrix::Column>(r, orderedRows);
   }
 }
 
 template <class Matrix>
 void test_row_removal() {
-  auto columns = build_simple_boundary_matrix<typename Matrix::Column_type>();
+  auto columns = build_simple_boundary_matrix<typename Matrix::Column>();
   columns[6].pop_back();  // empties row 5. Not a legit boundary matrix anymore, but for the test,
                           // should be fine, except for chain.
 
@@ -843,7 +843,7 @@ void test_chain_row_removal(Matrix& m) {
 
 template <class Matrix>
 void test_column_removal() {
-  auto columns = build_simple_boundary_matrix<typename Matrix::Column_type>();
+  auto columns = build_simple_boundary_matrix<typename Matrix::Column>();
   Matrix m(columns, 5);
 
   test_content_equality(columns, m);
@@ -858,11 +858,11 @@ void test_column_removal() {
   unsigned int i = 0;
   for (auto& b : columns) {
     if (i == 2 || i == 4) ++i;
-    test_column_equality<typename Matrix::Column_type>(b, get_column_content_via_iterators(m.get_column(i++)));
+    test_column_equality<typename Matrix::Column>(b, get_column_content_via_iterators(m.get_column(i++)));
   }
 
   if constexpr (!Matrix::Option_list::has_row_access) {
-    m.insert_column(witness_content<typename Matrix::Column_type>{}, 2);
+    m.insert_column(witness_content<typename Matrix::Column>{}, 2);
     BOOST_CHECK_NO_THROW(m.get_column(2));
     BOOST_CHECK_THROW(m.get_column(4), std::logic_error);
   }
@@ -870,7 +870,7 @@ void test_column_removal() {
 
 template <class Matrix>
 void test_boundary_maximal_simplex_removal() {
-  auto columns = build_simple_boundary_matrix<typename Matrix::Column_type>();
+  auto columns = build_simple_boundary_matrix<typename Matrix::Column>();
   Matrix m(columns, 5);
 
   test_content_equality(columns, m);
@@ -885,12 +885,12 @@ void test_boundary_maximal_simplex_removal() {
 
   test_content_equality(columns, m);
   BOOST_CHECK_EQUAL(m.get_number_of_columns(), 6);
-  BOOST_CHECK_EQUAL(m.get_current_barcode().back().death, static_cast<typename Matrix::pos_index>(-1));
+  BOOST_CHECK_EQUAL(m.get_current_barcode().back().death, static_cast<typename Matrix::Pos_index>(-1));
 }
 
 template <class Matrix>
 void test_ru_maximal_simplex_removal() {
-  auto columns = build_simple_boundary_matrix<typename Matrix::Column_type>();
+  auto columns = build_simple_boundary_matrix<typename Matrix::Column>();
   Matrix m(columns, 5);
 
   columns[5].clear();
@@ -911,13 +911,13 @@ void test_ru_maximal_simplex_removal() {
   test_content_equality(columns, m);
   BOOST_CHECK_EQUAL(m.get_number_of_columns(), 6);
   if constexpr (Matrix::Option_list::has_column_pairings) {
-    BOOST_CHECK_EQUAL(m.get_current_barcode().back().death, static_cast<typename Matrix::pos_index>(-1));
+    BOOST_CHECK_EQUAL(m.get_current_barcode().back().death, static_cast<typename Matrix::Pos_index>(-1));
   }
 }
 
 template <class Matrix>
 void test_chain_maximal_simplex_removal(Matrix& m) {
-  auto columns = build_simple_chain_matrix<typename Matrix::Column_type>();
+  auto columns = build_simple_chain_matrix<typename Matrix::Column>();
 
   test_content_equality(columns, m);
   BOOST_CHECK_EQUAL(m.get_number_of_columns(), 7);
@@ -936,7 +936,7 @@ void test_chain_maximal_simplex_removal(Matrix& m) {
   test_content_equality(columns, m);
   BOOST_CHECK_EQUAL(m.get_number_of_columns(), 6);
   if constexpr (Matrix::Option_list::has_column_pairings) {
-    BOOST_CHECK_EQUAL(m.get_current_barcode().back().death, static_cast<typename Matrix::pos_index>(-1));
+    BOOST_CHECK_EQUAL(m.get_current_barcode().back().death, static_cast<typename Matrix::Pos_index>(-1));
   }
 }
 
@@ -964,7 +964,7 @@ void test_maximal_dimension(Matrix& m) {
 
 template <class Matrix>
 void test_base_operation() {
-  auto columns = build_general_matrix<typename Matrix::Column_type>();
+  auto columns = build_general_matrix<typename Matrix::Column>();
   Matrix m(columns, 5);
 
   test_content_equality(columns, m);
@@ -1006,7 +1006,7 @@ void test_base_operation() {
 
 template <class Matrix>
 void test_base_col_comp_operation() {
-  auto columns = build_general_matrix<typename Matrix::Column_type>();
+  auto columns = build_general_matrix<typename Matrix::Column>();
   Matrix m(columns, 5);
 
   test_content_equality(columns, m);
@@ -1052,12 +1052,12 @@ void test_base_col_comp_operation() {
 
 template <class Matrix>
 void test_ru_operation() {
-  auto columns = build_simple_boundary_matrix<typename Matrix::Column_type>();
+  auto columns = build_simple_boundary_matrix<typename Matrix::Column>();
   Matrix m(columns, 5);
 
   columns[5].clear();
 
-  std::vector<witness_content<typename Matrix::Column_type> > uColumns(7);
+  std::vector<witness_content<typename Matrix::Column> > uColumns(7);
   if constexpr (Matrix::Option_list::is_z2) {
     if constexpr (Matrix::Option_list::has_vine_update) {
       uColumns[0] = {0};
@@ -1090,7 +1090,7 @@ void test_ru_operation() {
   unsigned int i = 0;
   if constexpr (is_indexed_by_position<Matrix>()) {
     for (auto& b : uColumns) {
-      test_column_equality<typename Matrix::Column_type>(b, get_column_content_via_iterators(m.get_column(i++, false)));
+      test_column_equality<typename Matrix::Column>(b, get_column_content_via_iterators(m.get_column(i++, false)));
     }
   }
 
@@ -1109,7 +1109,7 @@ void test_ru_operation() {
   if constexpr (is_indexed_by_position<Matrix>()) {
     i = 0;
     for (auto& b : uColumns) {
-      test_column_equality<typename Matrix::Column_type>(b, get_column_content_via_iterators(m.get_column(i++, false)));
+      test_column_equality<typename Matrix::Column>(b, get_column_content_via_iterators(m.get_column(i++, false)));
     }
   }
 
@@ -1128,7 +1128,7 @@ void test_ru_operation() {
   if constexpr (is_indexed_by_position<Matrix>()) {
     i = 0;
     for (auto& b : uColumns) {
-      test_column_equality<typename Matrix::Column_type>(b, get_column_content_via_iterators(m.get_column(i++, false)));
+      test_column_equality<typename Matrix::Column>(b, get_column_content_via_iterators(m.get_column(i++, false)));
     }
   }
 
@@ -1145,7 +1145,7 @@ void test_ru_operation() {
     if constexpr (is_indexed_by_position<Matrix>()) {
       i = 0;
       for (auto& b : uColumns) {
-        test_column_equality<typename Matrix::Column_type>(b,
+        test_column_equality<typename Matrix::Column>(b,
                                                            get_column_content_via_iterators(m.get_column(i++, false)));
       }
     }
@@ -1162,7 +1162,7 @@ void test_ru_operation() {
     if constexpr (is_indexed_by_position<Matrix>()) {
       i = 0;
       for (auto& b : uColumns) {
-        test_column_equality<typename Matrix::Column_type>(b,
+        test_column_equality<typename Matrix::Column>(b,
                                                            get_column_content_via_iterators(m.get_column(i++, false)));
       }
     }
@@ -1171,7 +1171,7 @@ void test_ru_operation() {
 
 template <class Matrix>
 void test_chain_operation(Matrix& m) {
-  auto columns = build_simple_chain_matrix<typename Matrix::Column_type>();
+  auto columns = build_simple_chain_matrix<typename Matrix::Column>();
 
   test_content_equality(columns, m);
 
@@ -1210,9 +1210,9 @@ void test_chain_operation(Matrix& m) {
 
 template <class Matrix>
 void test_base_cell_range_operation() {
-  using Cell = typename Matrix::Cell_type;
+  using Cell = typename Matrix::Matrix_cell;
 
-  auto columns = build_general_matrix<typename Matrix::Column_type>();
+  auto columns = build_general_matrix<typename Matrix::Column>();
   Matrix m(columns, 5);
 
   std::vector<Cell> range;
@@ -1252,9 +1252,9 @@ void test_base_cell_range_operation() {
 
 template <class Matrix>
 void test_base_col_comp_cell_range_operation() {
-  using Cell = typename Matrix::Cell_type;
+  using Cell = typename Matrix::Matrix_cell;
 
-  auto columns = build_general_matrix<typename Matrix::Column_type>();
+  auto columns = build_general_matrix<typename Matrix::Column>();
   Matrix m(columns, 5);
 
   std::vector<Cell> range;
@@ -1300,7 +1300,7 @@ void test_base_col_comp_cell_range_operation() {
 
 template <class Matrix>
 void test_const_operation() {
-  using C = typename Matrix::Column_type;
+  using C = typename Matrix::Column;
   typename Matrix::Column_settings settings(5);
 
   auto columns = build_general_matrix<C>();
@@ -1338,7 +1338,7 @@ void test_const_operation() {
 
 template <class Matrix>
 void test_base_col_comp_const_operation() {
-  using C = typename Matrix::Column_type;
+  using C = typename Matrix::Column;
   typename Matrix::Column_settings settings(5);
 
   auto columns = build_general_matrix<C>();
@@ -1389,7 +1389,7 @@ void test_barcode() {
     }
   };
 
-  auto columns = build_longer_boundary_matrix<typename Matrix::Column_type>();
+  auto columns = build_longer_boundary_matrix<typename Matrix::Column>();
   Matrix m(columns, 5);
 
   const auto& barcode = m.get_current_barcode();
@@ -1397,22 +1397,22 @@ void test_barcode() {
   if constexpr (Matrix::Option_list::is_of_boundary_type) {
     columns[5].clear();
   } else {
-    columns = build_longer_chain_matrix<typename Matrix::Column_type>();
+    columns = build_longer_chain_matrix<typename Matrix::Column>();
   }
   test_content_equality(columns, m);
 
   if constexpr (Matrix::Option_list::has_row_access) {
-    std::vector<witness_content<typename Matrix::Column_type> > rows;
+    std::vector<witness_content<typename Matrix::Column> > rows;
     if constexpr (Matrix::Option_list::is_of_boundary_type) {
-      rows = build_longer_reduced_row_matrix<typename Matrix::Column_type>();
+      rows = build_longer_reduced_row_matrix<typename Matrix::Column>();
     } else {
-      rows = build_longer_chain_row_matrix<typename Matrix::Column_type>();
+      rows = build_longer_chain_row_matrix<typename Matrix::Column>();
     }
     unsigned int i = 0;
     for (auto& r : rows) {
       if constexpr (Matrix::Option_list::has_removable_rows)
         if (i == 6) continue;
-      test_column_equality<typename Matrix::Column_type>(r, get_ordered_row(m, i++));
+      test_column_equality<typename Matrix::Column>(r, get_ordered_row(m, i++));
     }
   }
 
@@ -1457,7 +1457,7 @@ void test_barcode() {
 
 template <class Matrix>
 void test_shifted_barcode() {
-  using C = typename Matrix::Column_type;
+  using C = typename Matrix::Column;
   struct BarComp {
     bool operator()(const std::tuple<int, int, int>& c1, const std::tuple<int, int, int>& c2) const {
       if (std::get<0>(c1) == std::get<0>(c2)) return std::get<1>(c1) < std::get<1>(c2);
@@ -1591,7 +1591,7 @@ void test_shifted_barcode() {
 
 template <class Matrix>
 void test_base_swaps() {
-  auto columns = build_simple_boundary_matrix<typename Matrix::Column_type>();
+  auto columns = build_simple_boundary_matrix<typename Matrix::Column>();
   Matrix m(columns, 5);
 
   test_content_equality(columns, m);
@@ -1637,7 +1637,7 @@ void test_base_swaps() {
 // non-barcode
 template <class Matrix>
 void test_vine_swap_with_position_index(Matrix& m) {
-  std::vector<witness_content<typename Matrix::Column_type> > columns;
+  std::vector<witness_content<typename Matrix::Column> > columns;
   bool change;
 
   if constexpr (Matrix::Option_list::is_of_boundary_type) {
@@ -1650,7 +1650,7 @@ void test_vine_swap_with_position_index(Matrix& m) {
     BOOST_CHECK(m.is_zero_column(2));
     BOOST_CHECK(m.is_zero_column(5));
     BOOST_CHECK(m.is_zero_column(7));
-    columns = build_longer_boundary_matrix<typename Matrix::Column_type>();
+    columns = build_longer_boundary_matrix<typename Matrix::Column>();
     columns[5].clear();
   } else {
     BOOST_CHECK_EQUAL(m.get_column_with_pivot(0), 0);
@@ -1662,7 +1662,7 @@ void test_vine_swap_with_position_index(Matrix& m) {
     BOOST_CHECK_EQUAL(m.get_column_with_pivot(6), 6);
     BOOST_CHECK_EQUAL(m.get_column_with_pivot(7), 7);
     BOOST_CHECK_EQUAL(m.get_column_with_pivot(8), 8);
-    columns = build_longer_chain_matrix<typename Matrix::Column_type>();
+    columns = build_longer_chain_matrix<typename Matrix::Column>();
   }
   test_content_equality(columns, m);
 
@@ -1671,7 +1671,7 @@ void test_vine_swap_with_position_index(Matrix& m) {
     auto it = barcode.begin();
     BOOST_CHECK_EQUAL(it->dim, 0);
     BOOST_CHECK_EQUAL(it->birth, 0);
-    BOOST_CHECK_EQUAL(it->death, static_cast<typename Matrix::pos_index>(-1));
+    BOOST_CHECK_EQUAL(it->death, static_cast<typename Matrix::Pos_index>(-1));
     ++it;
     BOOST_CHECK_EQUAL(it->dim, 0);
     BOOST_CHECK_EQUAL(it->birth, 1);
@@ -1730,7 +1730,7 @@ void test_vine_swap_with_position_index(Matrix& m) {
     auto it = barcode.begin();
     BOOST_CHECK_EQUAL(it->dim, 0);
     BOOST_CHECK_EQUAL(it->birth, 0);
-    BOOST_CHECK_EQUAL(it->death, static_cast<typename Matrix::pos_index>(-1));
+    BOOST_CHECK_EQUAL(it->death, static_cast<typename Matrix::Pos_index>(-1));
     ++it;
     BOOST_CHECK_EQUAL(it->dim, 0);
     BOOST_CHECK_EQUAL(it->birth, 1);
@@ -1781,7 +1781,7 @@ void test_vine_swap_with_position_index(Matrix& m) {
     auto it = barcode.begin();
     BOOST_CHECK_EQUAL(it->dim, 0);
     BOOST_CHECK_EQUAL(it->birth, 0);
-    BOOST_CHECK_EQUAL(it->death, static_cast<typename Matrix::pos_index>(-1));
+    BOOST_CHECK_EQUAL(it->death, static_cast<typename Matrix::Pos_index>(-1));
     ++it;
     BOOST_CHECK_EQUAL(it->dim, 0);
     BOOST_CHECK_EQUAL(it->birth, 1);
@@ -1832,7 +1832,7 @@ void test_vine_swap_with_position_index(Matrix& m) {
     auto it = barcode.begin();
     BOOST_CHECK_EQUAL(it->dim, 0);
     BOOST_CHECK_EQUAL(it->birth, 0);
-    BOOST_CHECK_EQUAL(it->death, static_cast<typename Matrix::pos_index>(-1));
+    BOOST_CHECK_EQUAL(it->death, static_cast<typename Matrix::Pos_index>(-1));
     ++it;
     BOOST_CHECK_EQUAL(it->dim, 0);
     BOOST_CHECK_EQUAL(it->birth, 1);
@@ -1883,7 +1883,7 @@ void test_vine_swap_with_position_index(Matrix& m) {
     auto it = barcode.begin();
     BOOST_CHECK_EQUAL(it->dim, 0);
     BOOST_CHECK_EQUAL(it->birth, 0);
-    BOOST_CHECK_EQUAL(it->death, static_cast<typename Matrix::pos_index>(-1));
+    BOOST_CHECK_EQUAL(it->death, static_cast<typename Matrix::Pos_index>(-1));
     ++it;
     BOOST_CHECK_EQUAL(it->dim, 0);
     BOOST_CHECK_EQUAL(it->birth, 1);
@@ -1950,7 +1950,7 @@ void test_vine_swap_with_position_index(Matrix& m) {
     auto it = barcode.begin();
     BOOST_CHECK_EQUAL(it->dim, 0);
     BOOST_CHECK_EQUAL(it->birth, 0);
-    BOOST_CHECK_EQUAL(it->death, static_cast<typename Matrix::pos_index>(-1));
+    BOOST_CHECK_EQUAL(it->death, static_cast<typename Matrix::Pos_index>(-1));
     ++it;
     BOOST_CHECK_EQUAL(it->dim, 0);
     BOOST_CHECK_EQUAL(it->birth, 1);
@@ -1976,7 +1976,7 @@ void test_vine_swap_with_position_index(Matrix& m) {
 // non-barcode
 template <class Matrix>
 void test_vine_swap_with_id_index(Matrix& m) {
-  std::vector<witness_content<typename Matrix::Column_type> > columns;
+  std::vector<witness_content<typename Matrix::Column> > columns;
   unsigned int next;
 
   if constexpr (Matrix::Option_list::is_of_boundary_type) {
@@ -1989,7 +1989,7 @@ void test_vine_swap_with_id_index(Matrix& m) {
     BOOST_CHECK(m.is_zero_column(2));
     BOOST_CHECK(m.is_zero_column(5));
     BOOST_CHECK(m.is_zero_column(7));
-    columns = build_longer_boundary_matrix<typename Matrix::Column_type>();
+    columns = build_longer_boundary_matrix<typename Matrix::Column>();
     columns[5].clear();
   } else {
     BOOST_CHECK_EQUAL(m.get_column_with_pivot(0), 0);
@@ -2001,7 +2001,7 @@ void test_vine_swap_with_id_index(Matrix& m) {
     BOOST_CHECK_EQUAL(m.get_column_with_pivot(6), 6);
     BOOST_CHECK_EQUAL(m.get_column_with_pivot(7), 7);
     BOOST_CHECK_EQUAL(m.get_column_with_pivot(8), 8);
-    columns = build_longer_chain_matrix<typename Matrix::Column_type>();
+    columns = build_longer_chain_matrix<typename Matrix::Column>();
   }
   test_content_equality(columns, m);
 
@@ -2010,7 +2010,7 @@ void test_vine_swap_with_id_index(Matrix& m) {
     auto it = barcode.begin();
     BOOST_CHECK_EQUAL(it->dim, 0);
     BOOST_CHECK_EQUAL(it->birth, 0);
-    BOOST_CHECK_EQUAL(it->death, static_cast<typename Matrix::pos_index>(-1));
+    BOOST_CHECK_EQUAL(it->death, static_cast<typename Matrix::Pos_index>(-1));
     ++it;
     BOOST_CHECK_EQUAL(it->dim, 0);
     BOOST_CHECK_EQUAL(it->birth, 1);
@@ -2069,7 +2069,7 @@ void test_vine_swap_with_id_index(Matrix& m) {
     auto it = barcode.begin();
     BOOST_CHECK_EQUAL(it->dim, 0);
     BOOST_CHECK_EQUAL(it->birth, 0);
-    BOOST_CHECK_EQUAL(it->death, static_cast<typename Matrix::pos_index>(-1));
+    BOOST_CHECK_EQUAL(it->death, static_cast<typename Matrix::Pos_index>(-1));
     ++it;
     BOOST_CHECK_EQUAL(it->dim, 0);
     BOOST_CHECK_EQUAL(it->birth, 1);
@@ -2120,7 +2120,7 @@ void test_vine_swap_with_id_index(Matrix& m) {
     auto it = barcode.begin();
     BOOST_CHECK_EQUAL(it->dim, 0);
     BOOST_CHECK_EQUAL(it->birth, 0);
-    BOOST_CHECK_EQUAL(it->death, static_cast<typename Matrix::pos_index>(-1));
+    BOOST_CHECK_EQUAL(it->death, static_cast<typename Matrix::Pos_index>(-1));
     ++it;
     BOOST_CHECK_EQUAL(it->dim, 0);
     BOOST_CHECK_EQUAL(it->birth, 1);
@@ -2171,7 +2171,7 @@ void test_vine_swap_with_id_index(Matrix& m) {
     auto it = barcode.begin();
     BOOST_CHECK_EQUAL(it->dim, 0);
     BOOST_CHECK_EQUAL(it->birth, 0);
-    BOOST_CHECK_EQUAL(it->death, static_cast<typename Matrix::pos_index>(-1));
+    BOOST_CHECK_EQUAL(it->death, static_cast<typename Matrix::Pos_index>(-1));
     ++it;
     BOOST_CHECK_EQUAL(it->dim, 0);
     BOOST_CHECK_EQUAL(it->birth, 1);
@@ -2222,7 +2222,7 @@ void test_vine_swap_with_id_index(Matrix& m) {
     auto it = barcode.begin();
     BOOST_CHECK_EQUAL(it->dim, 0);
     BOOST_CHECK_EQUAL(it->birth, 0);
-    BOOST_CHECK_EQUAL(it->death, static_cast<typename Matrix::pos_index>(-1));
+    BOOST_CHECK_EQUAL(it->death, static_cast<typename Matrix::Pos_index>(-1));
     ++it;
     BOOST_CHECK_EQUAL(it->dim, 0);
     BOOST_CHECK_EQUAL(it->birth, 1);
@@ -2294,7 +2294,7 @@ void test_vine_swap_with_id_index(Matrix& m) {
     auto it = barcode.begin();
     BOOST_CHECK_EQUAL(it->dim, 0);
     BOOST_CHECK_EQUAL(it->birth, 0);
-    BOOST_CHECK_EQUAL(it->death, static_cast<typename Matrix::pos_index>(-1));
+    BOOST_CHECK_EQUAL(it->death, static_cast<typename Matrix::Pos_index>(-1));
     ++it;
     BOOST_CHECK_EQUAL(it->dim, 0);
     BOOST_CHECK_EQUAL(it->birth, 1);

--- a/src/Persistence_matrix/test/pm_matrix_tests_options.h
+++ b/src/Persistence_matrix/test/pm_matrix_tests_options.h
@@ -24,8 +24,8 @@ using Zp = Gudhi::persistence_fields::Zp_field_operators<>;
 template <bool is_z2_only, Column_types col_type, bool rem_col, bool swaps>
 struct Base_options {
   using Field_coeff_operators = Zp;
-  using index_type = unsigned int;
-  using dimension_type = int;  // needs to be signed.
+  using Index = unsigned int;
+  using Dimension = int;  // needs to be signed.
 
   static const bool is_z2 = is_z2_only;
   static const Column_types column_type = col_type;
@@ -51,8 +51,8 @@ struct Base_options {
 template <bool is_z2_only, Column_types col_type, bool rem_row, bool intr_row, bool rem_col, bool swaps>
 struct Base_options_with_row_access {
   using Field_coeff_operators = Zp;
-  using index_type = unsigned int;
-  using dimension_type = int;  // needs to be signed.
+  using Index = unsigned int;
+  using Dimension = int;  // needs to be signed.
 
   static const bool is_z2 = is_z2_only;
   static const Column_types column_type = col_type;
@@ -78,8 +78,8 @@ struct Base_options_with_row_access {
 template <bool is_z2_only, Column_types col_type>
 struct Column_compression_options {
   using Field_coeff_operators = Zp;
-  using index_type = unsigned int;
-  using dimension_type = int;  // needs to be signed.
+  using Index = unsigned int;
+  using Dimension = int;  // needs to be signed.
 
   static const bool is_z2 = is_z2_only;
   static const Column_types column_type = col_type;
@@ -104,8 +104,8 @@ struct Column_compression_options {
 template <bool is_z2_only, Column_types col_type, bool rem_row, bool intr_row>
 struct Column_compression_options_with_row_access {
   using Field_coeff_operators = Zp;
-  using index_type = unsigned int;
-  using dimension_type = int;  // needs to be signed.
+  using Index = unsigned int;
+  using Dimension = int;  // needs to be signed.
 
   static const bool is_z2 = is_z2_only;
   static const Column_types column_type = col_type;
@@ -130,8 +130,8 @@ struct Column_compression_options_with_row_access {
 template <bool is_z2_only, Column_types col_type, bool rem_col, bool swaps, bool pos_idx>
 struct Boundary_options {
   using Field_coeff_operators = Zp;
-  using index_type = unsigned int;
-  using dimension_type = int;  // needs to be signed.
+  using Index = unsigned int;
+  using Dimension = int;  // needs to be signed.
 
   static const bool is_z2 = is_z2_only;
   static const Column_types column_type = col_type;
@@ -158,8 +158,8 @@ struct Boundary_options {
 template <bool is_z2_only, Column_types col_type, bool rem_row, bool intr_row, bool rem_col, bool swaps, bool pos_idx>
 struct Boundary_options_with_row_access {
   using Field_coeff_operators = Zp;
-  using index_type = unsigned int;
-  using dimension_type = int;  // needs to be signed.
+  using Index = unsigned int;
+  using Dimension = int;  // needs to be signed.
 
   static const bool is_z2 = is_z2_only;
   static const Column_types column_type = col_type;
@@ -186,8 +186,8 @@ struct Boundary_options_with_row_access {
 template <Column_types col_type, bool rep, bool rem_col, bool pos_idx, bool dim, bool barcode>
 struct RU_vine_options {
   using Field_coeff_operators = Zp;
-  using index_type = unsigned int;
-  using dimension_type = int;  // needs to be signed.
+  using Index = unsigned int;
+  using Dimension = int;  // needs to be signed.
 
   static const bool is_z2 = true;
   static const Column_types column_type = col_type;
@@ -216,8 +216,8 @@ struct RU_vine_options {
 template <bool is_z2_only, Column_types col_type, bool rem_col, bool pos_idx, bool dim, bool barcode>
 struct RU_rep_options {
   using Field_coeff_operators = Zp;
-  using index_type = unsigned int;
-  using dimension_type = int;  // needs to be signed.
+  using Index = unsigned int;
+  using Dimension = int;  // needs to be signed.
 
   static const bool is_z2 = is_z2_only;
   static const Column_types column_type = col_type;
@@ -247,8 +247,8 @@ template <Column_types col_type,
           bool rep, bool rem_row, bool intr_row, bool rem_col, bool pos_idx, bool dim, bool barcode>
 struct RU_vine_options_with_row_access {
   using Field_coeff_operators = Zp;
-  using index_type = unsigned int;
-  using dimension_type = int;  // needs to be signed.
+  using Index = unsigned int;
+  using Dimension = int;  // needs to be signed.
 
   static const bool is_z2 = true;
   static const Column_types column_type = col_type;
@@ -278,8 +278,8 @@ template <bool is_z2_only, Column_types col_type,
           bool rem_row, bool intr_row, bool rem_col, bool pos_idx, bool dim, bool barcode>
 struct RU_rep_options_with_row_access {
   using Field_coeff_operators = Zp;
-  using index_type = unsigned int;
-  using dimension_type = int;  // needs to be signed.
+  using Index = unsigned int;
+  using Dimension = int;  // needs to be signed.
 
   static const bool is_z2 = is_z2_only;
   static const Column_types column_type = col_type;
@@ -308,8 +308,8 @@ struct RU_rep_options_with_row_access {
 template <bool is_z2_only, Column_types col_type, bool rem_col, bool pos_idx, bool dim>
 struct Chain_barcode_options {
   using Field_coeff_operators = Zp;
-  using index_type = unsigned int;
-  using dimension_type = int;  // needs to be signed.
+  using Index = unsigned int;
+  using Dimension = int;  // needs to be signed.
 
   static const bool is_z2 = is_z2_only;
   static const Column_types column_type = col_type;
@@ -339,8 +339,8 @@ struct Chain_barcode_options {
 template <Column_types col_type, bool rep, bool barcode, bool rem_col, bool pos_idx, bool dim>
 struct Chain_vine_options {
   using Field_coeff_operators = Zp;
-  using index_type = unsigned int;
-  using dimension_type = int;  // needs to be signed.
+  using Index = unsigned int;
+  using Dimension = int;  // needs to be signed.
 
   static const bool is_z2 = true;
   static const Column_types column_type = col_type;
@@ -369,8 +369,8 @@ struct Chain_vine_options {
 template <bool is_z2_only, Column_types col_type, bool barcode, bool rem_col, bool pos_idx, bool dim>
 struct Chain_rep_options {
   using Field_coeff_operators = Zp;
-  using index_type = unsigned int;
-  using dimension_type = int;  // needs to be signed.
+  using Index = unsigned int;
+  using Dimension = int;  // needs to be signed.
 
   static const bool is_z2 = is_z2_only;
   static const Column_types column_type = col_type;
@@ -399,8 +399,8 @@ struct Chain_rep_options {
 template <bool is_z2_only, Column_types col_type, bool rem_row, bool intr_row, bool rem_col, bool pos_idx, bool dim>
 struct Chain_barcode_options_with_row_access {
   using Field_coeff_operators = Zp;
-  using index_type = unsigned int;
-  using dimension_type = int;  // needs to be signed.
+  using Index = unsigned int;
+  using Dimension = int;  // needs to be signed.
 
   static const bool is_z2 = is_z2_only;
   static const Column_types column_type = col_type;
@@ -431,8 +431,8 @@ template <Column_types col_type,
           bool rep, bool barcode, bool rem_row, bool intr_row, bool rem_col, bool pos_idx, bool dim>
 struct Chain_vine_options_with_row_access {
   using Field_coeff_operators = Zp;
-  using index_type = unsigned int;
-  using dimension_type = int;  // needs to be signed.
+  using Index = unsigned int;
+  using Dimension = int;  // needs to be signed.
 
   static const bool is_z2 = true;
   static const Column_types column_type = col_type;
@@ -462,8 +462,8 @@ template <bool is_z2_only, Column_types col_type,
           bool barcode, bool rem_row, bool intr_row, bool rem_col, bool pos_idx, bool dim>
 struct Chain_rep_options_with_row_access {
   using Field_coeff_operators = Zp;
-  using index_type = unsigned int;
-  using dimension_type = int;  // needs to be signed.
+  using Index = unsigned int;
+  using Dimension = int;  // needs to be signed.
 
   static const bool is_z2 = is_z2_only;
   static const Column_types column_type = col_type;

--- a/src/Persistence_matrix/test/pm_test_utilities.h
+++ b/src/Persistence_matrix/test/pm_test_utilities.h
@@ -27,7 +27,7 @@ using Zp = Gudhi::persistence_fields::Zp_field_operators<>;
 
 template <class Column>
 constexpr bool is_z2() {
-  return std::is_same_v<typename Column::Field_element_type, bool>;
+  return std::is_same_v<typename Column::Field_element, bool>;
 }
 
 template <class Column>
@@ -59,15 +59,15 @@ constexpr bool is_indexed_by_position() {
 }
 
 template <class Column>
-using cell_rep_type = typename std::conditional<is_z2<Column>(), unsigned int,
-                                                std::pair<unsigned int, typename Column::Field_element_type> >::type;
+using Cell_representative = typename std::conditional<is_z2<Column>(), unsigned int,
+                                                std::pair<unsigned int, typename Column::Field_element> >::type;
 
 template <class Column>
-using column_content = std::set<cell_rep_type<Column> >;
+using column_content = std::set<Cell_representative<Column> >;
 template <class Column>
-using witness_content = std::vector<cell_rep_type<Column> >;
+using witness_content = std::vector<Cell_representative<Column> >;
 
-// for vector, assumes no cell was removed via clear(index)
+// for vector, assumes no cell was removed via clear(Index)
 template <class Column>
 column_content<Column> get_column_content_via_iterators(const Column& col) {
   column_content<Column> cells;
@@ -83,11 +83,11 @@ column_content<Column> get_column_content_via_iterators(const Column& col) {
   return cells;
 }
 
-// assumes no cell was removed via clear(index)
+// assumes no cell was removed via clear(Index)
 template <class Matrix>
 column_content<Heap_column<Matrix> > get_column_content_via_iterators(const Heap_column<Matrix>& col) {
   column_content<Heap_column<Matrix> > cells;
-  std::vector<typename Heap_column<Matrix>::Field_element_type> cont;
+  std::vector<typename Heap_column<Matrix>::Field_element> cont;
   Zp operators(5);
 
   for (const auto& c : col) {
@@ -110,13 +110,13 @@ column_content<Heap_column<Matrix> > get_column_content_via_iterators(const Heap
   return cells;
 }
 
-// for vector, assumes no cell was removed via clear(index)
+// for vector, assumes no cell was removed via clear(Index)
 // base and base comp cannot call get_row as const so m cannot be const...
 template <class Matrix>
-column_content<typename Matrix::Column_type> get_ordered_row(Matrix& m, unsigned int rowIndex) {
-  column_content<typename Matrix::Column_type> orderedRows;
+column_content<typename Matrix::Column> get_ordered_row(Matrix& m, unsigned int rowIndex) {
+  column_content<typename Matrix::Column> orderedRows;
   for (const auto& cell : m.get_row(rowIndex)) {
-    if constexpr (is_z2<typename Matrix::Column_type>()) {
+    if constexpr (is_z2<typename Matrix::Column>()) {
       orderedRows.insert(cell.get_column_index());
     } else {
       orderedRows.insert({cell.get_column_index(), cell.get_element()});
@@ -153,12 +153,12 @@ void test_matrix_equality(const std::vector<witness_content<Column> >& witness,
 
 // base and base comp cannot call get_column as const so m cannot be const...
 template <class Matrix>
-void test_content_equality(const std::vector<witness_content<typename Matrix::Column_type> >& witness, Matrix& m)
+void test_content_equality(const std::vector<witness_content<typename Matrix::Column> >& witness, Matrix& m)
 {
   unsigned int i = 0;
   for (auto& b : witness) {
     const auto& col = m.get_column(i++);  // to force the const version
-    test_column_equality<typename Matrix::Column_type>(b, get_column_content_via_iterators(col));
+    test_column_equality<typename Matrix::Column>(b, get_column_content_via_iterators(col));
   }
   BOOST_CHECK_EQUAL(m.get_number_of_columns(), i);
 }


### PR DESCRIPTION
All types are now starting with a capital letter, with no "_type" or other at the end, as discussed in #917:

              So, if I understood well, your preference would be: all types start with a capitalized letter and only the name of object without any "_type" or "_t" at the end? Eg. `dimension_type` ---> `Dimension`.

_Originally posted by @hschreiber in https://github.com/GUDHI/gudhi-devel/pull/917#discussion_r1686650628_

              Yes on the description of my preference, I think that's mostly what we've been doing so far in Gudhi (with obvious exceptions like value_type for compatibility with the standard library, or Thing_type where "type" is not in the C++ sense but means "kind", "category").

_Originally posted by @mglisse in https://github.com/GUDHI/gudhi-devel/pull/917#discussion_r1686753508_
            