### PR TITLE
[Persistence matrix] Better additions in U for RU matrices in Z2

### DIFF
--- a/src/Persistence_matrix/concept/PersistenceMatrixColumn.h
+++ b/src/Persistence_matrix/concept/PersistenceMatrixColumn.h
@@ -427,6 +427,15 @@ class PersistenceMatrixColumn :
   PersistenceMatrixColumn& multiply_source_and_add(const Entry_range& column, const Field_element& val);
 
   /**
+   * @brief Adds a copy of the given entry at the end of the column. It is therefore assumed that the row index
+   * of the entry is higher than the current pivot of the column. Not available for @ref chainmatrix "chain matrices"
+   * and is only needed for @ref rumatrix "RU matrices".
+   * 
+   * @param entry Entry to push back.
+   */
+  void push_back(const Entry& entry);
+
+  /**
    * @brief Equality comparator. Equal in the sense that what is "supposed" to be contained in the columns is equal,
    * not what is actually stored in the underlying container. For example, the underlying container of 
    * @ref Vector_column can contain entries which were erased explicitly by @ref clear(Index). Those entries should not

--- a/src/Persistence_matrix/include/gudhi/Persistence_matrix/Base_matrix.h
+++ b/src/Persistence_matrix/include/gudhi/Persistence_matrix/Base_matrix.h
@@ -615,7 +615,7 @@ inline void Base_matrix<Master_matrix>::print()
   if constexpr (Master_matrix::Option_list::has_row_access) {
     std::cout << "Row Matrix:\n";
     for (Index i = 0; i < nextInsertIndex_; ++i) {
-      const auto& row = RA_opt::rows_[i];
+      const auto& row = (*RA_opt::rows_)[i];
       for (const auto& entry : row) {
         std::cout << entry.get_column_index() << " ";
       }

--- a/src/Persistence_matrix/include/gudhi/Persistence_matrix/Boundary_matrix.h
+++ b/src/Persistence_matrix/include/gudhi/Persistence_matrix/Boundary_matrix.h
@@ -729,8 +729,8 @@ inline void Boundary_matrix<Master_matrix>::print()
   if constexpr (Master_matrix::Option_list::has_row_access) {
     std::cout << "Row Matrix:\n";
     for (ID_index i = 0; i < nextInsertIndex_; ++i) {
-      const auto& row = RA_opt::rows_[i];
-      for (const auto& entry : row) {
+      const auto& row = (*RA_opt::rows_)[i];
+      for (const typename Column::Entry& entry : row) {
         std::cout << entry.get_column_index() << " ";
       }
       std::cout << "(" << i << ")\n";

--- a/src/Persistence_matrix/include/gudhi/Persistence_matrix/RU_matrix.h
+++ b/src/Persistence_matrix/include/gudhi/Persistence_matrix/RU_matrix.h
@@ -538,7 +538,7 @@ inline void RU_matrix<Master_matrix>::insert_boundary(ID_index cellIndex,
   if constexpr (Master_matrix::Option_list::has_vine_update) {
     if (cellIndex != nextEventIndex_) {
       Swap_opt::_positionToRowIdx().emplace(nextEventIndex_, cellIndex);
-      if (Master_matrix::Option_list::has_column_pairings) {
+      if constexpr (Master_matrix::Option_list::has_column_pairings) {
         Swap_opt::template RU_pairing<Master_matrix>::idToPosition_.emplace(cellIndex, nextEventIndex_);
       }
     }

--- a/src/Persistence_matrix/include/gudhi/Persistence_matrix/columns/heap_column.h
+++ b/src/Persistence_matrix/include/gudhi/Persistence_matrix/columns/heap_column.h
@@ -134,6 +134,8 @@ class Heap_column : public Master_matrix::Column_dimension_option, public Master
   Heap_column& multiply_source_and_add(const Entry_range& column, const Field_element& val);
   Heap_column& multiply_source_and_add(Heap_column& column, const Field_element& val);
 
+  void push_back(const Entry& entry);
+
   std::size_t compute_hash_value();
 
   friend bool operator==(const Heap_column& c1, const Heap_column& c2) {
@@ -866,6 +868,19 @@ inline Heap_column<Master_matrix>& Heap_column<Master_matrix>::multiply_source_a
   }
 
   return *this;
+}
+
+template <class Master_matrix>
+inline void Heap_column<Master_matrix>::push_back(const Entry& entry)
+{
+  static_assert(Master_matrix::Option_list::is_of_boundary_type, "`push_back` is not available for Chain matrices.");
+
+  Entry* newEntry = entryPool_->construct(entry.get_row_index());
+  if constexpr (!Master_matrix::Option_list::is_z2) {
+    newEntry->set_element(operators_->get_value(entry.get_element()));
+  }
+  column_.push_back(newEntry);
+  std::push_heap(column_.begin(), column_.end(), entryPointerComp_);
 }
 
 template <class Master_matrix>

--- a/src/Persistence_matrix/include/gudhi/Persistence_matrix/columns/intrusive_list_column.h
+++ b/src/Persistence_matrix/include/gudhi/Persistence_matrix/columns/intrusive_list_column.h
@@ -132,6 +132,8 @@ class Intrusive_list_column : public Master_matrix::Row_access_option,
   Intrusive_list_column& multiply_source_and_add(const Entry_range& column, const Field_element& val);
   Intrusive_list_column& multiply_source_and_add(Intrusive_list_column& column, const Field_element& val);
 
+  void push_back(const Entry& entry);
+
   friend bool operator==(const Intrusive_list_column& c1, const Intrusive_list_column& c2) {
     if (&c1 == &c2) return true;
 
@@ -819,6 +821,18 @@ inline Intrusive_list_column<Master_matrix>& Intrusive_list_column<Master_matrix
   }
 
   return *this;
+}
+
+template <class Master_matrix>
+inline void Intrusive_list_column<Master_matrix>::push_back(const Entry& entry)
+{
+  static_assert(Master_matrix::Option_list::is_of_boundary_type, "`push_back` is not available for Chain matrices.");
+
+  if constexpr (Master_matrix::Option_list::is_z2) {
+    _insert_entry(entry.get_row_index(), column_.end());
+  } else {
+    _insert_entry(entry.get_element(), entry.get_row_index(), column_.end());
+  }
 }
 
 template <class Master_matrix>

--- a/src/Persistence_matrix/include/gudhi/Persistence_matrix/columns/intrusive_set_column.h
+++ b/src/Persistence_matrix/include/gudhi/Persistence_matrix/columns/intrusive_set_column.h
@@ -133,6 +133,8 @@ class Intrusive_set_column : public Master_matrix::Row_access_option,
   Intrusive_set_column& multiply_source_and_add(const Entry_range& column, const Field_element& val);
   Intrusive_set_column& multiply_source_and_add(Intrusive_set_column& column, const Field_element& val);
 
+  void push_back(const Entry& entry);
+
   friend bool operator==(const Intrusive_set_column& c1, const Intrusive_set_column& c2) {
     if (&c1 == &c2) return true;
 
@@ -819,6 +821,18 @@ inline Intrusive_set_column<Master_matrix>& Intrusive_set_column<Master_matrix>:
   }
 
   return *this;
+}
+
+template <class Master_matrix>
+inline void Intrusive_set_column<Master_matrix>::push_back(const Entry& entry)
+{
+  static_assert(Master_matrix::Option_list::is_of_boundary_type, "`push_back` is not available for Chain matrices.");
+
+  if constexpr (Master_matrix::Option_list::is_z2) {
+    _insert_entry(entry.get_row_index(), column_.end());
+  } else {
+    _insert_entry(entry.get_element(), entry.get_row_index(), column_.end());
+  }
 }
 
 template <class Master_matrix>

--- a/src/Persistence_matrix/include/gudhi/Persistence_matrix/columns/list_column.h
+++ b/src/Persistence_matrix/include/gudhi/Persistence_matrix/columns/list_column.h
@@ -131,6 +131,8 @@ class List_column : public Master_matrix::Row_access_option,
   List_column& multiply_source_and_add(const Entry_range& column, const Field_element& val);
   List_column& multiply_source_and_add(List_column& column, const Field_element& val);
 
+  void push_back(const Entry& entry);
+
   friend bool operator==(const List_column& c1, const List_column& c2) {
     if (&c1 == &c2) return true;
 
@@ -803,6 +805,18 @@ inline List_column<Master_matrix>& List_column<Master_matrix>::multiply_source_a
   }
 
   return *this;
+}
+
+template <class Master_matrix>
+inline void List_column<Master_matrix>::push_back(const Entry& entry)
+{
+  static_assert(Master_matrix::Option_list::is_of_boundary_type, "`push_back` is not available for Chain matrices.");
+
+  if constexpr (Master_matrix::Option_list::is_z2) {
+    _insert_entry(entry.get_row_index(), column_.end());
+  } else {
+    _insert_entry(entry.get_element(), entry.get_row_index(), column_.end());
+  }
 }
 
 template <class Master_matrix>

--- a/src/Persistence_matrix/include/gudhi/Persistence_matrix/columns/naive_vector_column.h
+++ b/src/Persistence_matrix/include/gudhi/Persistence_matrix/columns/naive_vector_column.h
@@ -131,6 +131,8 @@ class Naive_vector_column : public Master_matrix::Row_access_option,
   Naive_vector_column& multiply_source_and_add(const Entry_range& column, const Field_element& val);
   Naive_vector_column& multiply_source_and_add(Naive_vector_column& column, const Field_element& val);
 
+  void push_back(const Entry& entry);
+
   friend bool operator==(const Naive_vector_column& c1, const Naive_vector_column& c2) {
     if (&c1 == &c2) return true;
     if (c1.column_.size() != c2.column_.size()) return false;
@@ -799,6 +801,18 @@ inline Naive_vector_column<Master_matrix>& Naive_vector_column<Master_matrix>::m
   }
 
   return *this;
+}
+
+template <class Master_matrix>
+inline void Naive_vector_column<Master_matrix>::push_back(const Entry& entry)
+{
+  static_assert(Master_matrix::Option_list::is_of_boundary_type, "`push_back` is not available for Chain matrices.");
+
+  if constexpr (Master_matrix::Option_list::is_z2) {
+    _insert_entry(entry.get_row_index(), column_);
+  } else {
+    _insert_entry(entry.get_element(), entry.get_row_index(), column_);
+  }
 }
 
 template <class Master_matrix>

--- a/src/Persistence_matrix/include/gudhi/Persistence_matrix/columns/set_column.h
+++ b/src/Persistence_matrix/include/gudhi/Persistence_matrix/columns/set_column.h
@@ -136,6 +136,8 @@ class Set_column : public Master_matrix::Row_access_option,
   Set_column& multiply_source_and_add(const Entry_range& column, const Field_element& val);
   Set_column& multiply_source_and_add(Set_column& column, const Field_element& val);
 
+  void push_back(const Entry& entry);
+
   friend bool operator==(const Set_column& c1, const Set_column& c2) {
     if (&c1 == &c2) return true;
 
@@ -795,6 +797,18 @@ inline Set_column<Master_matrix>& Set_column<Master_matrix>::multiply_source_and
   }
 
   return *this;
+}
+
+template <class Master_matrix>
+inline void Set_column<Master_matrix>::push_back(const Entry& entry)
+{
+  static_assert(Master_matrix::Option_list::is_of_boundary_type, "`push_back` is not available for Chain matrices.");
+
+  if constexpr (Master_matrix::Option_list::is_z2) {
+    _insert_entry(entry.get_row_index(), column_.end());
+  } else {
+    _insert_entry(entry.get_element(), entry.get_row_index(), column_.end());
+  }
 }
 
 template <class Master_matrix>

--- a/src/Persistence_matrix/include/gudhi/Persistence_matrix/columns/unordered_set_column.h
+++ b/src/Persistence_matrix/include/gudhi/Persistence_matrix/columns/unordered_set_column.h
@@ -152,6 +152,8 @@ class Unordered_set_column : public Master_matrix::Row_access_option,
   Unordered_set_column& multiply_source_and_add(const Entry_range& column, const Field_element& val);
   Unordered_set_column& multiply_source_and_add(Unordered_set_column& column, const Field_element& val);
 
+  void push_back(const Entry& entry);
+
   friend bool operator==(const Unordered_set_column& c1, const Unordered_set_column& c2) {
     if (&c1 == &c2) return true;
     if (c1.column_.size() != c2.column_.size()) return false;
@@ -798,6 +800,18 @@ inline Unordered_set_column<Master_matrix>& Unordered_set_column<Master_matrix>:
   }
 
   return *this;
+}
+
+template <class Master_matrix>
+inline void Unordered_set_column<Master_matrix>::push_back(const Entry& entry)
+{
+  static_assert(Master_matrix::Option_list::is_of_boundary_type, "`push_back` is not available for Chain matrices.");
+
+  if constexpr (Master_matrix::Option_list::is_z2) {
+    _insert_entry(entry.get_row_index());
+  } else {
+    _insert_entry(entry.get_element(), entry.get_row_index());
+  }
 }
 
 template <class Master_matrix>

--- a/src/Persistence_matrix/include/gudhi/Persistence_matrix/columns/vector_column.h
+++ b/src/Persistence_matrix/include/gudhi/Persistence_matrix/columns/vector_column.h
@@ -134,6 +134,8 @@ class Vector_column : public Master_matrix::Row_access_option,
   Vector_column& multiply_source_and_add(const Entry_range& column, const Field_element& val);
   Vector_column& multiply_source_and_add(Vector_column& column, const Field_element& val);
 
+  void push_back(const Entry& entry);
+
   std::size_t compute_hash_value();
 
   friend bool operator==(const Vector_column& c1, const Vector_column& c2) {
@@ -901,6 +903,18 @@ inline Vector_column<Master_matrix>& Vector_column<Master_matrix>::multiply_sour
   }
 
   return *this;
+}
+
+template <class Master_matrix>
+inline void Vector_column<Master_matrix>::push_back(const Entry& entry)
+{
+  static_assert(Master_matrix::Option_list::is_of_boundary_type, "`push_back` is not available for Chain matrices.");
+
+  if constexpr (Master_matrix::Option_list::is_z2) {
+    _insert_entry(entry.get_row_index(), column_);
+  } else {
+    _insert_entry(entry.get_element(), entry.get_row_index(), column_);
+  }
 }
 
 template <class Master_matrix>

--- a/src/Persistence_matrix/include/gudhi/Persistence_matrix/ru_rep_cycles.h
+++ b/src/Persistence_matrix/include/gudhi/Persistence_matrix/ru_rep_cycles.h
@@ -135,7 +135,7 @@ inline RU_representative_cycles<Master_matrix>::RU_representative_cycles(
 template <class Master_matrix>
 inline void RU_representative_cycles<Master_matrix>::update_representative_cycles() 
 {
-  if constexpr (Master_matrix::Option_list::has_vine_update) {
+  if constexpr (Master_matrix::Option_list::is_z2) {
     birthToCycle_.clear();
     birthToCycle_.resize(_matrix()->reducedMatrixR_.get_number_of_columns(), -1);
     Index c = 0;

--- a/src/Persistence_matrix/test/pm_matrix_tests.h
+++ b/src/Persistence_matrix/test/pm_matrix_tests.h
@@ -635,23 +635,13 @@ void test_ru_u_access() {
 
   std::vector<witness_content<typename Matrix::Column> > uColumns(7);
   if constexpr (Matrix::Option_list::is_z2) {
-    if constexpr (Matrix::Option_list::has_vine_update) {
-      uColumns[0] = {0};
-      uColumns[1] = {1};
-      uColumns[2] = {2};
-      uColumns[3] = {3, 5};
-      uColumns[4] = {4, 5};
-      uColumns[5] = {5};
-      uColumns[6] = {6};
-    } else {
-      uColumns[0] = {0};
-      uColumns[1] = {1};
-      uColumns[2] = {2};
-      uColumns[3] = {3};
-      uColumns[4] = {4};
-      uColumns[5] = {3, 4, 5};
-      uColumns[6] = {6};
-    }
+    uColumns[0] = {0};
+    uColumns[1] = {1};
+    uColumns[2] = {2};
+    uColumns[3] = {3, 5};
+    uColumns[4] = {4, 5};
+    uColumns[5] = {5};
+    uColumns[6] = {6};
   } else {
     uColumns[0] = {{0, 1}};
     uColumns[1] = {{1, 1}};
@@ -668,7 +658,7 @@ void test_ru_u_access() {
     test_column_equality<typename Matrix::Column>(c, get_column_content_via_iterators(col));
   }
 
-  if constexpr (Matrix::Option_list::has_vine_update) {
+  if constexpr (Matrix::Option_list::is_z2) {
     BOOST_CHECK(!m.is_zero_entry(3, 5, false));
     BOOST_CHECK(!m.is_zero_column(4, false));
     m.zero_entry(3, 5, false);
@@ -775,23 +765,13 @@ void test_ru_u_row_access() {
 
   std::vector<witness_content<typename Matrix::Column> > rows;
   if constexpr (Matrix::Option_list::is_z2) {
-    if constexpr (Matrix::Option_list::has_vine_update) {
-      rows.push_back({0});
-      rows.push_back({1});
-      rows.push_back({2});
-      rows.push_back({3});
-      rows.push_back({4});
-      rows.push_back({3, 4, 5});
-      rows.push_back({6});
-    } else {
-      rows.push_back({0});
-      rows.push_back({1});
-      rows.push_back({2});
-      rows.push_back({3, 5});
-      rows.push_back({4, 5});
-      rows.push_back({5});
-      rows.push_back({6});
-    }
+    rows.push_back({0});
+    rows.push_back({1});
+    rows.push_back({2});
+    rows.push_back({3});
+    rows.push_back({4});
+    rows.push_back({3, 4, 5});
+    rows.push_back({6});
   } else {
     rows.push_back({{0, 1}});
     rows.push_back({{1, 1}});
@@ -1059,23 +1039,13 @@ void test_ru_operation() {
 
   std::vector<witness_content<typename Matrix::Column> > uColumns(7);
   if constexpr (Matrix::Option_list::is_z2) {
-    if constexpr (Matrix::Option_list::has_vine_update) {
-      uColumns[0] = {0};
-      uColumns[1] = {1};
-      uColumns[2] = {2};
-      uColumns[3] = {3, 5};
-      uColumns[4] = {4, 5};
-      uColumns[5] = {5};
-      uColumns[6] = {6};
-    } else {
-      uColumns[0] = {0};
-      uColumns[1] = {1};
-      uColumns[2] = {2};
-      uColumns[3] = {3};
-      uColumns[4] = {4};
-      uColumns[5] = {3, 4, 5};
-      uColumns[6] = {6};
-    }
+    uColumns[0] = {0};
+    uColumns[1] = {1};
+    uColumns[2] = {2};
+    uColumns[3] = {3, 5};
+    uColumns[4] = {4, 5};
+    uColumns[5] = {5};
+    uColumns[6] = {6};
   } else {
     uColumns[0] = {{0, 1}};
     uColumns[1] = {{1, 1}};
@@ -1097,10 +1067,7 @@ void test_ru_operation() {
   m.add_to(3, 5);
   if constexpr (Matrix::Option_list::is_z2) {
     columns[5] = {0, 1};
-    if constexpr (Matrix::Option_list::has_vine_update)
-      uColumns[3] = {3};
-    else
-      uColumns[5] = {4, 5};
+    uColumns[3] = {3};
   } else {
     columns[5] = {{0, 1}, {1, 4}};
     uColumns[5] = {{4, 4}, {5, 1}};
@@ -1116,10 +1083,7 @@ void test_ru_operation() {
   m.add_to(4, 5);
   if constexpr (Matrix::Option_list::is_z2) {
     columns[5] = {0, 2};
-    if constexpr (Matrix::Option_list::has_vine_update)
-      uColumns[4] = {4};
-    else
-      uColumns[5] = {5};
+    uColumns[4] = {4};
   } else {
     columns[5] = {{0, 1}, {2, 4}};
     uColumns[5] = {{5, 1}};
@@ -1132,11 +1096,11 @@ void test_ru_operation() {
     }
   }
 
-  if constexpr (!Matrix::Option_list::has_vine_update) {
+  if constexpr (!Matrix::Option_list::is_z2 || !is_RU<Matrix>()) {
     m.multiply_target_and_add_to(5, 3, 3);
     if constexpr (Matrix::Option_list::is_z2) {
       columns[3] = {1, 2};
-      uColumns[3] = {3, 5};
+      uColumns[5] = {3, 5};
     } else {
       columns[3] = {{0, 4}, {1, 2}, {2, 4}};
       uColumns[3] = {{3, 3}, {5, 1}};


### PR DESCRIPTION
Small optimization for the reduction of U in the RU decomposition. It does not make a big difference for small complexes, but divides by two the reduction time for big complexes.
The difference is mostly at line 851 of `RU_matrix.h`.