### PR TITLE
fix doxygen groups

### DIFF
--- a/src/Coxeter_triangulation/include/gudhi/Coxeter_triangulation/Cell_complex/Hasse_diagram_cell.h
+++ b/src/Coxeter_triangulation/include/gudhi/Coxeter_triangulation/Cell_complex/Hasse_diagram_cell.h
@@ -28,11 +28,9 @@ class Hasse_diagram;
  * \class Hasse_diagram_cell
  * \brief Data structure to store a cell in a Hasse diagram.
  *
- * \ingroup Hasse_diagram
- *
  * \details
  * The use and interfaces of this Hasse diagram cell is limited to the \ref coxeter_triangulation implementation.
- * 
+ *
  * This is a data structure to store a cell in a general Hasse diagram data structure. 	It stores the following
  * information about the cell: References to boundary and coBoundary elements, dimension of a cell and its filtration.
  * It also allow to store any additional information of a type Additional_information which is a template parameter of

--- a/src/Persistence_representations/include/gudhi/Sliced_Wasserstein.h
+++ b/src/Persistence_representations/include/gudhi/Sliced_Wasserstein.h
@@ -57,8 +57,10 @@ namespace Persistence_representations {
  * The first method is usually much more accurate but also
  * much slower. For more details, please see \cite pmlr-v70-carriere17a .
  *
+ * This class implements the following concepts: Topological_data_with_distances, Real_valued_topological_data,
+ * Topological_data_with_scalar_product
+ *
  **/
-
 class Sliced_Wasserstein {
  protected:
   Persistence_diagram diagram;
@@ -331,8 +333,6 @@ class Sliced_Wasserstein {
 
  public:
   /** \brief Sliced Wasserstein kernel constructor.
-   * \implements Topological_data_with_distances, Real_valued_topological_data, Topological_data_with_scalar_product
-   * \ingroup Sliced_Wasserstein
    *
    * @param[in] _diagram  persistence diagram.
    * @param[in] _sigma    bandwidth parameter.
@@ -347,7 +347,6 @@ class Sliced_Wasserstein {
   }
 
   /** \brief Evaluation of the kernel on a pair of diagrams.
-   * \ingroup Sliced_Wasserstein
    *
    * @pre       approx and sigma attributes need to be the same for both instances.
    * @param[in] second other instance of class Sliced_Wasserstein.
@@ -360,7 +359,6 @@ class Sliced_Wasserstein {
   }
 
   /** \brief Evaluation of the distance between images of diagrams in the Hilbert space of the kernel.
-   * \ingroup Sliced_Wasserstein
    *
    * @pre       approx and sigma attributes need to be the same for both instances.
    * @param[in] second  other instance of class Sliced_Wasserstein.


### PR DESCRIPTION
Fix #1184 

I tried to fix the `\implements` but I didn't find the way to do it correctly.
It works fine for [Field_Zp](https://gudhi.inria.fr/doc/latest/class_gudhi_1_1persistent__cohomology_1_1_field___zp.html) that `\implements CoefficientField`, but here it was not working for Persistence representation.