### PR TITLE
Simplex tree dimension simplex range

### DIFF
--- a/.github/next_release.md
+++ b/.github/next_release.md
@@ -14,6 +14,14 @@ Below is a list of changes:
 - [Module](link)
      - **...**
 
+- [Alpha complex dD](https://gudhi.inria.fr/doc/latest/class_gudhi_1_1alpha__complex_1_1_alpha__complex.html)
+     - **API break:** The simplicial complex for the Alpha complex concept has been changed to
+       `dimension_simplex_range` (that must returns a range of simplices of a given dimension) instead of
+       `skeleton_simplex_range` (that was returning a range of simplices lower or equal to a given dimension)
+
+- [Simplex_tree](https://gudhi.inria.fr/doc/latest/class_gudhi_1_1_simplex__tree.html)
+     - A new iterator over the simplices of the simplicial complex that match a given dimension
+
 - [Representations](https://gudhi.inria.fr/python/latest/representations.html)
      - in metrics, `BottleneckDistance` argument `epsilon` is deprecrated and renamed `e` to be consistent with `bottleneck_distance` and `pairwise_persistence_diagram_distances`
 

--- a/src/Alpha_complex/concept/SimplicialComplexForAlpha.h
+++ b/src/Alpha_complex/concept/SimplicialComplexForAlpha.h
@@ -66,10 +66,9 @@ struct SimplicialComplexForAlpha {
   /** \brief Iterator over the simplices of the skeleton of the complex, for a given dimension.
    *
    * 'value_type' must be 'Simplex_handle'. */
-  typedef unspecified Skeleton_simplex_range;
-  /** \brief Returns a range over the simplices of the skeleton of the simplicial complex, for a given
-   * dimension. */
-  Skeleton_simplex_range skeleton_simplex_range;
+  typedef unspecified Dimension_simplex_range;
+  /** \brief Returns a range over the the simplices of the simplicial complex for a given dimension. */
+  Dimension_simplex_range dimension_simplex_range(int dimension);
 
   /** \brief Return type of an insertion of a simplex
    */

--- a/src/Alpha_complex/include/gudhi/Alpha_complex.h
+++ b/src/Alpha_complex/include/gudhi/Alpha_complex.h
@@ -458,32 +458,29 @@ class Alpha_complex {
       // ### For i : d -> 0
       for (int decr_dim = triangulation_->maximal_dimension(); decr_dim >= 0; decr_dim--) {
         // ### Foreach Sigma of dim i
-        for (Simplex_handle f_simplex : complex.skeleton_simplex_range(decr_dim)) {
-          int f_simplex_dim = complex.dimension(f_simplex);
-          if (decr_dim == f_simplex_dim) {
-            // ### If filt(Sigma) is NaN : filt(Sigma) = alpha(Sigma)
-            if (isnan(complex.filtration(f_simplex))) {
-              Filtration_value alpha_complex_filtration = 0.0;
-              // No need to compute squared_radius on a non-weighted single point - alpha is 0.0
-              if (Weighted || f_simplex_dim > 0) {
-                auto const& sqrad = radius(complex, f_simplex);
+        for (Simplex_handle f_simplex : complex.dimension_simplex_range(decr_dim)) {
+          // ### If filt(Sigma) is NaN : filt(Sigma) = alpha(Sigma)
+          if (isnan(complex.filtration(f_simplex))) {
+            Filtration_value alpha_complex_filtration = 0.0;
+            // No need to compute squared_radius on a non-weighted single point - alpha is 0.0
+            if (Weighted || decr_dim > 0) {
+              auto const& sqrad = radius(complex, f_simplex);
 #if CGAL_VERSION_NR >= 1050000000
-                if(exact) CGAL::exact(sqrad);
+              if(exact) CGAL::exact(sqrad);
 #endif
-                alpha_complex_filtration = cgal_converter(sqrad);
-                if constexpr (!Output_squared_values) {
-                  alpha_complex_filtration = sqrt(alpha_complex_filtration);
-                }
+              alpha_complex_filtration = cgal_converter(sqrad);
+              if constexpr (!Output_squared_values) {
+                alpha_complex_filtration = sqrt(alpha_complex_filtration);
               }
-              complex.assign_filtration(f_simplex, alpha_complex_filtration);
-#ifdef DEBUG_TRACES
-              std::clog << "filt(Sigma) is NaN : filt(Sigma) =" << complex.filtration(f_simplex) << std::endl;
-#endif  // DEBUG_TRACES
             }
-            // No need to propagate further, unweighted points all have value 0
-            if (decr_dim > !Weighted)
-              propagate_alpha_filtration(complex, f_simplex);
+            complex.assign_filtration(f_simplex, alpha_complex_filtration);
+#ifdef DEBUG_TRACES
+            std::clog << "filt(Sigma) is NaN : filt(Sigma) =" << complex.filtration(f_simplex) << std::endl;
+#endif  // DEBUG_TRACES
           }
+          // No need to propagate further, unweighted points all have value 0
+          if (decr_dim > !Weighted)
+            propagate_alpha_filtration(complex, f_simplex);
         }
         old_cache_ = std::move(cache_);
         cache_.clear();

--- a/src/Cech_complex/test/test_cech_complex.cpp
+++ b/src/Cech_complex/test/test_cech_complex.cpp
@@ -95,25 +95,25 @@ BOOST_AUTO_TEST_CASE(Cech_complex_for_documentation) {
   BOOST_CHECK(st.num_simplices() == 27);
 
   // Check filtration values of vertices is 0.0
-  for (auto f_simplex : st.skeleton_simplex_range(0)) {
+  for (auto f_simplex : st.dimension_simplex_range(0)) {
     BOOST_CHECK(st.filtration(f_simplex) == 0.0);
   }
 
   // Check filtration values of edges
-  for (auto f_simplex : st.skeleton_simplex_range(DIMENSION_1)) {
-    if (DIMENSION_1 == st.dimension(f_simplex)) {
-      std::vector<Point> vp;
-      std::clog << "vertex = (";
-      for (auto vertex : st.simplex_vertex_range(f_simplex)) {
-        std::clog << vertex << ",";
-        vp.push_back(points.at(vertex));
-      }
-      std::clog << ") - distance =" << Gudhi::cech_complex::Sphere_circumradius<Kernel, Filtration_value>()(vp.at(0), vp.at(1))
-                << " - filtration =" << st.filtration(f_simplex) << std::endl;
-      BOOST_CHECK(vp.size() == 2);
-      GUDHI_TEST_FLOAT_EQUALITY_CHECK(st.filtration(f_simplex),
-                                      Gudhi::cech_complex::Sphere_circumradius<Kernel, Filtration_value>()(vp.at(0), vp.at(1)));
+  for (auto f_simplex : st.dimension_simplex_range(DIMENSION_1)) {
+    std::vector<Point> vp;
+    std::clog << "vertex = (";
+    for (auto vertex : st.simplex_vertex_range(f_simplex)) {
+      std::clog << vertex << ",";
+      vp.push_back(points.at(vertex));
     }
+    std::clog << ") - distance ="
+              << Gudhi::cech_complex::Sphere_circumradius<Kernel, Filtration_value>()(vp.at(0), vp.at(1))
+              << " - filtration =" << st.filtration(f_simplex) << std::endl;
+    BOOST_CHECK(vp.size() == 2);
+    GUDHI_TEST_FLOAT_EQUALITY_CHECK(st.filtration(f_simplex),
+                                    Gudhi::cech_complex::Sphere_circumradius<Kernel, Filtration_value>()(vp.at(0),
+                                                                                                         vp.at(1)));
   }
 
   const int DIMENSION_2 = 2;

--- a/src/Rips_complex/test/test_rips_complex.cpp
+++ b/src/Rips_complex/test/test_rips_complex.cpp
@@ -63,24 +63,22 @@ BOOST_AUTO_TEST_CASE(RIPS_DOC_OFF_file) {
   BOOST_CHECK(st.num_simplices() == 18);
 
   // Check filtration values of vertices is 0.0
-  for (auto f_simplex : st.skeleton_simplex_range(0)) {
+  for (auto f_simplex : st.dimension_simplex_range(0)) {
     BOOST_CHECK(st.filtration(f_simplex) == 0.0);
   }
 
   // Check filtration values of edges
-  for (auto f_simplex : st.skeleton_simplex_range(DIMENSION_1)) {
-    if (DIMENSION_1 == st.dimension(f_simplex)) {
-      std::vector<Point> vp;
-      std::clog << "vertex = (";
-      for (auto vertex : st.simplex_vertex_range(f_simplex)) {
-        std::clog << vertex << ",";
-        vp.push_back(off_reader.get_point_cloud().at(vertex));
-      }
-      std::clog << ") - distance =" << Gudhi::Euclidean_distance()(vp.at(0), vp.at(1)) <<
-          " - filtration =" << st.filtration(f_simplex) << std::endl;
-      BOOST_CHECK(vp.size() == 2);
-      GUDHI_TEST_FLOAT_EQUALITY_CHECK(st.filtration(f_simplex), Gudhi::Euclidean_distance()(vp.at(0), vp.at(1)));
+  for (auto f_simplex : st.dimension_simplex_range(DIMENSION_1)) {
+    std::vector<Point> vp;
+    std::clog << "vertex = (";
+    for (auto vertex : st.simplex_vertex_range(f_simplex)) {
+      std::clog << vertex << ",";
+      vp.push_back(off_reader.get_point_cloud().at(vertex));
     }
+    std::clog << ") - distance =" << Gudhi::Euclidean_distance()(vp.at(0), vp.at(1))
+              << " - filtration =" << st.filtration(f_simplex) << std::endl;
+    BOOST_CHECK(vp.size() == 2);
+    GUDHI_TEST_FLOAT_EQUALITY_CHECK(st.filtration(f_simplex), Gudhi::Euclidean_distance()(vp.at(0), vp.at(1)));
   }
 
   const int DIMENSION_2 = 2;
@@ -88,7 +86,7 @@ BOOST_AUTO_TEST_CASE(RIPS_DOC_OFF_file) {
   rips_complex_from_file.create_complex(st2, DIMENSION_2);
   std::clog << "st2.dimension()=" << st2.dimension() << std::endl;
   BOOST_CHECK(st2.dimension() == DIMENSION_2);
-  
+
   std::clog << "st2.num_vertices()=" << st2.num_vertices() << std::endl;
   BOOST_CHECK(st2.num_vertices() == NUMBER_OF_VERTICES);
 
@@ -101,7 +99,7 @@ BOOST_AUTO_TEST_CASE(RIPS_DOC_OFF_file) {
   Simplex_tree::Filtration_value f012 = st2.filtration(st2.find({0, 1, 2}));
   std::clog << "f012= " << f012 << " | f01= " << f01 << " - f02= " << f02 << " - f12= " << f12 << std::endl;
   GUDHI_TEST_FLOAT_EQUALITY_CHECK(f012, std::max(f01, std::max(f02,f12)));
-  
+
   Simplex_tree::Filtration_value f45 = st2.filtration(st2.find({4, 5}));
   Simplex_tree::Filtration_value f56 = st2.filtration(st2.find({5, 6}));
   Simplex_tree::Filtration_value f46 = st2.filtration(st2.find({4, 6}));
@@ -114,7 +112,7 @@ BOOST_AUTO_TEST_CASE(RIPS_DOC_OFF_file) {
   rips_complex_from_file.create_complex(st3, DIMENSION_3);
   std::clog << "st3.dimension()=" << st3.dimension() << std::endl;
   BOOST_CHECK(st3.dimension() == DIMENSION_3);
-  
+
   std::clog << "st3.num_vertices()=" << st3.num_vertices() << std::endl;
   BOOST_CHECK(st3.num_vertices() == NUMBER_OF_VERTICES);
 
@@ -313,23 +311,21 @@ BOOST_AUTO_TEST_CASE(Rips_doc_csv_file) {
   BOOST_CHECK(st.num_simplices() == 18);
 
   // Check filtration values of vertices is 0.0
-  for (auto f_simplex : st.skeleton_simplex_range(0)) {
+  for (auto f_simplex : st.dimension_simplex_range(0)) {
     BOOST_CHECK(st.filtration(f_simplex) == 0.0);
   }
 
   // Check filtration values of edges
-  for (auto f_simplex : st.skeleton_simplex_range(DIMENSION_1)) {
-    if (DIMENSION_1 == st.dimension(f_simplex)) {
-      std::vector<Simplex_tree::Vertex_handle> vvh;
-      std::clog << "vertex = (";
-      for (auto vertex : st.simplex_vertex_range(f_simplex)) {
-        std::clog << vertex << ",";
-        vvh.push_back(vertex);
-      }
-      std::clog << ") - filtration =" << st.filtration(f_simplex) << std::endl;
-      BOOST_CHECK(vvh.size() == 2);
-      GUDHI_TEST_FLOAT_EQUALITY_CHECK(st.filtration(f_simplex), distances[vvh.at(0)][vvh.at(1)]);
+  for (auto f_simplex : st.dimension_simplex_range(DIMENSION_1)) {
+    std::vector<Simplex_tree::Vertex_handle> vvh;
+    std::clog << "vertex = (";
+    for (auto vertex : st.simplex_vertex_range(f_simplex)) {
+      std::clog << vertex << ",";
+      vvh.push_back(vertex);
     }
+    std::clog << ") - filtration =" << st.filtration(f_simplex) << std::endl;
+    BOOST_CHECK(vvh.size() == 2);
+    GUDHI_TEST_FLOAT_EQUALITY_CHECK(st.filtration(f_simplex), distances[vvh.at(0)][vvh.at(1)]);
   }
 
   const int DIMENSION_2 = 2;
@@ -337,7 +333,7 @@ BOOST_AUTO_TEST_CASE(Rips_doc_csv_file) {
   rips_complex_from_file.create_complex(st2, DIMENSION_2);
   std::clog << "st2.dimension()=" << st2.dimension() << std::endl;
   BOOST_CHECK(st2.dimension() == DIMENSION_2);
-  
+
   std::clog << "st2.num_vertices()=" << st2.num_vertices() << std::endl;
   BOOST_CHECK(st2.num_vertices() == NUMBER_OF_VERTICES);
 
@@ -350,7 +346,7 @@ BOOST_AUTO_TEST_CASE(Rips_doc_csv_file) {
   Simplex_tree::Filtration_value f012 = st2.filtration(st2.find({0, 1, 2}));
   std::clog << "f012= " << f012 << " | f01= " << f01 << " - f02= " << f02 << " - f12= " << f12 << std::endl;
   GUDHI_TEST_FLOAT_EQUALITY_CHECK(f012, std::max(f01, std::max(f02,f12)));
-  
+
   Simplex_tree::Filtration_value f45 = st2.filtration(st2.find({4, 5}));
   Simplex_tree::Filtration_value f56 = st2.filtration(st2.find({5, 6}));
   Simplex_tree::Filtration_value f46 = st2.filtration(st2.find({4, 6}));
@@ -363,7 +359,7 @@ BOOST_AUTO_TEST_CASE(Rips_doc_csv_file) {
   rips_complex_from_file.create_complex(st3, DIMENSION_3);
   std::clog << "st3.dimension()=" << st3.dimension() << std::endl;
   BOOST_CHECK(st3.dimension() == DIMENSION_3);
-  
+
   std::clog << "st3.num_vertices()=" << st3.num_vertices() << std::endl;
   BOOST_CHECK(st3.num_vertices() == NUMBER_OF_VERTICES);
 

--- a/src/Simplex_tree/benchmark/CMakeLists.txt
+++ b/src/Simplex_tree/benchmark/CMakeLists.txt
@@ -1,1 +1,3 @@
 add_executable_with_targets(simplex_tree_cofaces_benchmark simplex_tree_cofaces_benchmark.cpp TBB::tbb)
+add_executable_with_targets(simplex_tree_dimension_simplex_range_benchmark
+                            simplex_tree_dimension_simplex_range_benchmark.cpp TBB::tbb)

--- a/src/Simplex_tree/benchmark/random_simplices.h
+++ b/src/Simplex_tree/benchmark/random_simplices.h
@@ -16,13 +16,21 @@
 
 std::random_device rd;
 
+/** \brief Returns a random simplex.
+ *
+ * @param[in] subset_min_size The minimal size of the subset.
+ * @param[in] subset_max_size The maximal size of the subset.
+ * @param[in] range_max_value The maximal vertex value.
+ *
+ * @return A random simplex (for example, random_simplex(2, 5, 50) may return {1, 9, 13, 19} as the subset length
+ * is in between 2 and 5, and the maximal vertex value is less than 50) */
 template <class Vertex_handle>
-std::vector<Vertex_handle> rand_int_range(int subset_min_size,
+std::vector<Vertex_handle> random_simplex(int subset_min_size,
                                           int subset_max_size,
                                           Vertex_handle range_max_value)
 {
 #ifdef DEBUG_TRACES
-  std::clog << "rand_int_range - subset_min_size = " << subset_min_size << " - subset_max_size = " << subset_max_size
+  std::clog << "random_simplex - subset_min_size = " << subset_min_size << " - subset_max_size = " << subset_max_size
             << " - range_max_value = " << range_max_value << std::endl;
 #endif  // DEBUG_TRACES
 

--- a/src/Simplex_tree/benchmark/random_simplices.h
+++ b/src/Simplex_tree/benchmark/random_simplices.h
@@ -1,0 +1,38 @@
+/*    This file is part of the Gudhi Library - https://gudhi.inria.fr/ - which is released under MIT.
+ *    See file LICENSE or go to https://gudhi.inria.fr/licensing/ for full license details.
+ *    Author(s):       Vincent Rouvreau
+ *
+ *    Copyright (C) 2025 Inria
+ *
+ *    Modification(s):
+ *      - YYYY/MM Author: Description of the modification
+ */
+
+#include <iostream>
+#include <random>
+#include <numeric>  // for std::iota
+#include <algorithm>  // for std::shuffle
+#include <vector>
+
+std::random_device rd;
+
+template <class Vertex_handle>
+std::vector<Vertex_handle> rand_int_range(int subset_min_size,
+                                          int subset_max_size,
+                                          Vertex_handle range_max_value)
+{
+#ifdef DEBUG_TRACES
+  std::clog << "rand_int_range - subset_min_size = " << subset_min_size << " - subset_max_size = " << subset_max_size
+            << " - range_max_value = " << range_max_value << std::endl;
+#endif  // DEBUG_TRACES
+
+  std::vector<Vertex_handle> range(range_max_value);
+  std::iota(range.begin(), range.end(), 0); // range is { 0, 1, 2, ..., 99 } when range_max_value is 100
+
+  std::shuffle(range.begin(), range.end(), std::mt19937 { rd() });
+
+  std::uniform_int_distribution<int> dist(subset_min_size, subset_max_size);
+  // Return a subset, which size is in between [subset_min_size; subset_max_size], of shuffled range
+  // {1, 9, 13, 19, 86, 36}, for example
+  return std::vector<Vertex_handle> {range.begin(), range.begin() + dist(rd)};
+}

--- a/src/Simplex_tree/benchmark/simplex_tree_cofaces_benchmark.cpp
+++ b/src/Simplex_tree/benchmark/simplex_tree_cofaces_benchmark.cpp
@@ -5,41 +5,19 @@
  *    Copyright (C) 2023 Inria
  *
  *    Modification(s):
+ *      - 2025/08 Vincent Rouvreau: externalize rand_int_range in random_simplces.h for DRY purposes
  *      - YYYY/MM Author: Description of the modification
  */
 
 #include <gudhi/Simplex_tree.h>
 #include <gudhi/Clock.h>
 
+#include "random_simplices.h"
+
 #include <iostream>
-#include <random>
-#include <numeric>  // for std::iota
-#include <algorithm>  // for std::shuffle and std::sample
+#include <algorithm>  // for std::sample
 #include <vector>
 #include <cstdlib>
-
-std::random_device rd;
-
-template <class Vertex_handle>
-std::vector<Vertex_handle> rand_int_range(int subset_min_size,
-                                          int subset_max_size,
-                                          Vertex_handle range_max_value)
-{
-#ifdef DEBUG_TRACES
-  std::clog << "rand_int_range - subset_min_size = " << subset_min_size << " - subset_max_size = " << subset_max_size
-            << " - range_max_value = " << range_max_value << std::endl;
-#endif  // DEBUG_TRACES
-
-  std::vector<Vertex_handle> range(range_max_value);
-  std::iota(range.begin(), range.end(), 0); // range is { 0, 1, 2, ..., 99 } when range_max_value is 100
-
-  std::shuffle(range.begin(), range.end(), std::mt19937 { rd() });
-
-  std::uniform_int_distribution<int> dist(subset_min_size, subset_max_size);
-  // Return a subset, which size is in between [subset_min_size; subset_max_size], of shuffled range
-  // {1, 9, 13, 19, 86, 36}, for example
-  return std::vector<Vertex_handle> {range.begin(), range.begin() + dist(rd)};
-}
 
 template <class Stree>
 void benchmark_stars_computation(int nb_vertices) {
@@ -53,7 +31,7 @@ void benchmark_stars_computation(int nb_vertices) {
   for (Vertex_handle v=0; v < nb_vertices; v++)
     st.insert_simplex_and_subfaces(rand_int_range<Vertex_handle>(2, 5, nb_vertices));
   std::cout << "... " << st.num_vertices() << " vertices and " << st.num_simplices() << " simplices." << std::endl;
-  
+
   Gudhi::Clock benchmark_search("... Looking for random existing simplices");
   // 5.000 random simplices of size in between [2; 5] has been inserted - about 50.000 simplices in the Simplex_tree
   const int SH_SIZE = 20000;
@@ -112,7 +90,7 @@ int main(int argc, char *argv[]) {
   }
   if (argc == 2)
     nb_vertices = atoi(argv[1]);
-    
+
   std::clog << "** Without cofaces computation optimization" << std::endl;
   benchmark_stars_computation<Gudhi::Simplex_tree<Stree_basic_cofaces_options>>(nb_vertices);
 

--- a/src/Simplex_tree/benchmark/simplex_tree_cofaces_benchmark.cpp
+++ b/src/Simplex_tree/benchmark/simplex_tree_cofaces_benchmark.cpp
@@ -5,7 +5,7 @@
  *    Copyright (C) 2023 Inria
  *
  *    Modification(s):
- *      - 2025/08 Vincent Rouvreau: externalize rand_int_range in random_simplces.h for DRY purposes
+ *      - 2025/08 Vincent Rouvreau: externalize rand_int_range in random_simplices.h for DRY purposes
  *      - YYYY/MM Author: Description of the modification
  */
 
@@ -29,7 +29,7 @@ void benchmark_stars_computation(int nb_vertices) {
   Stree st;
   // Insert 'nb_vertices' random simplices, of size in between [2; 5] and vertices in between [0; nb_vertices]
   for (Vertex_handle v=0; v < nb_vertices; v++)
-    st.insert_simplex_and_subfaces(rand_int_range<Vertex_handle>(2, 5, nb_vertices));
+    st.insert_simplex_and_subfaces(random_simplex<Vertex_handle>(2, 5, nb_vertices));
   std::cout << "... " << st.num_vertices() << " vertices and " << st.num_simplices() << " simplices." << std::endl;
 
   Gudhi::Clock benchmark_search("... Looking for random existing simplices");

--- a/src/Simplex_tree/benchmark/simplex_tree_dimension_simplex_range_benchmark.cpp
+++ b/src/Simplex_tree/benchmark/simplex_tree_dimension_simplex_range_benchmark.cpp
@@ -36,7 +36,7 @@ int main(int argc, char *argv[]) {
   Simplex_tree st;
   // Insert 'nb_vertices' random simplices, of size in between [2; 5] and vertices in between [0; nb_vertices]
   for (Vertex_handle v=0; v < nb_vertices; v++)
-    st.insert_simplex_and_subfaces(rand_int_range<Vertex_handle>(2, 5, nb_vertices));
+    st.insert_simplex_and_subfaces(random_simplex<Vertex_handle>(2, 5, nb_vertices));
   std::clog << "... " << st.num_vertices() << " vertices and " << st.num_simplices()
             << " simplices. Dimension is " << st.dimension() << "\n";
 

--- a/src/Simplex_tree/benchmark/simplex_tree_dimension_simplex_range_benchmark.cpp
+++ b/src/Simplex_tree/benchmark/simplex_tree_dimension_simplex_range_benchmark.cpp
@@ -11,35 +11,11 @@
 #include <gudhi/Simplex_tree.h>
 #include <gudhi/Clock.h>
 
+#include "random_simplices.h"
+
 #include <iostream>
-#include <random>
-#include <numeric>  // for std::iota
-#include <algorithm>  // for std::shuffle and std::sample
 #include <vector>
 #include <cstdlib>
-
-std::random_device rd;
-
-template <class Vertex_handle>
-std::vector<Vertex_handle> rand_int_range(int subset_min_size,
-                                          int subset_max_size,
-                                          Vertex_handle range_max_value)
-{
-#ifdef DEBUG_TRACES
-  std::clog << "rand_int_range - subset_min_size = " << subset_min_size << " - subset_max_size = " << subset_max_size
-            << " - range_max_value = " << range_max_value << std::endl;
-#endif  // DEBUG_TRACES
-
-  std::vector<Vertex_handle> range(range_max_value);
-  std::iota(range.begin(), range.end(), 0); // range is { 0, 1, 2, ..., 99 } when range_max_value is 100
-
-  std::shuffle(range.begin(), range.end(), std::mt19937 { rd() });
-
-  std::uniform_int_distribution<int> dist(subset_min_size, subset_max_size);
-  // Return a subset, which size is in between [subset_min_size; subset_max_size], of shuffled range
-  // {1, 9, 13, 19, 86, 36}, for example
-  return std::vector<Vertex_handle> {range.begin(), range.begin() + dist(rd)};
-}
 
 int main(int argc, char *argv[]) {
   int nb_vertices = 100000;

--- a/src/Simplex_tree/benchmark/simplex_tree_dimension_simplex_range_benchmark.cpp
+++ b/src/Simplex_tree/benchmark/simplex_tree_dimension_simplex_range_benchmark.cpp
@@ -1,0 +1,86 @@
+/*    This file is part of the Gudhi Library - https://gudhi.inria.fr/ - which is released under MIT.
+ *    See file LICENSE or go to https://gudhi.inria.fr/licensing/ for full license details.
+ *    Author(s):       Vincent Rouvreau
+ *
+ *    Copyright (C) 2023 Inria
+ *
+ *    Modification(s):
+ *      - YYYY/MM Author: Description of the modification
+ */
+
+#include <gudhi/Simplex_tree.h>
+#include <gudhi/Clock.h>
+
+#include <iostream>
+#include <random>
+#include <numeric>  // for std::iota
+#include <algorithm>  // for std::shuffle and std::sample
+#include <vector>
+#include <cstdlib>
+
+std::random_device rd;
+
+template <class Vertex_handle>
+std::vector<Vertex_handle> rand_int_range(int subset_min_size,
+                                          int subset_max_size,
+                                          Vertex_handle range_max_value)
+{
+#ifdef DEBUG_TRACES
+  std::clog << "rand_int_range - subset_min_size = " << subset_min_size << " - subset_max_size = " << subset_max_size
+            << " - range_max_value = " << range_max_value << std::endl;
+#endif  // DEBUG_TRACES
+
+  std::vector<Vertex_handle> range(range_max_value);
+  std::iota(range.begin(), range.end(), 0); // range is { 0, 1, 2, ..., 99 } when range_max_value is 100
+
+  std::shuffle(range.begin(), range.end(), std::mt19937 { rd() });
+
+  std::uniform_int_distribution<int> dist(subset_min_size, subset_max_size);
+  // Return a subset, which size is in between [subset_min_size; subset_max_size], of shuffled range
+  // {1, 9, 13, 19, 86, 36}, for example
+  return std::vector<Vertex_handle> {range.begin(), range.begin() + dist(rd)};
+}
+
+int main(int argc, char *argv[]) {
+  int nb_vertices = 100000;
+  if (argc > 2) {
+    std::cerr << "Error: Number of arguments (" << argc << ") is not correct\n";
+    std::cerr << "Usage: " << (argv[0] - 1) << " [NB_VERTICES] \n";
+    std::cerr << "    NB_VERTICES is 5.000 by default.\n";
+    exit(EXIT_FAILURE);  // ----- >>
+  }
+  if (argc == 2)
+    nb_vertices = atoi(argv[1]);
+
+  using Simplex_tree = Gudhi::Simplex_tree<>;
+  using Vertex_handle  = typename Simplex_tree::Vertex_handle;
+
+  std::clog << "... Simplex_tree construction\n";
+
+  Simplex_tree st;
+  // Insert 'nb_vertices' random simplices, of size in between [2; 5] and vertices in between [0; nb_vertices]
+  for (Vertex_handle v=0; v < nb_vertices; v++)
+    st.insert_simplex_and_subfaces(rand_int_range<Vertex_handle>(2, 5, nb_vertices));
+  std::clog << "... " << st.num_vertices() << " vertices and " << st.num_simplices()
+            << " simplices. Dimension is " << st.dimension() << "\n";
+
+  for (int dim = 0; dim < 7; dim++) {
+    std::clog << "... benchmark for dimension " << dim << "\n";
+    int count = 0;
+    Gudhi::Clock benchmark_skeleton_exact("Benchmark the skeleton range but with the exact dim test");
+    for(auto sh : st.skeleton_simplex_range(dim)) {
+      // Get only the simplices with the exact dimension
+      if (st.dimension(sh) == dim)
+        ++count;
+    }
+    std::clog << benchmark_skeleton_exact << " - count = " << count << "\n";
+
+    count = 0;
+    Gudhi::Clock benchmark_dimension("Benchmark the dimension range");
+    for([[maybe_unused]] auto sh : st.dimension_simplex_range(dim)) {
+      ++count;
+    }
+    std::clog << benchmark_dimension << " - count = " << count << "\n";
+  }
+  return EXIT_SUCCESS;
+}

--- a/src/Simplex_tree/include/gudhi/Simplex_tree.h
+++ b/src/Simplex_tree/include/gudhi/Simplex_tree.h
@@ -309,6 +309,12 @@ class Simplex_tree {
   /** \brief Range over the simplices of the skeleton of the simplicial complex, for a given
    * dimension. */
   typedef boost::iterator_range<Skeleton_simplex_iterator> Skeleton_simplex_range;
+  /** \brief Iterator over the simplices of the simplicial complex that match the dimension specified by the parameter.
+   *
+   * 'value_type' is Simplex_handle. */
+  typedef Simplex_tree_dimension_simplex_iterator<Simplex_tree> Dimension_simplex_iterator;
+  /** \brief Range over the simplices of the simplicial complex that match a given dimension. */
+  typedef boost::iterator_range<Dimension_simplex_iterator> Dimension_simplex_range;
   /** \brief Range over the simplices of the simplicial complex, ordered by the filtration. */
   typedef std::vector<Simplex_handle> Filtration_simplex_range;
   /** \brief Iterator over the simplices of the simplicial complex, ordered by the filtration.
@@ -349,6 +355,18 @@ class Simplex_tree {
   Skeleton_simplex_range skeleton_simplex_range(int dim) const {
     return Skeleton_simplex_range(Skeleton_simplex_iterator(this, dim),
                                   Skeleton_simplex_iterator());
+  }
+
+  /** \brief Returns a range over the simplices the simplicial complex that match the dimension specified by the
+   * parameter.
+   *
+   * @param[in] dim The exact dimension of the simplices.
+   *
+   * The simplices are ordered according to lexicographic order on the list of
+   * Vertex_handles of a simplex, read in increasing < order for Vertex_handles. */
+  Dimension_simplex_range dimension_simplex_range(int dim) const {
+    return Dimension_simplex_range(Dimension_simplex_iterator(this, dim),
+                                   Dimension_simplex_iterator());
   }
 
   /** \brief Returns a range over the simplices of the simplicial complex,
@@ -978,7 +996,7 @@ class Simplex_tree {
   /**
    * @brief Inserts a Node in the set of siblings nodes. Calls `update_simplex_tree_after_node_insertion`
    * if the insertion succeeded.
-   * 
+   *
    * @tparam update_fil If true, as well as Options::store_filtration, and the node is already present, assigns
    * the "union" of the input filtration_value and the value already present in the node as filtration value.
    * @tparam update_children If true and the node has no children, create a child with sib as uncle.
@@ -1305,7 +1323,7 @@ class Simplex_tree {
    *
    * Any insertion, deletion or change of filtration value invalidates this cache,
    * which can be cleared with @ref clear_filtration().
-   * 
+   *
    * @tparam Comparator Method type taking two Simplex_handle as input and returns a bool.
    * @tparam Ignorer Method type taking one Simplex_handle as input and returns a bool.
    * @param is_before_in_filtration Method used to compare two simplices with respect to their position in the
@@ -2369,12 +2387,12 @@ class Simplex_tree {
   };
 
   //TODO: externalize this method and `decode_extended_filtration`
-  /** \brief Extend filtration for computing extended persistence. 
-   * This function only uses the filtration values at the 0-dimensional simplices, 
-   * and computes the extended persistence diagram induced by the lower-star filtration 
-   * computed with these values. 
-   * \post Note that after calling this function, the filtration 
-   * values are actually modified. The function `decode_extended_filtration()` 
+  /** \brief Extend filtration for computing extended persistence.
+   * This function only uses the filtration values at the 0-dimensional simplices,
+   * and computes the extended persistence diagram induced by the lower-star filtration
+   * computed with these values.
+   * \post Note that after calling this function, the filtration
+   * values are actually modified. The function `decode_extended_filtration()`
    * retrieves the original values and outputs the extended simplex type.
    *
    * @warning Currently only works for @ref SimplexTreeOptions::Filtration_value which are
@@ -2648,7 +2666,7 @@ class Simplex_tree {
 
   std::size_t num_simplices_and_filtration_serialization_size(Siblings const* sib, std::size_t& fv_byte_size) const {
     using namespace Gudhi::simplex_tree;
-    
+
     auto sib_begin = sib->members().begin();
     auto sib_end = sib->members().end();
     size_t simplices_number = sib->members().size();
@@ -2778,7 +2796,7 @@ class Simplex_tree {
    * @private
    * @brief Deserialize the array of char (flattened version of the tree) to initialize a Simplex tree.
    * It is the user's responsibility to provide an 'empty' Simplex_tree, there is no guarantee otherwise.
-   * 
+   *
    * @tparam F Method taking a reference to a @ref Filtration_value and a `const char*` as input and returning a
    * `const char*`.
    * @param[in] buffer A pointer on a buffer that contains a serialized Simplex_tree.
@@ -2788,13 +2806,13 @@ class Simplex_tree {
    * (second argument) the serialized filtration value and turn it into an object of type @ref Filtration_value that is
    * stored in the first argument of the method. It then returns the new position of the buffer pointer after the
    * reading.
-   * 
+   *
    * @exception std::invalid_argument In case the deserialization does not finish at the correct buffer_size.
    * @exception std::logic_error In debug mode, if the Simplex_tree is not 'empty'.
-   * 
+   *
    * @warning Serialize/Deserialize is not portable. It is meant to be read in a Simplex_tree with the same
    * SimplexTreeOptions (except for the @ref Filtration_value type) and on a computer with the same architecture.
-   * 
+   *
    */
   template <class F>
   void deserialize(const char* buffer, const std::size_t buffer_size, F&& deserialize_filtration_value) {

--- a/src/Simplex_tree/include/gudhi/Simplex_tree.h
+++ b/src/Simplex_tree/include/gudhi/Simplex_tree.h
@@ -357,7 +357,7 @@ class Simplex_tree {
                                   Skeleton_simplex_iterator());
   }
 
-  /** \brief Returns a range over the simplices the simplicial complex that match the dimension specified by the
+  /** \brief Returns a range over the simplices of the simplicial complex that match the dimension specified by the
    * parameter.
    *
    * @param[in] dim The exact dimension of the simplices.

--- a/src/Simplex_tree/include/gudhi/Simplex_tree/Simplex_tree_iterators.h
+++ b/src/Simplex_tree/include/gudhi/Simplex_tree/Simplex_tree_iterators.h
@@ -509,7 +509,7 @@ class Simplex_tree_dimension_simplex_iterator : public boost::iterator_facade<
     return sh_;
   }
 
-  inline void until_leaf_or_dim() {
+  void until_leaf_or_dim() {
     while (st_->has_children(sh_) && curr_dim_ != dim_) {
       sib_ = sh_->second.children();
       sh_ = sib_->members().begin();

--- a/src/Simplex_tree/include/gudhi/Simplex_tree/Simplex_tree_iterators.h
+++ b/src/Simplex_tree/include/gudhi/Simplex_tree/Simplex_tree_iterators.h
@@ -480,7 +480,8 @@ class Simplex_tree_dimension_simplex_iterator : public boost::iterator_facade<
         st_(st),
         dim_(dim),
         curr_dim_(0) {
-    if (st == nullptr || st->root() == nullptr || st->root()->members().empty() || st->upper_bound_dimension() < dim) {
+    if (st == nullptr || st->root() == nullptr || st->root()->members().empty() ||
+        st->upper_bound_dimension() < dim || dim < 0) {
       st_ = nullptr;
     } else {
       sh_ = st->root()->members().begin();

--- a/src/Simplex_tree/include/gudhi/Simplex_tree/Simplex_tree_iterators.h
+++ b/src/Simplex_tree/include/gudhi/Simplex_tree/Simplex_tree_iterators.h
@@ -439,6 +439,7 @@ class Simplex_tree_skeleton_simplex_iterator : public boost::iterator_facade<
       sh_ = sib_->oncles()->members().find(sib_->parent());
       sib_ = sib_->oncles();
       --curr_dim_;
+      return;
     }
     while (st_->has_children(sh_) && curr_dim_ < dim_skel_) {
       sib_ = sh_->second.children();

--- a/src/Simplex_tree/include/gudhi/Simplex_tree/Simplex_tree_iterators.h
+++ b/src/Simplex_tree/include/gudhi/Simplex_tree/Simplex_tree_iterators.h
@@ -20,7 +20,7 @@
 
 namespace Gudhi {
 
-/** \addtogroup simplex_tree 
+/** \addtogroup simplex_tree
  * Iterators and range types for the Simplex_tree.
  *  @{
  */
@@ -439,7 +439,6 @@ class Simplex_tree_skeleton_simplex_iterator : public boost::iterator_facade<
       sh_ = sib_->oncles()->members().find(sib_->parent());
       sib_ = sib_->oncles();
       --curr_dim_;
-      return;
     }
     while (st_->has_children(sh_) && curr_dim_ < dim_skel_) {
       sib_ = sh_->second.children();
@@ -452,6 +451,104 @@ class Simplex_tree_skeleton_simplex_iterator : public boost::iterator_facade<
   Siblings const* sib_;
   SimplexTree const* st_;
   int dim_skel_;
+  int curr_dim_;
+};
+
+/** \brief Iterator over the simplices of the simplicial complex that match the dimension specified by the parameter.
+ *
+ * Forward iterator, value_type is SimplexTree::Simplex_handle.*/
+template<class SimplexTree>
+class Simplex_tree_dimension_simplex_iterator : public boost::iterator_facade<
+    Simplex_tree_dimension_simplex_iterator<SimplexTree>,
+    typename SimplexTree::Simplex_handle const, boost::forward_traversal_tag> {
+ public:
+  typedef typename SimplexTree::Simplex_handle Simplex_handle;
+  typedef typename SimplexTree::Siblings Siblings;
+  typedef typename SimplexTree::Vertex_handle Vertex_handle;
+
+// any end() iterator
+  Simplex_tree_dimension_simplex_iterator()
+      : sib_(nullptr),
+        st_(nullptr),
+        dim_(0),
+        curr_dim_(0) {
+  }
+
+  Simplex_tree_dimension_simplex_iterator(SimplexTree const* st, int dim)
+      : sib_(nullptr),
+        st_(st),
+        dim_(dim),
+        curr_dim_(0) {
+    if (st == nullptr || st->root() == nullptr || st->root()->members().empty()) {
+      st_ = nullptr;
+    } else {
+      sh_ = st->root()->members().begin();
+      sib_ = st->root();
+      until_leaf_or_dim();
+    }
+    if (curr_dim_ != dim_) {
+      // we reached a leaf that does not respect the required dimension - call increment
+      increment();
+    }
+  }
+ private:
+  friend class boost::iterator_core_access;
+
+// valid when iterating along the SAME boundary.
+  bool equal(Simplex_tree_dimension_simplex_iterator const& other) const {
+    if (other.st_ == nullptr) {
+      return (st_ == nullptr);
+    }
+    if (st_ == nullptr) {
+      return false;
+    }
+    return (&(sh_->second) == &(other.sh_->second));
+  }
+
+  Simplex_handle const& dereference() const {
+    return sh_;
+  }
+
+  void until_leaf_or_dim() {
+    while (st_->has_children(sh_) && curr_dim_ != dim_) {
+      sib_ = sh_->second.children();
+      sh_ = sib_->members().begin();
+      ++curr_dim_;
+    }
+#ifdef DEBUG_TRACES
+    std::clog << "Simplex_tree::dimension_simplex_range until_leaf_or_dim reached (";
+    for (auto vertex : st_->simplex_vertex_range(sh_)) {
+      std::clog << vertex << ",";
+    }
+    std::clog << ")\n";
+#endif  // DEBUG_TRACES
+  }
+  // Depth first traversal of the skeleton.
+  void increment() {
+    ++sh_;
+    while (sh_ == sib_->members().end()) {
+      if (sib_->oncles() == nullptr) {
+        st_ = nullptr;
+        return;
+      }  // reach the end
+      sh_ = sib_->oncles()->members().find(sib_->parent());
+      sib_ = sib_->oncles();
+      --curr_dim_;
+      ++sh_;
+      until_leaf_or_dim();
+    }
+    // It seems we do it twice here, but necessary when coming from the constructor
+    until_leaf_or_dim();
+    if (curr_dim_ != dim_) {
+      // we reached a leaf that does not respect the dimension - recall increment
+      increment();
+    }
+  }
+
+  Simplex_handle sh_;
+  Siblings const* sib_;
+  SimplexTree const* st_;
+  int dim_;
   int curr_dim_;
 };
 

--- a/src/Simplex_tree/include/gudhi/Simplex_tree/Simplex_tree_iterators.h
+++ b/src/Simplex_tree/include/gudhi/Simplex_tree/Simplex_tree_iterators.h
@@ -480,7 +480,7 @@ class Simplex_tree_dimension_simplex_iterator : public boost::iterator_facade<
         st_(st),
         dim_(dim),
         curr_dim_(0) {
-    if (st == nullptr || st->root() == nullptr || st->root()->members().empty() || st->dimension() < dim) {
+    if (st == nullptr || st->root() == nullptr || st->root()->members().empty() || st->upper_bound_dimension() < dim) {
       st_ = nullptr;
     } else {
       sh_ = st->root()->members().begin();

--- a/src/Simplex_tree/include/gudhi/Simplex_tree/Simplex_tree_iterators.h
+++ b/src/Simplex_tree/include/gudhi/Simplex_tree/Simplex_tree_iterators.h
@@ -480,16 +480,15 @@ class Simplex_tree_dimension_simplex_iterator : public boost::iterator_facade<
         st_(st),
         dim_(dim),
         curr_dim_(0) {
-    if (st == nullptr || st->root() == nullptr || st->root()->members().empty()) {
+    if (st == nullptr || st->root() == nullptr || st->root()->members().empty() || st->dimension() < dim) {
       st_ = nullptr;
     } else {
       sh_ = st->root()->members().begin();
       sib_ = st->root();
       until_leaf_or_dim();
-    }
-    if (curr_dim_ != dim_) {
-      // we reached a leaf that does not respect the required dimension - call increment
-      increment();
+      // if we reached a leaf that does not respect the required dimension - call increment
+      if (curr_dim_ != dim_)
+        increment();
     }
   }
  private:
@@ -510,7 +509,7 @@ class Simplex_tree_dimension_simplex_iterator : public boost::iterator_facade<
     return sh_;
   }
 
-  void until_leaf_or_dim() {
+  inline void until_leaf_or_dim() {
     while (st_->has_children(sh_) && curr_dim_ != dim_) {
       sib_ = sh_->second.children();
       sh_ = sib_->members().begin();
@@ -524,7 +523,7 @@ class Simplex_tree_dimension_simplex_iterator : public boost::iterator_facade<
     std::clog << ")\n";
 #endif  // DEBUG_TRACES
   }
-  // Depth first traversal of the skeleton.
+  // Depth first traversal of the tree structure. Returns when reaching a simplex with a given dimension
   void increment() {
     ++sh_;
     while (sh_ == sib_->members().end()) {
@@ -540,10 +539,9 @@ class Simplex_tree_dimension_simplex_iterator : public boost::iterator_facade<
     }
     // It seems we do it twice here, but necessary when coming from the constructor
     until_leaf_or_dim();
-    if (curr_dim_ != dim_) {
-      // we reached a leaf that does not respect the dimension - recall increment
+    // if we reached a leaf that does not respect the dimension - recall increment
+    if (curr_dim_ != dim_)
       increment();
-    }
   }
 
   Simplex_handle sh_;

--- a/src/Simplex_tree/test/simplex_tree_constness_unit_test.cpp
+++ b/src/Simplex_tree/test/simplex_tree_constness_unit_test.cpp
@@ -67,6 +67,13 @@ void test_simplex_tree_constness(const Simplex_tree& const_stree) {
     for (auto vertex : const_stree.simplex_vertex_range(sh)) std::clog << "(" << vertex << ")";
     std::clog << std::endl;
   }
+  std::clog << "* dimension_simplex_range in dim " << const_stree.dimension() << "\n";
+  for (auto sh : const_stree.dimension_simplex_range(const_stree.dimension())) {
+    std::clog << "   "
+              << "[" << const_stree.filtration(sh) << "] ";
+    for (auto vertex : const_stree.simplex_vertex_range(sh)) std::clog << "(" << vertex << ")";
+    std::clog << std::endl;
+  }
   std::clog << "* star_simplex_range of {0, 1, 6}\n";
   for (auto sh : const_stree.star_simplex_range(const_stree.find({0, 1, 6}))) {
     std::clog << "   "

--- a/src/Simplex_tree/test/simplex_tree_unit_test.cpp
+++ b/src/Simplex_tree/test/simplex_tree_unit_test.cpp
@@ -1229,3 +1229,48 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(for_each_simplex_skip_iteration, typeST, list_of_t
   BOOST_CHECK(num_simplices_by_dim_until_two[0] == num_simplices_by_dim[0]);
   BOOST_CHECK(num_simplices_by_dim_until_two[1] == num_simplices_by_dim[1]);
 }
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(simplex_tree_dimension_vertex_iterator, typeST, list_of_tested_variants) {
+  std::clog << "********************************************************************" << std::endl;
+  std::clog << "TEST OF DIMENSION VERTEX ITERATORS" << std::endl;
+  typeST st;
+
+  st.insert_simplex_and_subfaces({0});
+  st.insert_simplex_and_subfaces({1,2});
+  st.insert_simplex_and_subfaces({2,3,4});
+  st.insert_simplex_and_subfaces({5,6,7,8});
+  st.insert_simplex_and_subfaces({9});
+
+  for(int dim = 0; dim < 5; dim++) {
+    using Simplex = std::vector<typename typeST::Vertex_handle>;
+    std::vector<Simplex> skeleton_simplices;
+    for(auto sh : st.skeleton_simplex_range(dim)) {
+      // Get only the simplices with the exact dimension
+      if (st.dimension(sh) == dim) {
+        Simplex output;
+        std::clog << "skeleton_simplex_range (";
+        for (auto vertex : st.simplex_vertex_range(sh)) {
+          std::clog << vertex << ", ";
+          output.emplace_back(vertex);
+        }
+        skeleton_simplices.emplace_back(output);
+        std::clog << ")\n";
+      }
+    }
+
+    std::vector<Simplex> dimension_simplices;
+    for(auto sh : st.dimension_simplex_range(dim)) {
+      BOOST_CHECK(st.dimension(sh) == dim);
+      Simplex output;
+      std::clog << "dimension_simplex_range (";
+      for (auto vertex : st.simplex_vertex_range(sh)) {
+        std::clog << vertex << ", ";
+        output.emplace_back(vertex);
+      }
+      dimension_simplices.emplace_back(output);
+      std::clog << ")\n";
+    }
+    // Order is important, but should be guaranteed by construction
+    BOOST_CHECK(dimension_simplices == skeleton_simplices);
+  }
+}

--- a/src/Simplex_tree/test/simplex_tree_unit_test.cpp
+++ b/src/Simplex_tree/test/simplex_tree_unit_test.cpp
@@ -1275,3 +1275,16 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(simplex_tree_dimension_vertex_iterator, typeST, li
     BOOST_CHECK(dimension_simplices == skeleton_simplices);
   }
 }
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(empty_simplex_tree_dimension_vertex_iterator, typeST, list_of_tested_variants) {
+  std::clog << "********************************************************************\n";
+  std::clog << "TEST OF DIMENSION VERTEX ITERATORS ON AN EMPTY SIMPLEX TREE\n";
+  typeST st;
+
+  for(int dim = -1; dim <= 1; dim++) {
+    std::clog << " - For dimension = " << dim << "\n";
+    for([[maybe_unused]] auto sh : st.dimension_simplex_range(dim)) {
+      BOOST_CHECK(false);  // Shall not happen
+    }
+  }
+}

--- a/src/Simplex_tree/test/simplex_tree_unit_test.cpp
+++ b/src/Simplex_tree/test/simplex_tree_unit_test.cpp
@@ -1231,8 +1231,8 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(for_each_simplex_skip_iteration, typeST, list_of_t
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(simplex_tree_dimension_vertex_iterator, typeST, list_of_tested_variants) {
-  std::clog << "********************************************************************" << std::endl;
-  std::clog << "TEST OF DIMENSION VERTEX ITERATORS" << std::endl;
+  std::clog << "********************************************************************\n";
+  std::clog << "TEST OF DIMENSION VERTEX ITERATORS\n";
   typeST st;
 
   st.insert_simplex_and_subfaces({0});
@@ -1241,7 +1241,8 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(simplex_tree_dimension_vertex_iterator, typeST, li
   st.insert_simplex_and_subfaces({5,6,7,8});
   st.insert_simplex_and_subfaces({9});
 
-  for(int dim = 0; dim < 5; dim++) {
+  for(int dim = 0; dim < 6; dim++) {
+    std::clog << " - For dimension = " << dim << "\n";
     using Simplex = std::vector<typename typeST::Vertex_handle>;
     std::vector<Simplex> skeleton_simplices;
     for(auto sh : st.skeleton_simplex_range(dim)) {


### PR DESCRIPTION
* Fix #183 
* Use it in Alpha complex and some unitary tests

TBD: python interfaces

### Bench results
```txt
$ ./simplex_tree_dimension_simplex_range_benchmark
... Simplex_tree construction
... 96951 vertices and 1147249 simplices. Dimension is 4
... benchmark for dimension 0
Benchmark the skeleton range but with the exact dim test: 0.001s
 - count = 96951
Benchmark the dimension range: 0s
 - count = 96951
... benchmark for dimension 1
Benchmark the skeleton range but with the exact dim test: 0.023s
 - count = 500280
Benchmark the dimension range: 0.018s
 - count = 500280
... benchmark for dimension 2
Benchmark the skeleton range but with the exact dim test: 0.037s
 - count = 375156
Benchmark the dimension range: 0.034s
 - count = 375156
... benchmark for dimension 3
Benchmark the skeleton range but with the exact dim test: 0.042s
 - count = 149923
Benchmark the dimension range: 0.037s
 - count = 149923
... benchmark for dimension 4
Benchmark the skeleton range but with the exact dim test: 0.042s
 - count = 24939
Benchmark the dimension range: 0.038s
 - count = 24939
... benchmark for dimension 5
Benchmark the skeleton range but with the exact dim test: 0.043s
 - count = 0
Benchmark the dimension range: 0s
 - count = 0
... benchmark for dimension 6
Benchmark the skeleton range but with the exact dim test: 0.042s
 - count = 0
Benchmark the dimension range: 0s
 - count = 0
```