### PR TITLE
Azure Windows CI 

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,85 +1,96 @@
 jobs:
-  
-  - job: 'OSx'
+  - job: "OSx"
     displayName: "Build and test OSx"
     timeoutInMinutes: 0
     cancelTimeoutInMinutes: 60
     pool:
       vmImage: macOS-latest
     variables:
-      pythonVersion: '3.9'
+      pythonVersion: "3.9"
       cmakeBuildType: Release
 
     steps:
-    # Use a specific Python version
-    - task: UsePythonVersion@0
-      displayName: Use Python $(pythonVersion)
-      inputs:
-        versionSpec: $(pythonVersion)
-        addToPath: true
-        architecture: 'x64'
+      # Use a specific Python version
+      - task: UsePythonVersion@0
+        displayName: Use Python $(pythonVersion)
+        inputs:
+          versionSpec: $(pythonVersion)
+          addToPath: true
+          architecture: "x64"
 
-    - bash: |
-        git submodule update --init
-        python -m pip install --user -r ext/gudhi-deploy/build-requirements.txt
-        python -m pip install --user -r ext/gudhi-deploy/test-requirements.txt
-        python -m pip uninstall -y pykeops
-        brew update || true
-        brew install ninja graphviz doxygen boost eigen gmp mpfr tbb cgal || true
-      displayName: 'Install build dependencies'
-    - bash: |
-        mkdir build
-        cd build
-        cmake -DCMAKE_BUILD_TYPE:STRING=$(cmakeBuildType) -GNinja -DWITH_GUDHI_EXAMPLE=ON -DWITH_GUDHI_TEST=ON -DWITH_GUDHI_UTILITIES=ON -DWITH_GUDHI_PYTHON=ON -DWITH_GUDHI_REMOTE_TEST=ON ..
-        ninja
-        ninja doxygen
-        ctest --output-on-failure
-      displayName: 'Build, test and documentation generation'
+      - bash: |
+          git submodule update --init
+          python -m pip install --user -r ext/gudhi-deploy/build-requirements.txt
+          python -m pip install --user -r ext/gudhi-deploy/test-requirements.txt
+          python -m pip uninstall -y pykeops
+          brew update || true
+          brew install ninja graphviz doxygen boost eigen gmp mpfr tbb cgal || true
+        displayName: "Install build dependencies"
+      - bash: |
+          mkdir build
+          cd build
+          cmake -DCMAKE_BUILD_TYPE:STRING=$(cmakeBuildType) -GNinja -DWITH_GUDHI_EXAMPLE=ON -DWITH_GUDHI_TEST=ON -DWITH_GUDHI_UTILITIES=ON -DWITH_GUDHI_PYTHON=ON -DWITH_GUDHI_REMOTE_TEST=ON ..
+          ninja
+          ninja doxygen
+          ctest --output-on-failure
+        displayName: "Build, test and documentation generation"
 
-  - job: 'Windows'
+  - job: "Windows"
     displayName: "Build and test Windows"
     timeoutInMinutes: 0
     cancelTimeoutInMinutes: 60
     pool:
       vmImage: windows-latest
     variables:
-      pythonVersion: '3.9'
+      pythonVersion: "3.9"
       cmakeVcpkgFlags: -DVCPKG_TARGET_TRIPLET=x64-windows -DCMAKE_TOOLCHAIN_FILE=c:\vcpkg\scripts\buildsystems\vcpkg.cmake
       cmakeFlags: -DWITH_GUDHI_EXAMPLE=ON -DWITH_GUDHI_TEST=ON -DWITH_GUDHI_UTILITIES=ON -DWITH_GUDHI_PYTHON=OFF
-    continueOnError: false
 
     steps:
-    # Use a specific Python version
-    - task: UsePythonVersion@0
-      displayName: Use Python $(pythonVersion)
-      inputs:
-        versionSpec: $(pythonVersion)
-        addToPath: true
-        architecture: 'x64'
+      # Use a specific Python version
+      - task: UsePythonVersion@0
+        displayName: Use Python $(pythonVersion)
+        inputs:
+          versionSpec: $(pythonVersion)
+          addToPath: true
+          architecture: "x64"
 
-    - script: |
-        git submodule update --init
-        python -m pip install --user -r ext/gudhi-deploy/build-requirements.txt
-        python -m pip install --user -r ext/gudhi-deploy/test-requirements.txt
-        # Only vcpkg release libs for CI
-        echo.set(VCPKG_BUILD_TYPE release)>> C:\vcpkg\triplets\x64-windows.cmake
-        vcpkg install boost-filesystem:x64-windows boost-test:x64-windows boost-program-options:x64-windows tbb:x64-windows eigen3:x64-windows cgal:x64-windows
-        choco install -y ninja --force --force-dependencies
-      displayName: 'Install build dependencies'
-    - script: |
-        call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" amd64
-        mkdir build
-        cd build
-        cmake -DCMAKE_BUILD_TYPE=Release -G "Ninja" -DFORCE_EIGEN_DEFAULT_DENSE_INDEX_TYPE_TO_INT=ON $(cmakeVcpkgFlags) $(cmakeFlags) ..
-        ninja
-        ctest --output-on-failure -C Release -E diff_files
-        cmake  -DWITH_GUDHI_PYTHON=ON -DWITH_GUDHI_REMOTE_TEST=ON .
-        cd src\python
-        copy "C:\vcpkg\installed\x64-windows\bin\mpfr*.dll" ".\gudhi\"
-        copy "C:\vcpkg\installed\x64-windows\bin\gmp*.dll" ".\gudhi\"
-        copy "C:\vcpkg\installed\x64-windows\bin\tbb*.dll" ".\gudhi\"
-        python setup.py build_ext --inplace
-        SET PYTHONPATH=%CD%;%PYTHONPATH%
-        echo %PYTHONPATH%
-        ctest --output-on-failure -C Release
-      displayName: 'Build and test'
+      - script: |
+          git submodule update --init
+          python -m pip install --user -r ext/gudhi-deploy/build-requirements.txt
+          IF %ERRORLEVEL% NEQ 0 EXIT 1
+          python -m pip install --user -r ext/gudhi-deploy/test-requirements.txt
+          IF %ERRORLEVEL% NEQ 0 EXIT 1
+          # Only vcpkg release libs for CI
+          echo.set(VCPKG_BUILD_TYPE release)>> C:\vcpkg\triplets\x64-windows.cmake
+          vcpkg install boost-filesystem:x64-windows boost-test:x64-windows boost-program-options:x64-windows tbb:x64-windows eigen3:x64-windows cgal:x64-windows
+          IF %ERRORLEVEL% NEQ 0 EXIT 1
+          choco install -y ninja --force --force-dependencies
+          IF %ERRORLEVEL% NEQ 0 EXIT 1
+        displayName: "Install build dependencies"
+      - script: |
+          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" amd64
+          mkdir build
+          cd build
+          cmake -DCMAKE_BUILD_TYPE=Release -G "Ninja" -DFORCE_EIGEN_DEFAULT_DENSE_INDEX_TYPE_TO_INT=ON $(cmakeVcpkgFlags) $(cmakeFlags) ..
+          IF %ERRORLEVEL% NEQ 0 EXIT 1
+          ninja
+          IF %ERRORLEVEL% NEQ 0 EXIT 1
+          ctest --output-on-failure -C Release -E diff_files
+          IF %ERRORLEVEL% NEQ 0 EXIT 1
+          cmake  -DWITH_GUDHI_PYTHON=ON -DWITH_GUDHI_REMOTE_TEST=ON .
+          IF %ERRORLEVEL% NEQ 0 EXIT 1
+          cd src\python
+          copy "C:\vcpkg\installed\x64-windows\bin\mpfr*.dll" ".\gudhi\"
+          IF %ERRORLEVEL% NEQ 0 EXIT 1
+          copy "C:\vcpkg\installed\x64-windows\bin\gmp*.dll" ".\gudhi\"
+          IF %ERRORLEVEL% NEQ 0 EXIT 1
+          copy "C:\vcpkg\installed\x64-windows\bin\tbb*.dll" ".\gudhi\"
+          IF %ERRORLEVEL% NEQ 0 EXIT 1
+          python setup.py build_ext --inplace
+          IF %ERRORLEVEL% NEQ 0 EXIT 1
+          SET PYTHONPATH=%CD%;%PYTHONPATH%
+          echo %PYTHONPATH%
+          ctest --output-on-failure -C Release
+          IF %ERRORLEVEL% NEQ 0 EXIT 1
+        displayName: "Build and test"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -46,6 +46,7 @@ jobs:
       pythonVersion: '3.9'
       cmakeVcpkgFlags: -DVCPKG_TARGET_TRIPLET=x64-windows -DCMAKE_TOOLCHAIN_FILE=c:\vcpkg\scripts\buildsystems\vcpkg.cmake
       cmakeFlags: -DWITH_GUDHI_EXAMPLE=ON -DWITH_GUDHI_TEST=ON -DWITH_GUDHI_UTILITIES=ON -DWITH_GUDHI_PYTHON=OFF
+    continueOnError: false
 
     steps:
     # Use a specific Python version
@@ -66,7 +67,6 @@ jobs:
         choco install -y ninja --force --force-dependencies
       displayName: 'Install build dependencies'
     - script: |
-        $ErrorActionPreference = 'Stop'
         call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" amd64
         mkdir build
         cd build


### PR DESCRIPTION
Powershell (`- powershell:` instead of `- script:`) is said to do the job, but launching `vcvarsall.bat` to set all the environment variables required by MSVC2022 seems to be complicated. I may try again this other solution