### PR TITLE
windows-latest is windows-2022 but is going to be deprecated. Test windows-2025

### DIFF
--- a/.github/workflows/pip-build-windows.yml
+++ b/.github/workflows/pip-build-windows.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   build:
-    runs-on: windows-latest
+    runs-on: windows-2025
     strategy:
       max-parallel: 4
       matrix:


### PR DESCRIPTION
This change will be rolled out over a period of several weeks beginning September 2, 2025 and will complete by September 30, 2025.    

During this period your workflows will gradually switch over to the new image, once they are migrated they will not run on Windows Server 2022 in any future runs.    
