### PR TITLE
Fix tensorflow len issues

### DIFF
--- a/src/python/gudhi/point_cloud/knn.py
+++ b/src/python/gudhi/point_cloud/knn.py
@@ -100,9 +100,22 @@ class KNearestNeighbors:
         Args:
             X (numpy.array): coordinates for reference points.
         """
-        if self.k > len(X):
+        # Handle TensorFlow tensors before using len()
+        if self.params.get("enable_autodiff", False):
+            try:
+                import tensorflow as tf
+                if hasattr(tf, 'is_tensor') and tf.is_tensor(X):
+                    n_samples = int(X.shape[0])
+                else:
+                    n_samples = len(X)
+            except (ImportError, AttributeError):
+                n_samples = len(X)
+        else:
+            n_samples = len(X)
+            
+        if self.k > n_samples:
             raise ValueError(
-                f"Expected number of neighbors (aka. 'k') <= number of samples, but k={self.k} and number of samples={len(X)}"
+                f"Expected number of neighbors (aka. 'k') <= number of samples, but k={self.k} and number of samples={n_samples}"
             )
         self.ref_points = X
         if self.params.get("enable_autodiff", False):

--- a/src/python/gudhi/wasserstein/wasserstein.py
+++ b/src/python/gudhi/wasserstein/wasserstein.py
@@ -275,8 +275,31 @@ def wasserstein_distance(
     """
 
     # First step: handle empty diagrams
-    n = len(X)
-    m = len(Y)
+    # Handle TensorFlow tensors before using len()
+    if enable_autodiff:
+        try:
+            # Try to get shape from tensor if it's a TensorFlow tensor
+            import tensorflow as tf
+            if hasattr(X, 'shape') and hasattr(Y, 'shape'):
+                # For TensorFlow tensors, use shape[0] instead of len()
+                if hasattr(tf, 'is_tensor') and tf.is_tensor(X):
+                    n = int(X.shape[0])
+                else:
+                    n = len(X)
+                if hasattr(tf, 'is_tensor') and tf.is_tensor(Y):
+                    m = int(Y.shape[0])
+                else:
+                    m = len(Y)
+            else:
+                n = len(X)
+                m = len(Y)
+        except (ImportError, AttributeError):
+            # Fallback if TensorFlow not available or tensor doesn't have shape
+            n = len(X)
+            m = len(Y)
+    else:
+        n = len(X)
+        m = len(Y)
 
     if n == 0:
         if m == 0:


### PR DESCRIPTION
## Summary
To fix  TypeError issues that occur when using TensorFlow symbolic tensors with `enable_autodiff=True` in GUDHI's wasserstein distance and KNN functions.

## Problem
The issue was that `len(X)` and `len(Y)` were called on TensorFlow symbalic tensors before checking if autodiff was enabled. TensorFlow symbolic tensors don't support the `len()` function, causing a TypeError.

This is related to [issue #530](https://github.com/GUDHI/gudhi-devel/issues/530).

## Changes
1. **wasserstein.py**: Added TensorFlow tensor detection before using `len()` in the `wasserstein_distance` function
2. **knn.py**: Added similar TensorFlow tensor detection in the `fit` method

## Details
- Use `tensor.shape[0]` for TensorFlow tensors instead of `len(tensor)`
- Tried to keep backward compatibility with numpy arrays 
- Added proper error handling for missing TensorFlow dependency
- Only apply the fix when `enable_autodiff=True`

## Testing
- Both functions now handle TensorFlow symbolic tensors without throwing TypeError
- Backward compatibility with numpy arrays is maintained (from the tests i had)
- Functions work correctly when TensorFlow is not available

## Files Changed
- `src/python/gudhi/wasserstein/wasserstein.py`
- `src/python/gudhi/point_cloud/knn.py`