### PR TITLE
Simple_mdspan

### DIFF
--- a/src/common/include/gudhi/simple_mdspan.h
+++ b/src/common/include/gudhi/simple_mdspan.h
@@ -1,0 +1,277 @@
+/*    This file is part of the Gudhi Library - https://gudhi.inria.fr/ - which is released under MIT.
+ *    See file LICENSE or go to https://gudhi.inria.fr/licensing/ for full license details.
+ *    Author(s):       Hannah Schreiber, David Loiseaux
+ *
+ *    Copyright (C) 2025 Inria
+ *
+ *    Modification(s):
+ *      - YYYY/MM Author: Description of the modification
+ */
+
+/**
+ * @private
+ * @file simple_mdspan.h
+ * @author Hannah Schreiber, David Loiseaux
+ */
+
+#ifndef GUDHI_SIMPLE_MDSPAN_H_
+#define GUDHI_SIMPLE_MDSPAN_H_
+
+#include <cstddef>      // std::size_t
+#include <type_traits>  // std::remove_cv_t
+#include <limits>
+#include <initializer_list>
+#include <vector>
+
+#include <gudhi/Debug_utils.h>
+
+namespace Gudhi {
+
+/**
+ * @private
+ * @brief Reproduces the behaviour of C++23 `std::layout_right` class.
+ */
+class layout_right
+{
+ public:
+  class mapping
+  {
+   public:
+    using index_type = std::size_t;
+    using extents_type = std::vector<index_type>;
+    using size_type = typename extents_type::size_type;
+    using rank_type = std::size_t;
+    using layout_type = layout_right;
+
+    // constructors
+    mapping() noexcept = default;
+    mapping(const mapping&) noexcept = default;
+
+    mapping(const extents_type& exts) noexcept : exts_(exts)
+    {
+      if (!exts_.empty()) _initialize_strides();
+    }
+
+    mapping& operator=(const mapping&) noexcept = default;
+
+    // observers
+    constexpr const extents_type& extents() const noexcept { return exts_; }
+
+    index_type required_span_size() const noexcept
+    {
+      if (exts_.empty()) return 0;
+      return ext_shifts_[0] * exts_[0];
+    }
+
+    template <class... Indices>
+    constexpr index_type operator()(Indices... indices) const
+    {
+      return operator()({static_cast<index_type>(indices)...});
+    }
+
+    template <class IndexRange = std::initializer_list<index_type> >
+    constexpr index_type operator()(const IndexRange& indices) const
+    {
+      GUDHI_CHECK(indices.size() == exts_.size(), "Wrong number of parameters.");
+
+      index_type newIndex = 0;
+      auto it = indices.begin();
+      GUDHI_CHECK_code(unsigned int i = 0);
+      for (auto stride : ext_shifts_) {
+        GUDHI_CHECK_code(GUDHI_CHECK(*it < exts_[i], "Out of bound index."));
+        newIndex += (stride * (*it));
+        ++it;
+        GUDHI_CHECK_code(++i);
+      }
+
+      return newIndex;
+    }
+
+    static constexpr bool is_always_unique() noexcept { return true; }
+
+    static constexpr bool is_always_exhaustive() noexcept { return true; }
+
+    static constexpr bool is_always_strided() noexcept { return true; }
+
+    static constexpr bool is_unique() noexcept { return true; }
+
+    static constexpr bool is_exhaustive() noexcept { return true; }
+
+    static constexpr bool is_strided() noexcept { return true; }
+
+    index_type stride(rank_type r) const
+    {
+      GUDHI_CHECK(r < ext_shifts_.size(), "Stride out of bound.");
+      return ext_shifts_[r];
+    }
+
+    friend bool operator==(const mapping& m1, const mapping& m2) noexcept { return m1.exts_ == m2.exts_; }
+
+    friend void swap(mapping& m1, mapping& m2) noexcept
+    {
+      m1.exts_.swap(m2.exts_);
+      m1.ext_shifts_.swap(m2.ext_shifts_);
+    }
+
+    // as not everything is computed at compile time as for mdspan, update is usually faster than reconstructing
+    // everytime.
+    void update_extent(rank_type r, index_type new_value)
+    {
+      GUDHI_CHECK(r < exts_.size(), "Index out of bound.");
+      exts_[r] = new_value;
+      _update_strides(r);
+    }
+
+   private:
+    extents_type exts_;
+    extents_type ext_shifts_;
+
+    void _initialize_strides()
+    {
+      ext_shifts_.resize(exts_.size());
+      ext_shifts_.back() = 1;
+      for (auto i = exts_.size() - 1; i > 0; --i) {
+        ext_shifts_[i - 1] = ext_shifts_[i] * exts_[i];
+      }
+    }
+
+    void _update_strides(rank_type start)
+    {
+      for (auto i = start; i > 0; --i) {
+        ext_shifts_[i - 1] = ext_shifts_[i] * exts_[i];
+      }
+    }
+  };
+};
+
+/**
+ * @private
+ * @brief Simplified version of C++23 `std::mdspan` class that compiles with C++17.
+ *
+ * Main differences:
+ * - extends are all dynamic,
+ * - there is no Extend class, everything is managed by the mapper class instead,
+ * - there is no AccessorPolicy template: the container pointed by the stored pointer is assumed to be vector-like,
+ * i.e., continuous and, e.g., you can do `ptr_ + 2` to access the third element,
+ * - `object[i,j,k,...]` is replaced by either `object(i,j,k,...)` or `object[{i,j,k,...}]`, as C++17 does not
+ * allow more than one argument for `operator[]`,
+ * - two additional methods: `update_extent` and `update_data` to avoid recalculating the helpers in the mapping class
+ * at each size modification of the underlying container. In the original `std::mdspan` most of the work is done
+ * at compile time, so it is usually fine to reconstruct a view everytime needed. That is not the case here.
+ */
+template <typename T, class LayoutPolicy = layout_right>
+class Simple_mdspan
+{
+ public:
+  using layout_type = LayoutPolicy;
+  using mapping_type = typename LayoutPolicy::mapping;
+  using extents_type = typename mapping_type::extents_type;
+  using element_type = T;
+  using value_type = std::remove_cv_t<T>;
+  using index_type = typename mapping_type::index_type;
+  using size_type = typename mapping_type::size_type;
+  using rank_type = typename mapping_type::rank_type;
+  using data_handle_type = T*;
+  using reference = T&;
+
+  Simple_mdspan() : ptr_(nullptr) {}
+
+  Simple_mdspan(const Simple_mdspan& rhs) = default;
+  Simple_mdspan(Simple_mdspan&& rhs) = default;
+
+  template <class... IndexTypes>
+  explicit Simple_mdspan(data_handle_type ptr, IndexTypes... exts)
+      : Simple_mdspan(ptr, {static_cast<index_type>(exts)...})
+  {}
+
+  template <class IndexRange = std::initializer_list<index_type> >
+  Simple_mdspan(data_handle_type ptr, const IndexRange& exts) : ptr_(ptr), map_(extents_type(exts.begin(), exts.end()))
+  {
+    GUDHI_CHECK(ptr != nullptr || empty() || *(exts.begin()) == 0, "Given pointer is not properly initialized.");
+  }
+
+  Simple_mdspan(data_handle_type ptr, const mapping_type& m) : ptr_(ptr), map_(m) {}
+
+  Simple_mdspan& operator=(const Simple_mdspan& rhs) = default;
+  Simple_mdspan& operator=(Simple_mdspan&& rhs) = default;
+
+  // version with [] not possible before C++23
+  template <class... IndexTypes>
+  constexpr reference operator()(IndexTypes... indices) const
+  {
+    return operator[]({static_cast<index_type>(indices)...});
+  }
+
+  template <class IndexRange = std::initializer_list<index_type> >
+  reference operator[](const IndexRange& indices) const
+  {
+    return *(ptr_ + map_(indices));
+  }
+
+  constexpr rank_type rank() noexcept { return map_.extents().size(); }
+
+  constexpr rank_type rank_dynamic() noexcept { return map_.extents().size(); }
+
+  static constexpr std::size_t static_extent(rank_type r) noexcept { return std::numeric_limits<std::size_t>::max(); }
+
+  constexpr index_type extent(rank_type r) const
+  {
+    GUDHI_CHECK(r < map_.extents().size(), "Out of bound index.");
+    return map_.extents()[r];
+  }
+
+  constexpr size_type size() const noexcept { return map_.required_span_size(); }
+
+  constexpr bool empty() const noexcept { return map_.required_span_size() == 0; }
+
+  constexpr index_type stride(rank_type r) const { return map_.stride(r); }
+
+  constexpr const extents_type& extents() const noexcept { return map_.extents(); }
+
+  constexpr const data_handle_type& data_handle() const noexcept { return ptr_; }
+
+  constexpr const mapping_type& mapping() const noexcept { return map_; }
+
+  // if is_unique() is true for all possible instantiations of this class
+  static constexpr bool is_always_unique() { return mapping_type::is_always_unique(); }
+
+  // if is_exhaustive() is true for all possible instantiations of this class
+  static constexpr bool is_always_exhaustive() { return mapping_type::is_always_exhaustive(); }
+
+  // if is_strided() is true for all possible instantiations of this class
+  static constexpr bool is_always_strided() { return mapping_type::is_always_strided(); }
+
+  // unicity of the mapping (i,j,k,...) -> real index
+  constexpr bool is_unique() const { return map_.is_unique(); }
+
+  // if all real indices have a preimage in form (i,j,k,...)
+  constexpr bool is_exhaustive() const { return map_.is_exhaustive(); }
+
+  // if distance in memory is constant between two values in same rank
+  constexpr bool is_strided() const { return map_.is_strided(); }
+
+  friend constexpr void swap(Simple_mdspan& x, Simple_mdspan& y) noexcept
+  {
+    std::swap(x.ptr_, y.ptr_);
+    swap(x.map_, y.map_);
+  }
+
+  // as not everything is computed at compile time as for mdspan, update is usually faster than reconstructing
+  // everytime.
+  void update_extent(rank_type r, index_type new_value) { map_.update_extent(r, new_value); }
+
+  // for update_extent to make sense, as resizing the vector can move it in the memory
+  void update_data(data_handle_type ptr)
+  {
+    GUDHI_CHECK(ptr != nullptr, "Null pointer not valid input.");
+    ptr_ = ptr;
+  }
+
+ private:
+  data_handle_type ptr_;
+  mapping_type map_;
+};
+
+}  // namespace Gudhi
+
+#endif  // GUDHI_SIMPLE_MDSPAN_H_

--- a/src/common/include/gudhi/simple_mdspan.h
+++ b/src/common/include/gudhi/simple_mdspan.h
@@ -18,14 +18,196 @@
 #define GUDHI_SIMPLE_MDSPAN_H_
 
 #include <cstddef>      // std::size_t
-#include <type_traits>  // std::remove_cv_t
+#include <stdexcept>
+#include <type_traits>  // std::remove_cv_t, std::make_unsigned_t, std::integral_constant
 #include <limits>
 #include <initializer_list>
-#include <vector>
+#include <utility>
+#include <array>
 
 #include <gudhi/Debug_utils.h>
 
 namespace Gudhi {
+
+inline constexpr std::size_t dynamic_extent = std::numeric_limits<std::size_t>::max();
+
+template <class IndexType, std::size_t... Extents>
+class extents;
+
+namespace detail {
+
+  template <std::size_t v>
+  struct is_dynamic : std::integral_constant<std::size_t, 0> {};
+
+  template <>
+  struct is_dynamic<dynamic_extent> : std::integral_constant<std::size_t, 1> {};
+
+  template <std::size_t I, class T>
+  struct dynamic_count;
+
+  template <std::size_t I, std::size_t first, std::size_t... Tail>
+  struct dynamic_count<I, std::integer_sequence<std::size_t, first, Tail...> >
+      : std::integral_constant<std::size_t,
+                              (is_dynamic<first>::value +
+                                dynamic_count<I - 1, std::integer_sequence<std::size_t, Tail...>>::value)> {
+  };
+
+  template <std::size_t first, std::size_t... Tail>
+  struct dynamic_count<0, std::integer_sequence<std::size_t, first, Tail...> >
+      : std::integral_constant<std::size_t, is_dynamic<first>::value> {
+  };
+
+  template <std::size_t first>
+  struct dynamic_count<0, std::integer_sequence<std::size_t, first> >
+      : std::integral_constant<std::size_t, is_dynamic<first>::value> {};
+
+  template <std::size_t I, class T>
+  struct extent_value;
+
+  template <std::size_t I, std::size_t first, std::size_t... Tail>
+  struct extent_value<I, std::integer_sequence<std::size_t, first, Tail...>>
+      : extent_value<I - 1, std::integer_sequence<std::size_t, Tail...>> {};
+
+  template <std::size_t first, std::size_t... Tail>
+  struct extent_value<0, std::integer_sequence<std::size_t, first, Tail...>>
+      : std::integral_constant<std::size_t, first> {};
+
+  template <class T, T I, T N, T... integers>
+  struct dynamic_value_sequence {
+    using type = typename dynamic_value_sequence<T, I + 1, N, integers..., dynamic_extent>::type;
+  };
+
+  template <class T, T N, T... integers>
+  struct dynamic_value_sequence<T, N, N, integers...> {
+    using type = std::integer_sequence<T, integers...>;
+  };
+
+  template <class IndexType, std::size_t... Pack>
+  constexpr auto dynamic_value_extents(std::integer_sequence<std::size_t, Pack...>)
+  {
+    return extents<IndexType, Pack...>();
+  };
+
+  template <class IndexType, std::size_t Rank>
+  constexpr auto dynamic_value_extents_value =
+      dynamic_value_extents<IndexType>((typename Gudhi::detail::dynamic_value_sequence<std::size_t, 0, Rank>::type{}));
+
+}  // namespace detail
+
+template <class IndexType, std::size_t Rank>
+using dextents = decltype(detail::dynamic_value_extents_value<IndexType, Rank>);
+
+/**
+ * @private
+ * @brief Reproduces the behaviour of C++23 `std::extents` class.
+ */
+template <class IndexType, std::size_t... Extents>
+class extents
+{
+ public:
+  using index_type = IndexType;
+  using size_type = std::make_unsigned_t<index_type>;
+  using rank_type = std::size_t;
+
+  // observers of the multidimensional index space
+  static constexpr rank_type rank() noexcept { return sizeof...(Extents); }
+
+  static constexpr rank_type rank_dynamic() noexcept
+  {
+    return detail::dynamic_count<rank() - 1, std::integer_sequence<std::size_t, Extents...> >::value;
+  }
+
+  static constexpr std::size_t static_extent(rank_type r) noexcept
+  {
+    std::array<std::size_t, sizeof...(Extents)> exts{Extents...};
+    return exts[r];
+  }
+
+  constexpr index_type extent(rank_type r) const noexcept
+  {
+    if (dynamic_extent_shifts_[r] < 0) return static_extent(r);
+    return dynamic_extents_[dynamic_extent_shifts_[r]];
+  }
+
+  void update_dynamic_extent(rank_type r, index_type i){
+    if (dynamic_extent_shifts_[r] < 0) throw std::invalid_argument("Given rank is not dynamic.");
+    dynamic_extents_[dynamic_extent_shifts_[r]] = i;
+  }
+
+  // constructors
+  constexpr extents() noexcept : dynamic_extents_(), dynamic_extent_shifts_(_init_shifts()) {}
+
+  template <class OtherIndexType, std::size_t... OtherExtents>
+  constexpr explicit extents(const extents<OtherIndexType, OtherExtents...>& other) noexcept
+      : dynamic_extents_(), dynamic_extent_shifts_(_init_shifts())
+  {
+    for (rank_type r = 0; r < rank(); ++r) {
+      if (dynamic_extent_shifts_[r] >= 0) dynamic_extents_[dynamic_extent_shifts_[r]] = other.extent(r);
+    }
+  }
+
+  template <class... OtherIndexTypes>
+  constexpr explicit extents(OtherIndexTypes... extents) noexcept
+      : dynamic_extents_{static_cast<IndexType>(extents)...}, dynamic_extent_shifts_(_init_shifts())
+  {}
+
+  template <class OtherIndexType, std::size_t N>
+  constexpr explicit extents(const std::array<OtherIndexType, N>& other) noexcept
+      : dynamic_extents_{other}, dynamic_extent_shifts_(_init_shifts())
+  {}
+
+  // comparison operators
+  template <class OtherIndexType, std::size_t... OtherExtents>
+  friend constexpr bool operator==(const extents& e1, const extents<OtherIndexType, OtherExtents...>& e2) noexcept
+  {
+    if (e1.rank() != e2.rank()) return false;
+    for (rank_type r = 0; r < rank(); ++r) {
+      if (e1.extent(r) != e2.extent(r)) return false;
+    }
+    return true;
+  }
+
+  friend void swap(extents& e1, extents& e2) noexcept
+  {
+    e1.dynamic_extents_.swap(e2.dynamic_extents_);
+    e1.dynamic_extent_shifts_.swap(e2.dynamic_extent_shifts_);
+  }
+
+  friend std::ostream &operator<<(std::ostream &stream, const extents &e)
+  {
+    stream << "[ " << sizeof...(Extents) << " ] ";
+    ((stream << Extents << ' '), ...);
+
+    return stream;
+  }
+
+ private:
+  std::array<index_type, rank_dynamic()> dynamic_extents_;
+  std::array<int, rank()> dynamic_extent_shifts_;
+
+  static constexpr std::array<int, rank()> _init_shifts()
+  {
+    std::array<std::size_t, sizeof...(Extents)> exts{Extents...};
+    std::array<int, rank()> res = {};
+    std::size_t index = 0;
+    for (rank_type i = 0; i < rank(); ++i) {
+      if (exts[i] == dynamic_extent) {
+        res[i] = index;
+        ++index;
+      } else {
+        res[i] = -1;
+      }
+    }
+    return res;
+  }
+};
+
+// Does not seem to work with C++17(?) because the use of 'dextents' is not explicit enough:
+// "trailing return type ‘Gudhi::dextents<long unsigned int, sizeof... (Integrals)>’ of deduction guide is not a
+// specialization of ‘Gudhi::extents<IndexType, Extents>’"
+// Or does someone knows a workaround...?
+// template<class... Integrals>
+// explicit extents(Integrals...) -> dextents<std::size_t, sizeof...(Integrals)>;
 
 /**
  * @private
@@ -34,13 +216,14 @@ namespace Gudhi {
 class layout_right
 {
  public:
+  template<class Extents>
   class mapping
   {
    public:
-    using index_type = std::size_t;
-    using extents_type = std::vector<index_type>;
+    using extents_type = Extents;
+    using index_type = typename extents_type::index_type;
     using size_type = typename extents_type::size_type;
-    using rank_type = std::size_t;
+    using rank_type = typename extents_type::rank_type;
     using layout_type = layout_right;
 
     // constructors
@@ -49,7 +232,7 @@ class layout_right
 
     mapping(const extents_type& exts) noexcept : exts_(exts)
     {
-      if (!exts_.empty()) _initialize_strides();
+      if constexpr (extents_type::rank() != 0) _initialize_strides();
     }
 
     mapping& operator=(const mapping&) noexcept = default;
@@ -59,8 +242,8 @@ class layout_right
 
     index_type required_span_size() const noexcept
     {
-      if (exts_.empty()) return 0;
-      return ext_shifts_[0] * exts_[0];
+      if constexpr (extents_type::rank() == 0) return 0;
+      else return ext_shifts_[0] * exts_.extent(0);
     }
 
     template <class... Indices>
@@ -72,13 +255,13 @@ class layout_right
     template <class IndexRange = std::initializer_list<index_type> >
     constexpr index_type operator()(const IndexRange& indices) const
     {
-      GUDHI_CHECK(indices.size() == exts_.size(), "Wrong number of parameters.");
+      GUDHI_CHECK(indices.size() == extents_type::rank(), "Wrong number of parameters.");
 
       index_type newIndex = 0;
       auto it = indices.begin();
       GUDHI_CHECK_code(unsigned int i = 0);
       for (auto stride : ext_shifts_) {
-        GUDHI_CHECK_code(GUDHI_CHECK(*it < exts_[i], "Out of bound index."));
+        GUDHI_CHECK_code(GUDHI_CHECK(*it < exts_.extent(i), "Out of bound index."));
         newIndex += (stride * (*it));
         ++it;
         GUDHI_CHECK_code(++i);
@@ -109,36 +292,34 @@ class layout_right
 
     friend void swap(mapping& m1, mapping& m2) noexcept
     {
-      m1.exts_.swap(m2.exts_);
+      swap(m1.exts_, m2.exts_);
       m1.ext_shifts_.swap(m2.ext_shifts_);
     }
 
-    // as not everything is computed at compile time as for mdspan, update is usually faster than reconstructing
-    // everytime.
+    // update can be faster than reconstructing everytime if only relatively small r's are updated.
     void update_extent(rank_type r, index_type new_value)
     {
-      GUDHI_CHECK(r < exts_.size(), "Index out of bound.");
-      exts_[r] = new_value;
+      GUDHI_CHECK(r < extents_type::rank(), "Index out of bound.");
+      exts_.update_dynamic_extent(r, new_value);
       _update_strides(r);
     }
 
    private:
     extents_type exts_;
-    extents_type ext_shifts_;
+    std::array<index_type,extents_type::rank()> ext_shifts_;
 
-    void _initialize_strides()
+    constexpr void _initialize_strides()
     {
-      ext_shifts_.resize(exts_.size());
-      ext_shifts_.back() = 1;
-      for (auto i = exts_.size() - 1; i > 0; --i) {
-        ext_shifts_[i - 1] = ext_shifts_[i] * exts_[i];
+      ext_shifts_[extents_type::rank() - 1] = 1;
+      for (auto i = extents_type::rank() - 1; i > 0; --i) {
+        ext_shifts_[i - 1] = ext_shifts_[i] * exts_.extent(i);
       }
     }
 
-    void _update_strides(rank_type start)
+    constexpr void _update_strides(rank_type start)
     {
       for (auto i = start; i > 0; --i) {
-        ext_shifts_[i - 1] = ext_shifts_[i] * exts_[i];
+        ext_shifts_[i - 1] = ext_shifts_[i] * exts_.extent(i);
       }
     }
   };
@@ -149,23 +330,22 @@ class layout_right
  * @brief Simplified version of C++23 `std::mdspan` class that compiles with C++17.
  *
  * Main differences:
- * - extends are all dynamic,
- * - there is no Extend class, everything is managed by the mapper class instead,
  * - there is no AccessorPolicy template: the container pointed by the stored pointer is assumed to be vector-like,
  * i.e., continuous and, e.g., you can do `ptr_ + 2` to access the third element,
+ * - does not implement any "submdspan" methods (C++26),
  * - `object[i,j,k,...]` is replaced by either `object(i,j,k,...)` or `object[{i,j,k,...}]`, as C++17 does not
  * allow more than one argument for `operator[]`,
  * - two additional methods: `update_extent` and `update_data` to avoid recalculating the helpers in the mapping class
- * at each size modification of the underlying container. In the original `std::mdspan` most of the work is done
- * at compile time, so it is usually fine to reconstruct a view everytime needed. That is not the case here.
+ * at each size modification of the underlying container, when the update is trivial (i.e. when only rank 0 is
+ * modified, which happens often in our use case). 
  */
-template <typename T, class LayoutPolicy = layout_right>
+template <typename T, class Extents, class LayoutPolicy = layout_right>
 class Simple_mdspan
 {
  public:
   using layout_type = LayoutPolicy;
-  using mapping_type = typename LayoutPolicy::mapping;
-  using extents_type = typename mapping_type::extents_type;
+  using mapping_type = typename LayoutPolicy::template mapping<Extents>;
+  using extents_type = Extents;
   using element_type = T;
   using value_type = std::remove_cv_t<T>;
   using index_type = typename mapping_type::index_type;
@@ -181,13 +361,16 @@ class Simple_mdspan
 
   template <class... IndexTypes>
   explicit Simple_mdspan(data_handle_type ptr, IndexTypes... exts)
-      : Simple_mdspan(ptr, {static_cast<index_type>(exts)...})
-  {}
-
-  template <class IndexRange = std::initializer_list<index_type> >
-  Simple_mdspan(data_handle_type ptr, const IndexRange& exts) : ptr_(ptr), map_(extents_type(exts.begin(), exts.end()))
+      : ptr_(ptr), map_(extents_type(exts...))
   {
-    GUDHI_CHECK(ptr != nullptr || empty() || *(exts.begin()) == 0, "Given pointer is not properly initialized.");
+    GUDHI_CHECK(ptr != nullptr || empty() || Extents::rank() == 0, "Given pointer is not properly initialized.");
+  }
+
+  template <class OtherIndexType, size_t N>
+  constexpr explicit Simple_mdspan(data_handle_type ptr, const std::array<OtherIndexType, N>& exts)
+      : ptr_(ptr), map_(extents_type(exts))
+  {
+    GUDHI_CHECK(ptr != nullptr || empty() || Extents::rank() == 0, "Given pointer is not properly initialized.");
   }
 
   Simple_mdspan(data_handle_type ptr, const mapping_type& m) : ptr_(ptr), map_(m) {}
@@ -208,16 +391,16 @@ class Simple_mdspan
     return *(ptr_ + map_(indices));
   }
 
-  constexpr rank_type rank() noexcept { return map_.extents().size(); }
+  constexpr rank_type rank() noexcept { return map_.extents().rank(); }
 
-  constexpr rank_type rank_dynamic() noexcept { return map_.extents().size(); }
+  constexpr rank_type rank_dynamic() noexcept { return map_.extents().rank_dynamic(); }
 
   static constexpr std::size_t static_extent(rank_type r) noexcept { return std::numeric_limits<std::size_t>::max(); }
 
   constexpr index_type extent(rank_type r) const
   {
-    GUDHI_CHECK(r < map_.extents().size(), "Out of bound index.");
-    return map_.extents()[r];
+    GUDHI_CHECK(r < map_.extents().rank(), "Out of bound index.");
+    return map_.extents().extent(r);
   }
 
   constexpr size_type size() const noexcept { return map_.required_span_size(); }
@@ -271,6 +454,30 @@ class Simple_mdspan
   data_handle_type ptr_;
   mapping_type map_;
 };
+
+template <class CArray>
+Simple_mdspan(CArray&)
+    -> Simple_mdspan<std::remove_all_extents_t<CArray>, Gudhi::extents<std::size_t, std::extent_v<CArray, 0>>>;
+
+template <class Pointer>
+Simple_mdspan(Pointer&&)
+    -> Simple_mdspan<std::remove_pointer_t<std::remove_reference_t<Pointer>>, Gudhi::extents<std::size_t>>;
+
+template <class ElementType, class... Integrals>
+explicit Simple_mdspan(ElementType*, Integrals...)
+    -> Simple_mdspan<ElementType, Gudhi::dextents<std::size_t, sizeof...(Integrals)>>;
+
+template <class ElementType, class OtherIndexType, std::size_t N>
+Simple_mdspan(ElementType*, const std::array<OtherIndexType, N>&)
+    -> Simple_mdspan<ElementType, Gudhi::dextents<std::size_t, N>>;
+
+template <class ElementType, class IndexType, std::size_t... ExtentsPack>
+Simple_mdspan(ElementType*, const Gudhi::extents<IndexType, ExtentsPack...>&)
+    -> Simple_mdspan<ElementType, Gudhi::extents<IndexType, ExtentsPack...>>;
+
+template <class ElementType, class MappingType>
+Simple_mdspan(ElementType*, const MappingType&)
+    -> Simple_mdspan<ElementType, typename MappingType::extents_type, typename MappingType::layout_type>;
 
 }  // namespace Gudhi
 

--- a/src/common/test/CMakeLists.txt
+++ b/src/common/test/CMakeLists.txt
@@ -3,6 +3,7 @@ include(GUDHI_boost_test)
 add_executable ( Common_test_points_off_reader test_points_off_reader.cpp )
 add_executable ( Common_test_distance_matrix_reader test_distance_matrix_reader.cpp )
 add_executable ( Common_test_persistence_intervals_reader test_persistence_intervals_reader.cpp )
+add_executable ( Common_test_simple_mdspan test_simple_mdspan.cpp )
 
 # Do not forget to copy test files in current binary dir
 file(COPY "${CMAKE_SOURCE_DIR}/data/points/alphacomplexdoc.off" DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/)
@@ -15,3 +16,4 @@ file(COPY "${CMAKE_SOURCE_DIR}/src/common/test/persistence_intervals_without_dim
 gudhi_add_boost_test(Common_test_points_off_reader)
 gudhi_add_boost_test(Common_test_distance_matrix_reader)
 gudhi_add_boost_test(Common_test_persistence_intervals_reader)
+gudhi_add_boost_test(Common_test_simple_mdspan)

--- a/src/common/test/test_simple_mdspan.cpp
+++ b/src/common/test/test_simple_mdspan.cpp
@@ -24,7 +24,7 @@ BOOST_AUTO_TEST_CASE(test_simple_mdspan_access)
 
   auto ms2 = Simple_mdspan<int>(v.data(), 2, 6);
   auto ms3 = Simple_mdspan(v.data(), 2, 3, 2);
-  auto ms4 = Simple_mdspan(v.data(), {1, 12});
+  auto ms4 = Simple_mdspan<int>(v.data(), {1, 12});
 
   BOOST_CHECK_EQUAL((ms2[{0, 0}]), 1);
   BOOST_CHECK_EQUAL((ms2[{0, 1}]), 2);
@@ -117,7 +117,7 @@ BOOST_AUTO_TEST_CASE(test_simple_mdspan_properties)
 
   auto ms2 = Simple_mdspan<int>(v.data(), 2, 6);
   auto ms3 = Simple_mdspan(v.data(), 2, 3, 2);
-  auto ms4 = Simple_mdspan(v.data(), {1, 12});
+  auto ms4 = Simple_mdspan<int>(v.data(), {1, 12});
 
   BOOST_CHECK_EQUAL(ms2.rank(), 2);
   BOOST_CHECK_EQUAL(ms3.rank(), 3);

--- a/src/common/test/test_simple_mdspan.cpp
+++ b/src/common/test/test_simple_mdspan.cpp
@@ -8,6 +8,7 @@
  *      - YYYY/MM Author: Description of the modification
  */
 
+#include <cstddef>  // std::size_t
 #include <vector>
 
 #define BOOST_TEST_DYN_LINK
@@ -17,14 +18,17 @@
 #include <gudhi/simple_mdspan.h>
 
 using Gudhi::Simple_mdspan;
+using Gudhi::extents;
+using static_extents_ex = extents<int, 2, Gudhi::dynamic_extent, 2>;
 
 BOOST_AUTO_TEST_CASE(test_simple_mdspan_access)
 {
   std::vector<int> v{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
 
-  auto ms2 = Simple_mdspan<int>(v.data(), 2, 6);
+  auto ms2 = Simple_mdspan(v.data(), 2, 6);
   auto ms3 = Simple_mdspan(v.data(), 2, 3, 2);
-  auto ms4 = Simple_mdspan<int>(v.data(), {1, 12});
+  auto ms4 = Simple_mdspan(v.data(), std::array<std::size_t,2>{1, 12});
+  auto ms5 = Simple_mdspan<int,static_extents_ex>(v.data(), 3);
 
   BOOST_CHECK_EQUAL((ms2[{0, 0}]), 1);
   BOOST_CHECK_EQUAL((ms2[{0, 1}]), 2);
@@ -64,6 +68,19 @@ BOOST_AUTO_TEST_CASE(test_simple_mdspan_access)
   BOOST_CHECK_EQUAL((ms4(0, 9)), 10);
   BOOST_CHECK_EQUAL((ms4(0, 10)), 11);
   BOOST_CHECK_EQUAL((ms4(0, 11)), 12);
+
+  BOOST_CHECK_EQUAL((ms5[{0, 0, 0}]), 1);
+  BOOST_CHECK_EQUAL((ms5[{0, 0, 1}]), 2);
+  BOOST_CHECK_EQUAL((ms5[{0, 1, 0}]), 3);
+  BOOST_CHECK_EQUAL((ms5[{0, 1, 1}]), 4);
+  BOOST_CHECK_EQUAL((ms5[{0, 2, 0}]), 5);
+  BOOST_CHECK_EQUAL((ms5[{0, 2, 1}]), 6);
+  BOOST_CHECK_EQUAL((ms5[{1, 0, 0}]), 7);
+  BOOST_CHECK_EQUAL((ms5[{1, 0, 1}]), 8);
+  BOOST_CHECK_EQUAL((ms5[{1, 1, 0}]), 9);
+  BOOST_CHECK_EQUAL((ms5[{1, 1, 1}]), 10);
+  BOOST_CHECK_EQUAL((ms5[{1, 2, 0}]), 11);
+  BOOST_CHECK_EQUAL((ms5[{1, 2, 1}]), 12);
 
   for (std::size_t i = 0; i != ms2.extent(0); i++) {
     for (std::size_t j = 0; j != ms2.extent(1); j++) {
@@ -109,22 +126,38 @@ BOOST_AUTO_TEST_CASE(test_simple_mdspan_access)
   BOOST_CHECK_EQUAL((ms4(0, 9)), 1003);
   BOOST_CHECK_EQUAL((ms4(0, 10)), 1004);
   BOOST_CHECK_EQUAL((ms4(0, 11)), 1005);
+
+  BOOST_CHECK_EQUAL((ms5[{0, 0, 0}]), 0);
+  BOOST_CHECK_EQUAL((ms5[{0, 0, 1}]), 1);
+  BOOST_CHECK_EQUAL((ms5[{0, 1, 0}]), 2);
+  BOOST_CHECK_EQUAL((ms5[{0, 1, 1}]), 3);
+  BOOST_CHECK_EQUAL((ms5[{0, 2, 0}]), 4);
+  BOOST_CHECK_EQUAL((ms5[{0, 2, 1}]), 5);
+  BOOST_CHECK_EQUAL((ms5[{1, 0, 0}]), 1000);
+  BOOST_CHECK_EQUAL((ms5[{1, 0, 1}]), 1001);
+  BOOST_CHECK_EQUAL((ms5[{1, 1, 0}]), 1002);
+  BOOST_CHECK_EQUAL((ms5[{1, 1, 1}]), 1003);
+  BOOST_CHECK_EQUAL((ms5[{1, 2, 0}]), 1004);
+  BOOST_CHECK_EQUAL((ms5[{1, 2, 1}]), 1005);
 }
 
 BOOST_AUTO_TEST_CASE(test_simple_mdspan_properties)
 {
   std::vector<int> v{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
 
-  auto ms2 = Simple_mdspan<int>(v.data(), 2, 6);
+  auto ms2 = Simple_mdspan(v.data(), 2, 6);
   auto ms3 = Simple_mdspan(v.data(), 2, 3, 2);
-  auto ms4 = Simple_mdspan<int>(v.data(), {1, 12});
+  auto ms4 = Simple_mdspan(v.data(), std::array<std::size_t,2>{1, 12});
+  auto ms5 = Simple_mdspan<int,static_extents_ex>(v.data(), 3);
 
   BOOST_CHECK_EQUAL(ms2.rank(), 2);
   BOOST_CHECK_EQUAL(ms3.rank(), 3);
   BOOST_CHECK_EQUAL(ms4.rank(), 2);
+  BOOST_CHECK_EQUAL(ms5.rank(), 3);
   BOOST_CHECK_EQUAL(ms2.rank_dynamic(), 2);
   BOOST_CHECK_EQUAL(ms3.rank_dynamic(), 3);
   BOOST_CHECK_EQUAL(ms4.rank_dynamic(), 2);
+  BOOST_CHECK_EQUAL(ms5.rank_dynamic(), 1);
 
   BOOST_CHECK_EQUAL(ms2.extent(0), 2);
   BOOST_CHECK_EQUAL(ms2.extent(1), 6);
@@ -133,14 +166,19 @@ BOOST_AUTO_TEST_CASE(test_simple_mdspan_properties)
   BOOST_CHECK_EQUAL(ms3.extent(2), 2);
   BOOST_CHECK_EQUAL(ms4.extent(0), 1);
   BOOST_CHECK_EQUAL(ms4.extent(1), 12);
+  BOOST_CHECK_EQUAL(ms5.extent(0), 2);
+  BOOST_CHECK_EQUAL(ms5.extent(1), 3);
+  BOOST_CHECK_EQUAL(ms5.extent(2), 2);
 
   BOOST_CHECK_EQUAL(ms2.size(), 12);
   BOOST_CHECK_EQUAL(ms3.size(), 12);
   BOOST_CHECK_EQUAL(ms4.size(), 12);
+  BOOST_CHECK_EQUAL(ms5.size(), 12);
 
   BOOST_CHECK_EQUAL(ms2.empty(), false);
   BOOST_CHECK_EQUAL(ms3.empty(), false);
   BOOST_CHECK_EQUAL(ms4.empty(), false);
+  BOOST_CHECK_EQUAL(ms5.empty(), false);
 
   BOOST_CHECK_EQUAL(ms2.stride(0), 6);
   BOOST_CHECK_EQUAL(ms2.stride(1), 1);
@@ -149,4 +187,7 @@ BOOST_AUTO_TEST_CASE(test_simple_mdspan_properties)
   BOOST_CHECK_EQUAL(ms3.stride(2), 1);
   BOOST_CHECK_EQUAL(ms4.stride(0), 12);
   BOOST_CHECK_EQUAL(ms4.stride(1), 1);
+  BOOST_CHECK_EQUAL(ms5.stride(0), 6);
+  BOOST_CHECK_EQUAL(ms5.stride(1), 2);
+  BOOST_CHECK_EQUAL(ms5.stride(2), 1);
 }

--- a/src/common/test/test_simple_mdspan.cpp
+++ b/src/common/test/test_simple_mdspan.cpp
@@ -1,0 +1,152 @@
+/*    This file is part of the Gudhi Library - https://gudhi.inria.fr/ - which is released under MIT.
+ *    See file LICENSE or go to https://gudhi.inria.fr/licensing/ for full license details.
+ *    Author(s):       Hannah Schreiber
+ *
+ *    Copyright (C) 2025 Inria
+ *
+ *    Modification(s):
+ *      - YYYY/MM Author: Description of the modification
+ */
+
+#include <vector>
+
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_MODULE "simplex_mdspan"
+#include <boost/test/unit_test.hpp>
+
+#include <gudhi/simple_mdspan.h>
+
+using Gudhi::Simple_mdspan;
+
+BOOST_AUTO_TEST_CASE(test_simple_mdspan_access)
+{
+  std::vector<int> v{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+
+  auto ms2 = Simple_mdspan<int>(v.data(), 2, 6);
+  auto ms3 = Simple_mdspan(v.data(), 2, 3, 2);
+  auto ms4 = Simple_mdspan(v.data(), {1, 12});
+
+  BOOST_CHECK_EQUAL((ms2[{0, 0}]), 1);
+  BOOST_CHECK_EQUAL((ms2[{0, 1}]), 2);
+  BOOST_CHECK_EQUAL((ms2[{0, 2}]), 3);
+  BOOST_CHECK_EQUAL((ms2[{0, 3}]), 4);
+  BOOST_CHECK_EQUAL((ms2[{0, 4}]), 5);
+  BOOST_CHECK_EQUAL((ms2[{0, 5}]), 6);
+  BOOST_CHECK_EQUAL((ms2[{1, 0}]), 7);
+  BOOST_CHECK_EQUAL((ms2[{1, 1}]), 8);
+  BOOST_CHECK_EQUAL((ms2[{1, 2}]), 9);
+  BOOST_CHECK_EQUAL((ms2[{1, 3}]), 10);
+  BOOST_CHECK_EQUAL((ms2[{1, 4}]), 11);
+  BOOST_CHECK_EQUAL((ms2[{1, 5}]), 12);
+
+  BOOST_CHECK_EQUAL((ms3[{0, 0, 0}]), 1);
+  BOOST_CHECK_EQUAL((ms3[{0, 0, 1}]), 2);
+  BOOST_CHECK_EQUAL((ms3[{0, 1, 0}]), 3);
+  BOOST_CHECK_EQUAL((ms3[{0, 1, 1}]), 4);
+  BOOST_CHECK_EQUAL((ms3[{0, 2, 0}]), 5);
+  BOOST_CHECK_EQUAL((ms3[{0, 2, 1}]), 6);
+  BOOST_CHECK_EQUAL((ms3[{1, 0, 0}]), 7);
+  BOOST_CHECK_EQUAL((ms3[{1, 0, 1}]), 8);
+  BOOST_CHECK_EQUAL((ms3[{1, 1, 0}]), 9);
+  BOOST_CHECK_EQUAL((ms3[{1, 1, 1}]), 10);
+  BOOST_CHECK_EQUAL((ms3[{1, 2, 0}]), 11);
+  BOOST_CHECK_EQUAL((ms3[{1, 2, 1}]), 12);
+
+  BOOST_CHECK_EQUAL((ms4(0, 0)), 1);
+  BOOST_CHECK_EQUAL((ms4(0, 1)), 2);
+  BOOST_CHECK_EQUAL((ms4(0, 2)), 3);
+  BOOST_CHECK_EQUAL((ms4(0, 3)), 4);
+  BOOST_CHECK_EQUAL((ms4(0, 4)), 5);
+  BOOST_CHECK_EQUAL((ms4(0, 5)), 6);
+  BOOST_CHECK_EQUAL((ms4(0, 6)), 7);
+  BOOST_CHECK_EQUAL((ms4(0, 7)), 8);
+  BOOST_CHECK_EQUAL((ms4(0, 8)), 9);
+  BOOST_CHECK_EQUAL((ms4(0, 9)), 10);
+  BOOST_CHECK_EQUAL((ms4(0, 10)), 11);
+  BOOST_CHECK_EQUAL((ms4(0, 11)), 12);
+
+  for (std::size_t i = 0; i != ms2.extent(0); i++) {
+    for (std::size_t j = 0; j != ms2.extent(1); j++) {
+      ms2[{i, j}] = i * 1000 + j;
+    }
+  }
+
+  BOOST_CHECK_EQUAL((ms2[{0, 0}]), 0);
+  BOOST_CHECK_EQUAL((ms2[{0, 1}]), 1);
+  BOOST_CHECK_EQUAL((ms2[{0, 2}]), 2);
+  BOOST_CHECK_EQUAL((ms2[{0, 3}]), 3);
+  BOOST_CHECK_EQUAL((ms2[{0, 4}]), 4);
+  BOOST_CHECK_EQUAL((ms2[{0, 5}]), 5);
+  BOOST_CHECK_EQUAL((ms2[{1, 0}]), 1000);
+  BOOST_CHECK_EQUAL((ms2[{1, 1}]), 1001);
+  BOOST_CHECK_EQUAL((ms2[{1, 2}]), 1002);
+  BOOST_CHECK_EQUAL((ms2[{1, 3}]), 1003);
+  BOOST_CHECK_EQUAL((ms2[{1, 4}]), 1004);
+  BOOST_CHECK_EQUAL((ms2[{1, 5}]), 1005);
+
+  BOOST_CHECK_EQUAL((ms3[{0, 0, 0}]), 0);
+  BOOST_CHECK_EQUAL((ms3[{0, 0, 1}]), 1);
+  BOOST_CHECK_EQUAL((ms3[{0, 1, 0}]), 2);
+  BOOST_CHECK_EQUAL((ms3[{0, 1, 1}]), 3);
+  BOOST_CHECK_EQUAL((ms3[{0, 2, 0}]), 4);
+  BOOST_CHECK_EQUAL((ms3[{0, 2, 1}]), 5);
+  BOOST_CHECK_EQUAL((ms3[{1, 0, 0}]), 1000);
+  BOOST_CHECK_EQUAL((ms3[{1, 0, 1}]), 1001);
+  BOOST_CHECK_EQUAL((ms3[{1, 1, 0}]), 1002);
+  BOOST_CHECK_EQUAL((ms3[{1, 1, 1}]), 1003);
+  BOOST_CHECK_EQUAL((ms3[{1, 2, 0}]), 1004);
+  BOOST_CHECK_EQUAL((ms3[{1, 2, 1}]), 1005);
+
+  BOOST_CHECK_EQUAL((ms4(0, 0)), 0);
+  BOOST_CHECK_EQUAL((ms4(0, 1)), 1);
+  BOOST_CHECK_EQUAL((ms4(0, 2)), 2);
+  BOOST_CHECK_EQUAL((ms4(0, 3)), 3);
+  BOOST_CHECK_EQUAL((ms4(0, 4)), 4);
+  BOOST_CHECK_EQUAL((ms4(0, 5)), 5);
+  BOOST_CHECK_EQUAL((ms4(0, 6)), 1000);
+  BOOST_CHECK_EQUAL((ms4(0, 7)), 1001);
+  BOOST_CHECK_EQUAL((ms4(0, 8)), 1002);
+  BOOST_CHECK_EQUAL((ms4(0, 9)), 1003);
+  BOOST_CHECK_EQUAL((ms4(0, 10)), 1004);
+  BOOST_CHECK_EQUAL((ms4(0, 11)), 1005);
+}
+
+BOOST_AUTO_TEST_CASE(test_simple_mdspan_properties)
+{
+  std::vector<int> v{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+
+  auto ms2 = Simple_mdspan<int>(v.data(), 2, 6);
+  auto ms3 = Simple_mdspan(v.data(), 2, 3, 2);
+  auto ms4 = Simple_mdspan(v.data(), {1, 12});
+
+  BOOST_CHECK_EQUAL(ms2.rank(), 2);
+  BOOST_CHECK_EQUAL(ms3.rank(), 3);
+  BOOST_CHECK_EQUAL(ms4.rank(), 2);
+  BOOST_CHECK_EQUAL(ms2.rank_dynamic(), 2);
+  BOOST_CHECK_EQUAL(ms3.rank_dynamic(), 3);
+  BOOST_CHECK_EQUAL(ms4.rank_dynamic(), 2);
+
+  BOOST_CHECK_EQUAL(ms2.extent(0), 2);
+  BOOST_CHECK_EQUAL(ms2.extent(1), 6);
+  BOOST_CHECK_EQUAL(ms3.extent(0), 2);
+  BOOST_CHECK_EQUAL(ms3.extent(1), 3);
+  BOOST_CHECK_EQUAL(ms3.extent(2), 2);
+  BOOST_CHECK_EQUAL(ms4.extent(0), 1);
+  BOOST_CHECK_EQUAL(ms4.extent(1), 12);
+
+  BOOST_CHECK_EQUAL(ms2.size(), 12);
+  BOOST_CHECK_EQUAL(ms3.size(), 12);
+  BOOST_CHECK_EQUAL(ms4.size(), 12);
+
+  BOOST_CHECK_EQUAL(ms2.empty(), false);
+  BOOST_CHECK_EQUAL(ms3.empty(), false);
+  BOOST_CHECK_EQUAL(ms4.empty(), false);
+
+  BOOST_CHECK_EQUAL(ms2.stride(0), 6);
+  BOOST_CHECK_EQUAL(ms2.stride(1), 1);
+  BOOST_CHECK_EQUAL(ms3.stride(0), 6);
+  BOOST_CHECK_EQUAL(ms3.stride(1), 2);
+  BOOST_CHECK_EQUAL(ms3.stride(2), 1);
+  BOOST_CHECK_EQUAL(ms4.stride(0), 12);
+  BOOST_CHECK_EQUAL(ms4.stride(1), 1);
+}


### PR DESCRIPTION
As we would like to flatten some `vector<vector>` or even `vector<vector<vector>>>` in the future multi persistence module, for a better communication with Python, I recreated the `std::mdspan` class which comes for C++23 such that it works with C++17. I tried to keep the class as close as possible to the original. The idea is to replace this class with the standard `std::mdspan` with a minimum of effort once Gudhi changes the minimum compiler version standard to 23.