### PR TITLE
[Simplex_tree] add operator<< and operator>> to FiltrationValue concept

### DIFF
--- a/src/Simplex_tree/concept/FiltrationValue.h
+++ b/src/Simplex_tree/concept/FiltrationValue.h
@@ -107,4 +107,18 @@ struct FiltrationValue {
    * Overloads for native arithmetic types or other simple types are already implemented.
    */
   friend std::size_t get_serialization_size_of(const FiltrationValue& value);
+
+  /**
+   * @brief Outputs the filtration value into the stream. Only necessary if the `operator<<` of the simplex tree
+   * needs to be used. If also the simplex tree's `operator>>` is necessary, the output has to correspond to
+   * what the filtration value's @ref operator>> can reed.
+   */
+  friend std::ostream& operator<<(std::ostream& os, const FiltrationValue& fil);
+
+  /**
+   * @brief Inputs the content of the stream into the filtration value. Only necessary if the `operator>>` of the
+   * simplex tree needs to be used. If also the simplex tree's `operator<<` is necessary, the intput format has to
+   * correspond to the one used by the filtration value's @ref operator<< "".
+   */
+  friend std::istream& operator>>(std::istream& os, FiltrationValue& fil);
 };

--- a/src/Simplex_tree/test/simplex_tree_iostream_operator_unit_test.cpp
+++ b/src/Simplex_tree/test/simplex_tree_iostream_operator_unit_test.cpp
@@ -9,6 +9,7 @@
  */
 
 #include <iostream>
+#include <type_traits>
 
 #define BOOST_TEST_DYN_LINK
 #define BOOST_TEST_MODULE "simplex_tree_iostream_operator"
@@ -18,6 +19,7 @@
 //  ^
 // /!\ Nothing else from Simplex_tree shall be included to test includes are well defined.
 #include "gudhi/Simplex_tree.h"
+#include "test_vector_filtration_simplex_tree.h"
 
 using namespace Gudhi;
 
@@ -37,7 +39,10 @@ struct MyStableOptions : Simplex_tree_options_default {
 typedef boost::mpl::list<Simplex_tree<>,
                          Simplex_tree<Simplex_tree_options_fast_persistence>,
                          Simplex_tree<Simplex_tree_options_full_featured>,
-                         Simplex_tree<MyStableOptions> > list_of_tested_variants;
+                         Simplex_tree<MyStableOptions>,
+                         Simplex_tree<Simplex_tree_options_custom_fil_values_default>,
+                         Simplex_tree<Simplex_tree_options_custom_fil_values_fast_persistence>,
+                         Simplex_tree<Simplex_tree_options_custom_fil_values_full_featured> > list_of_tested_variants;
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(iostream_operator, Stree_type, list_of_tested_variants) {
   std::clog << "********************************************************************" << std::endl;
@@ -45,10 +50,17 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(iostream_operator, Stree_type, list_of_tested_vari
 
   Stree_type st;
 
-  st.insert_simplex_and_subfaces({0, 1, 6, 7}, 4.0);
-  st.insert_simplex_and_subfaces({3, 4, 5}, 3.0);
-  st.insert_simplex_and_subfaces({3, 0}, 2.0);
-  st.insert_simplex_and_subfaces({2, 1, 0}, 3.0);
+  if constexpr (std::is_arithmetic_v<typename Stree_type::Filtration_value>){
+    st.insert_simplex_and_subfaces({0, 1, 6, 7}, 4.0);
+    st.insert_simplex_and_subfaces({3, 4, 5}, 3.0);
+    st.insert_simplex_and_subfaces({3, 0}, 2.0);
+    st.insert_simplex_and_subfaces({2, 1, 0}, 3.0);
+  } else {
+    st.insert_simplex_and_subfaces({0, 1, 6, 7}, {4, 5, 6});
+    st.insert_simplex_and_subfaces({3, 4, 5}, {3, 4, 5});
+    st.insert_simplex_and_subfaces({3, 0}, {2, 3, 4});
+    st.insert_simplex_and_subfaces({2, 1, 0}, {3, 4, 5});
+  }
 
   st.initialize_filtration();
   // Display the Simplex_tree

--- a/src/Simplex_tree/test/test_vector_filtration_simplex_tree.h
+++ b/src/Simplex_tree/test/test_vector_filtration_simplex_tree.h
@@ -108,6 +108,26 @@ class Vector_filtration_value : public std::vector<int>
     stream << "]";
     return stream;
   }
+
+  friend std::istream &operator>>(std::istream &stream, Vector_filtration_value &f) {
+    char firstCharacter;
+    stream >> firstCharacter;
+    if (firstCharacter != '[') throw std::invalid_argument("Invalid incoming stream format for Vector_filtration_value.");
+    f.clear();
+    auto pos = stream.tellg();
+    stream >> firstCharacter;
+    if (firstCharacter == ']') return stream;
+    stream.seekg(pos, std::ios_base::beg);
+    int val;
+    char delimiter = '\0';
+    while (delimiter != ']') {
+      stream >> val;
+      if (!stream.good()) throw std::invalid_argument("Invalid incoming stream format for Vector_filtration_value.");
+      f.push_back(val);
+      stream >> delimiter;
+    }
+    return stream;
+  }
 };
 
 struct Simplex_tree_options_custom_fil_values_default {


### PR DESCRIPTION
We forgot those two methods when we generalized the `Filtration_value` type in the simplex tree...