### PR TITLE
Modify 'enum' to c++11 'enum class' for doxygen to be able to ref enumarations the way it has been done in doc

### DIFF
--- a/src/Persistence_matrix/include/gudhi/persistence_matrix_options.h
+++ b/src/Persistence_matrix/include/gudhi/persistence_matrix_options.h
@@ -27,7 +27,7 @@ namespace persistence_matrix {
  *
  * @brief List of column types.
  */
-enum Column_types { 
+enum class Column_types { 
   LIST,           /**< @ref List_column "": Underlying container is a std::list<@ref Cell*>. */
   SET,            /**< @ref Set_column "": Underlying container is a std::set<@ref Cell*>. */
   HEAP,           /**< @ref Heap_column "": Underlying container is a std::vector<@ref Cell*> ordered as a heap.
@@ -46,7 +46,7 @@ enum Column_types {
  * @brief List if indexation schemes. See @ref mp_indexation "description of indexation schemes" for more details
  * about the meaning of the indexation types.
  */
-enum Column_indexation_types { 
+enum class Column_indexation_types { 
   CONTAINER,  /**< Default use of @ref MatIdx indices. */
   POSITION,   /**< All input and output @ref MatIdx indices are replaced with @ref PosIdx indices. */
   IDENTIFIER  /**< All input and output @ref MatIdx indices are replaced with @ref IDIdx indices. */


### PR DESCRIPTION
After #1102 there were still some warnings for matrix module.
As I prefer the `enum class` c++11 feature and as it fixes these warnings, this is my fix proposal.
I did not test this fix with rips oscillating, zig zag or multi filtration branch, but I hope it does not use some of the former `enum` weak feature (increment, addition, ...)