### PR TITLE
[Persistence Matrix] Addition of small vectors as a column type

### DIFF
--- a/src/Persistence_matrix/include/gudhi/Matrix.h
+++ b/src/Persistence_matrix/include/gudhi/Matrix.h
@@ -313,8 +313,8 @@ class Matrix {
   using Matrix_heap_column = Heap_column<Matrix<PersistenceMatrixOptions> >;
   using Matrix_list_column = List_column<Matrix<PersistenceMatrixOptions> >;
   using Matrix_vector_column = Vector_column<Matrix<PersistenceMatrixOptions> >;
-  using Matrix_naive_vector_column = STD_naive_vector_column<Matrix<PersistenceMatrixOptions> >;
-  using Matrix_small_vector_column = Small_naive_vector_column<Matrix<PersistenceMatrixOptions> >;
+  using Matrix_naive_vector_column = Naive_std_vector_column<Matrix<PersistenceMatrixOptions> >;
+  using Matrix_small_vector_column = Naive_small_vector_column<Matrix<PersistenceMatrixOptions> >;
   using Matrix_set_column = Set_column<Matrix<PersistenceMatrixOptions> >;
   using Matrix_unordered_set_column = Unordered_set_column<Matrix<PersistenceMatrixOptions> >;
   using Matrix_intrusive_list_column = Intrusive_list_column<Matrix<PersistenceMatrixOptions> >;

--- a/src/Persistence_matrix/include/gudhi/Matrix.h
+++ b/src/Persistence_matrix/include/gudhi/Matrix.h
@@ -313,7 +313,8 @@ class Matrix {
   using Matrix_heap_column = Heap_column<Matrix<PersistenceMatrixOptions> >;
   using Matrix_list_column = List_column<Matrix<PersistenceMatrixOptions> >;
   using Matrix_vector_column = Vector_column<Matrix<PersistenceMatrixOptions> >;
-  using Matrix_naive_vector_column = Naive_vector_column<Matrix<PersistenceMatrixOptions> >;
+  using Matrix_naive_vector_column = STD_naive_vector_column<Matrix<PersistenceMatrixOptions> >;
+  using Matrix_small_vector_column = Small_naive_vector_column<Matrix<PersistenceMatrixOptions> >;
   using Matrix_set_column = Set_column<Matrix<PersistenceMatrixOptions> >;
   using Matrix_unordered_set_column = Unordered_set_column<Matrix<PersistenceMatrixOptions> >;
   using Matrix_intrusive_list_column = Intrusive_list_column<Matrix<PersistenceMatrixOptions> >;
@@ -345,7 +346,11 @@ class Matrix {
                             typename std::conditional<
                                 PersistenceMatrixOptions::column_type == Column_types::NAIVE_VECTOR,
                                 Matrix_naive_vector_column, 
-                                Matrix_intrusive_set_column
+                                typename std::conditional<
+                                    PersistenceMatrixOptions::column_type == Column_types::SMALL_VECTOR,
+                                    Matrix_small_vector_column, 
+                                    Matrix_intrusive_set_column
+                                    >::type
                                 >::type
                             >::type
                         >::type

--- a/src/Persistence_matrix/include/gudhi/Persistence_matrix/columns/heap_column.h
+++ b/src/Persistence_matrix/include/gudhi/Persistence_matrix/columns/heap_column.h
@@ -45,7 +45,6 @@ namespace persistence_matrix {
  * row index. Additionally, the given entry range added into the heap does not need to be somehow ordered.
  *
  * @tparam Master_matrix An instantiation of @ref Matrix from which all types and options are deduced.
- * @tparam Entry_constructor Factory of @ref Entry classes.
  */
 template <class Master_matrix>
 class Heap_column : public Master_matrix::Column_dimension_option, public Master_matrix::Chain_column_option

--- a/src/Persistence_matrix/include/gudhi/Persistence_matrix/columns/intrusive_list_column.h
+++ b/src/Persistence_matrix/include/gudhi/Persistence_matrix/columns/intrusive_list_column.h
@@ -41,7 +41,6 @@ namespace persistence_matrix {
  * are stored uniquely in the underlying container.
  *
  * @tparam Master_matrix An instantiation of @ref Matrix from which all types and options are deduced.
- * @tparam Entry_constructor Factory of @ref Entry classes.
  */
 template <class Master_matrix>
 class Intrusive_list_column : public Master_matrix::Row_access_option,

--- a/src/Persistence_matrix/include/gudhi/Persistence_matrix/columns/intrusive_set_column.h
+++ b/src/Persistence_matrix/include/gudhi/Persistence_matrix/columns/intrusive_set_column.h
@@ -42,7 +42,6 @@ namespace persistence_matrix {
  * are stored uniquely in the underlying container.
  *
  * @tparam Master_matrix An instantiation of @ref Matrix from which all types and options are deduced.
- * @tparam Entry_constructor Factory of @ref Entry classes.
  */
 template <class Master_matrix>
 class Intrusive_set_column : public Master_matrix::Row_access_option,

--- a/src/Persistence_matrix/include/gudhi/Persistence_matrix/columns/list_column.h
+++ b/src/Persistence_matrix/include/gudhi/Persistence_matrix/columns/list_column.h
@@ -42,7 +42,6 @@ namespace persistence_matrix {
  * are stored uniquely in the underlying container.
  *
  * @tparam Master_matrix An instantiation of @ref Matrix from which all types and options are deduced.
- * @tparam Entry_constructor Factory of @ref Entry classes.
  */
 template <class Master_matrix>
 class List_column : public Master_matrix::Row_access_option,

--- a/src/Persistence_matrix/include/gudhi/Persistence_matrix/columns/naive_vector_column.h
+++ b/src/Persistence_matrix/include/gudhi/Persistence_matrix/columns/naive_vector_column.h
@@ -224,9 +224,9 @@ class Naive_vector_column : public Master_matrix::Row_access_option,
 };
 
 template <class Master_matrix>
-using STD_naive_vector_column = Naive_vector_column<Master_matrix, std::vector<typename Master_matrix::Matrix_entry*> >;
+using Naive_std_vector_column = Naive_vector_column<Master_matrix, std::vector<typename Master_matrix::Matrix_entry*> >;
 template <class Master_matrix>
-using Small_naive_vector_column =
+using Naive_small_vector_column =
     Naive_vector_column<Master_matrix, boost::container::small_vector<typename Master_matrix::Matrix_entry*, 8> >;
 
 template <class Master_matrix, class Support>

--- a/src/Persistence_matrix/include/gudhi/Persistence_matrix/columns/naive_vector_column.h
+++ b/src/Persistence_matrix/include/gudhi/Persistence_matrix/columns/naive_vector_column.h
@@ -42,7 +42,6 @@ namespace persistence_matrix {
  * are stored uniquely in the underlying container.
  *
  * @tparam Master_matrix An instantiation of @ref Matrix from which all types and options are deduced.
- * @tparam Entry_constructor Factory of @ref Entry classes.
  */
 template <class Master_matrix>
 class Naive_vector_column : public Master_matrix::Row_access_option,

--- a/src/Persistence_matrix/include/gudhi/Persistence_matrix/columns/set_column.h
+++ b/src/Persistence_matrix/include/gudhi/Persistence_matrix/columns/set_column.h
@@ -42,7 +42,6 @@ namespace persistence_matrix {
  * are stored uniquely in the underlying container.
  *
  * @tparam Master_matrix An instantiation of @ref Matrix from which all types and options are deduced.
- * @tparam Entry_constructor Factory of @ref Entry classes.
  */
 template <class Master_matrix>
 class Set_column : public Master_matrix::Row_access_option,

--- a/src/Persistence_matrix/include/gudhi/Persistence_matrix/columns/unordered_set_column.h
+++ b/src/Persistence_matrix/include/gudhi/Persistence_matrix/columns/unordered_set_column.h
@@ -60,7 +60,6 @@ struct EntryPointerEq
  * also does not need to be ordered (contrary to most other column types).
  *
  * @tparam Master_matrix An instantiation of @ref Matrix from which all types and options are deduced.
- * @tparam Entry_constructor Factory of @ref Entry classes.
  */
 template <class Master_matrix>
 class Unordered_set_column : public Master_matrix::Row_access_option,

--- a/src/Persistence_matrix/include/gudhi/Persistence_matrix/columns/vector_column.h
+++ b/src/Persistence_matrix/include/gudhi/Persistence_matrix/columns/vector_column.h
@@ -44,7 +44,6 @@ namespace persistence_matrix {
  * On the other hand, two entries will never have the same row index.
  *
  * @tparam Master_matrix An instantiation of @ref Matrix from which all types and options are deduced.
- * @tparam Entry_constructor Factory of @ref Entry classes.
  */
 template <class Master_matrix>
 class Vector_column : public Master_matrix::Row_access_option,

--- a/src/Persistence_matrix/include/gudhi/persistence_matrix_options.h
+++ b/src/Persistence_matrix/include/gudhi/persistence_matrix_options.h
@@ -35,6 +35,8 @@ enum class Column_types {
   VECTOR,         /**< @ref Vector_column "": Underlying container is a std::vector<@ref Entry*>
                        with a lazy removal method. */
   NAIVE_VECTOR,   /**< @ref Naive_vector_column "": Underlying container is a std::vector<@ref Entry*>. */
+  SMALL_VECTOR,   /**< @ref Naive_vector_column "": Underlying container is a
+                       boost::container::small_vector<@ref Entry*, 8>. */
   UNORDERED_SET,  /**< @ref Unordered_set_column "": Underlying container is a std::unordered_set<@ref Entry*>. */
   INTRUSIVE_LIST, /**< @ref Intrusive_list_column "": Underlying container is a boost::intrusive::list<@ref Entry>. */
   INTRUSIVE_SET   /**< @ref Intrusive_set_column "": Underlying container is a boost::intrusive::set<@ref Entry>. */

--- a/src/Persistence_matrix/test/pm_column_tests_boost_type_lists.h
+++ b/src/Persistence_matrix/test/pm_column_tests_boost_type_lists.h
@@ -30,7 +30,8 @@ using Gudhi::persistence_matrix::Heap_column;
 using Gudhi::persistence_matrix::Intrusive_list_column;
 using Gudhi::persistence_matrix::Intrusive_set_column;
 using Gudhi::persistence_matrix::List_column;
-using Gudhi::persistence_matrix::Naive_vector_column;
+using Gudhi::persistence_matrix::STD_naive_vector_column;
+using Gudhi::persistence_matrix::Small_naive_vector_column;
 using Gudhi::persistence_matrix::Set_column;
 using Gudhi::persistence_matrix::Unordered_set_column;
 using Gudhi::persistence_matrix::Vector_column;
@@ -65,7 +66,9 @@ class column_non_validity {
     } else if constexpr (col_type::Master::Option_list::column_type == Column_types::UNORDERED_SET) {
       return !std::is_same_v<col_type, Unordered_set_column<typename col_type::Master> >;
     } else if constexpr (col_type::Master::Option_list::column_type == Column_types::NAIVE_VECTOR) {
-      return !std::is_same_v<col_type, Naive_vector_column<typename col_type::Master> >;
+      return !std::is_same_v<col_type, STD_naive_vector_column<typename col_type::Master> >;
+    } else if constexpr (col_type::Master::Option_list::column_type == Column_types::SMALL_VECTOR) {
+      return !std::is_same_v<col_type, Small_naive_vector_column<typename col_type::Master> >;
     } else if constexpr (col_type::Master::Option_list::column_type == Column_types::VECTOR) {
       return !std::is_same_v<col_type, Vector_column<typename col_type::Master> >;
     } else if constexpr (col_type::Master::Option_list::column_type == Column_types::HEAP) {
@@ -81,12 +84,13 @@ class column_non_validity {
 
 // if a new column type is implemented, create a `ct_*` structure for it and add it to this list...
 using col_type_list = boost::mp11::mp_list<ct_intrusive_list, ct_intrusive_set, ct_list, ct_set, ct_heap,
-                                           ct_unordered_set, ct_vector, ct_naive_vector>;
+                                           ct_unordered_set, ct_vector, ct_naive_vector, ct_small_vector>;
 using row_col_type_list = boost::mp11::mp_list<ct_intrusive_list, ct_intrusive_set, ct_list, ct_set, ct_unordered_set,
-                                               ct_vector, ct_naive_vector>;
+                                               ct_vector, ct_naive_vector, ct_small_vector>;
 //...and add the column name here.
-using column_list = mp_list_q<Intrusive_list_column, Intrusive_set_column, List_column, Set_column,
-                              Unordered_set_column, Naive_vector_column, Vector_column, Heap_column>;
+using column_list =
+    mp_list_q<Intrusive_list_column, Intrusive_set_column, List_column, Set_column, Unordered_set_column,
+              STD_naive_vector_column, Small_naive_vector_column, Vector_column, Heap_column>;
 using c_matrix_type_list = mp_list_q<Column_mini_matrix>;
 
 template <typename option_name_list, typename bool_is_z2, typename col_t, typename bool_has_row, typename bool_rem_row,

--- a/src/Persistence_matrix/test/pm_column_tests_boost_type_lists.h
+++ b/src/Persistence_matrix/test/pm_column_tests_boost_type_lists.h
@@ -30,8 +30,8 @@ using Gudhi::persistence_matrix::Heap_column;
 using Gudhi::persistence_matrix::Intrusive_list_column;
 using Gudhi::persistence_matrix::Intrusive_set_column;
 using Gudhi::persistence_matrix::List_column;
-using Gudhi::persistence_matrix::STD_naive_vector_column;
-using Gudhi::persistence_matrix::Small_naive_vector_column;
+using Gudhi::persistence_matrix::Naive_std_vector_column;
+using Gudhi::persistence_matrix::Naive_small_vector_column;
 using Gudhi::persistence_matrix::Set_column;
 using Gudhi::persistence_matrix::Unordered_set_column;
 using Gudhi::persistence_matrix::Vector_column;
@@ -66,9 +66,9 @@ class column_non_validity {
     } else if constexpr (col_type::Master::Option_list::column_type == Column_types::UNORDERED_SET) {
       return !std::is_same_v<col_type, Unordered_set_column<typename col_type::Master> >;
     } else if constexpr (col_type::Master::Option_list::column_type == Column_types::NAIVE_VECTOR) {
-      return !std::is_same_v<col_type, STD_naive_vector_column<typename col_type::Master> >;
+      return !std::is_same_v<col_type, Naive_std_vector_column<typename col_type::Master> >;
     } else if constexpr (col_type::Master::Option_list::column_type == Column_types::SMALL_VECTOR) {
-      return !std::is_same_v<col_type, Small_naive_vector_column<typename col_type::Master> >;
+      return !std::is_same_v<col_type, Naive_small_vector_column<typename col_type::Master> >;
     } else if constexpr (col_type::Master::Option_list::column_type == Column_types::VECTOR) {
       return !std::is_same_v<col_type, Vector_column<typename col_type::Master> >;
     } else if constexpr (col_type::Master::Option_list::column_type == Column_types::HEAP) {
@@ -90,7 +90,7 @@ using row_col_type_list = boost::mp11::mp_list<ct_intrusive_list, ct_intrusive_s
 //...and add the column name here.
 using column_list =
     mp_list_q<Intrusive_list_column, Intrusive_set_column, List_column, Set_column, Unordered_set_column,
-              STD_naive_vector_column, Small_naive_vector_column, Vector_column, Heap_column>;
+              Naive_std_vector_column, Naive_small_vector_column, Vector_column, Heap_column>;
 using c_matrix_type_list = mp_list_q<Column_mini_matrix>;
 
 template <typename option_name_list, typename bool_is_z2, typename col_t, typename bool_has_row, typename bool_rem_row,

--- a/src/Persistence_matrix/test/pm_common_boost_type_lists.h
+++ b/src/Persistence_matrix/test/pm_common_boost_type_lists.h
@@ -49,6 +49,10 @@ struct ct_naive_vector {
   static constexpr const Column_types t = Column_types::NAIVE_VECTOR;
 };
 
+struct ct_small_vector {
+  static constexpr const Column_types t = Column_types::SMALL_VECTOR;
+};
+
 struct true_value {
   static constexpr const bool t = true;
 };

--- a/src/Persistence_matrix/test/pm_matrix_tests_boost_type_lists.h
+++ b/src/Persistence_matrix/test/pm_matrix_tests_boost_type_lists.h
@@ -138,7 +138,7 @@ class matrix_non_validity {
 // users. But in case real changes were made to this module, it would be better to test at least once with all column
 // types as below:
 // using col_type_list = boost::mp11::mp_list<ct_intrusive_list, ct_intrusive_set, ct_list, ct_set, ct_heap,
-//                                            ct_unordered_set, ct_vector, ct_naive_vector>;
+//                                            ct_unordered_set, ct_vector, ct_naive_vector, ct_small_vector>;
 #ifdef PM_TEST_INTR_LIST
 using col_type_list = boost::mp11::mp_list<ct_intrusive_list>;
 #else
@@ -162,7 +162,11 @@ using col_type_list = boost::mp11::mp_list<ct_unordered_set>;
 #ifdef PM_TEST_NAIVE_VECTOR
 using col_type_list = boost::mp11::mp_list<ct_naive_vector>;
 #else
+#ifdef PM_TEST_SMALL_VECTOR
+using col_type_list = boost::mp11::mp_list<ct_small_vector>;
+#else
 using col_type_list = boost::mp11::mp_list<ct_vector>;
+#endif
 #endif
 #endif
 #endif


### PR DESCRIPTION
Replacing `std::vector` with `boost::container::small_vector` in `Naive_vector_column` showed some run time improvements on some particular use cases in [multipers](https://github.com/DavidLapous/multipers). So I added the possibility in the column choices.