### PR TITLE
[CI] Upload python doc before launching tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,14 +100,11 @@ jobs:
             cd version
             cmake -DCMAKE_BUILD_TYPE=Release -DWITH_GUDHI_EXAMPLE=OFF -DWITH_GUDHI_UTILITIES=OFF -DWITH_GUDHI_PYTHON=ON -DWITH_GUDHI_REMOTE_TEST=ON .
             cd python
-            python setup.py build_ext --inplace
-            ctest --output-on-failure
             make sphinx
             cp -R sphinx /tmp/sphinx
-            python setup.py install
-            python setup.py clean --all
             python -B -m pytest test/*.py --cov-report html --cov=gudhi
             cp -R htmlcov /tmp/htmlcov
+            ctest --output-on-failure -E test_
       - store_artifacts:
           path: /tmp/sphinx
           destination: sphinx


### PR DESCRIPTION
Sometimes tests are failing (CI ram limit is reached, fetch_openml fails, ...).
It would be nice to have documentation available when this happens.