### PR TITLE
[Persistence cohomology] Enabling more general FilteredComplex types

### DIFF
--- a/src/Persistent_cohomology/include/gudhi/Persistent_cohomology.h
+++ b/src/Persistent_cohomology/include/gudhi/Persistent_cohomology.h
@@ -165,6 +165,7 @@ class Persistent_cohomology {
    *
    * Assumes that the filtration provided by the simplicial complex is
    * valid. Undefined behavior otherwise. */
+  template<bool optimizations_possible = true>
   void compute_persistent_cohomology(Filtration_value min_interval_length = 0) {
     if (dim_max_ <= 0)
       return;  // --------->>
@@ -177,16 +178,20 @@ class Persistent_cohomology {
       cpx_->assign_key(sh, ++idx_fil);
       dsets_.make_set(cpx_->key(sh));
       int dim_simplex = cpx_->dimension(sh);
-      switch (dim_simplex) {
-        case 0:
-          vertices.push_back(idx_fil);
-          break;
-        case 1:
-          update_cohomology_groups_edge(sh);
-          break;
-        default:
-          update_cohomology_groups(sh, dim_simplex);
-          break;
+      if constexpr (optimizations_possible) {
+        switch (dim_simplex) {
+          case 0:
+            vertices.push_back(idx_fil);
+            break;
+          case 1:
+            update_cohomology_groups_edge(sh);
+            break;
+          default:
+            update_cohomology_groups(sh, dim_simplex);
+            break;
+        }
+      } else {
+        update_cohomology_groups(sh, dim_simplex);
       }
     }
     // Compute infinite intervals of dimension 0

--- a/src/Persistent_cohomology/test/persistent_cohomology_unit_test.cpp
+++ b/src/Persistent_cohomology/test/persistent_cohomology_unit_test.cpp
@@ -1,7 +1,5 @@
 #include <iostream>
 #include <string>
-#include <algorithm>
-#include <utility> // std::pair, std::make_pair
 #include <cmath> // float comparison
 #include <limits>
 #include <cstdint>  // for std::uint8_t
@@ -20,6 +18,19 @@ using namespace Gudhi::persistent_cohomology;
 using namespace boost::unit_test;
 
 typedef Simplex_tree<> typeST;
+
+template<bool with_optimizations>
+std::string get_persistence_string(typeST& st, int coefficient, int min_persistence){
+  Persistent_cohomology<typeST, Field_Zp> pcoh(st);
+  pcoh.init_coefficients( coefficient );  // initializes the coefficient field for homology
+  // Compute the persistent homology of the complex, with given minimal lifetime of homology feature to be recorded.
+  pcoh.compute_persistent_cohomology<with_optimizations>( min_persistence );
+  std::ostringstream ossPers;
+
+  pcoh.output_diagram(ossPers);
+  std::string strPers = ossPers.str();
+  return strPers;
+}
 
 std::string test_persistence(int coefficient, int min_persistence) {
   // file is copied in CMakeLists.txt
@@ -41,15 +52,8 @@ std::string test_persistence(int coefficient, int min_persistence) {
   st.initialize_filtration();
 
   // Compute the persistence diagram of the complex
-  Persistent_cohomology<Simplex_tree<>, Field_Zp> pcoh(st);
-
-  pcoh.init_coefficients( coefficient );  // initializes the coefficient field for homology
-  // Compute the persistent homology of the complex
-  pcoh.compute_persistent_cohomology( min_persistence );  // Minimal lifetime of homology feature to be recorded.
-  std::ostringstream ossPers;
-
-  pcoh.output_diagram(ossPers);
-  std::string strPers = ossPers.str();
+  auto strPers = get_persistence_string<true>(st, coefficient, min_persistence);
+  BOOST_CHECK_EQUAL(strPers, get_persistence_string<false>(st, coefficient, min_persistence));
   return strPers;
 }
 


### PR DESCRIPTION
For now, the persistence cohomology module only accepts complexes storing all dimensions from 0 to the maximal desired one and only simplicial/cubical ones (i.e. with a predictable boundary size). But the core algorithm it-self does not have this restrictions, it can more or less work with any valid boundary matrix. Which will be necessary for multi-persistence for example. But even for standard persistence, it can be useful.

The problems come from the optimizations for 0/1 homology, which need those restrictions. So for now, I just added the possibility to deactivate them. I am not sure if it is the best way to do this, but it works and should maintain retro-compatibility.

This PR is mostly to open the discussion about how we want to handle this.