### PR TITLE
Try to fix this matplotlib issue

### DIFF
--- a/src/python/test/test_persistence_graphical_tools.py
+++ b/src/python/test/test_persistence_graphical_tools.py
@@ -16,6 +16,9 @@ import warnings
 
 import gudhi as gd
 
+# Workaround - On CI, sometimes Tcl/Tk is not well installed, use Agg backend instead of default TkAgg
+# Thus, mplt.show() is not available
+mplt.use('Agg')
 
 def test_array_handler():
     diags = np.array([[1, 2], [3, 4], [5, 6]], float)


### PR DESCRIPTION
The issue was:
```
>       self.tk = _tkinter.create(screenName, baseName, className, interactive, wantobjects, useTk, sync, use)
E       _tkinter.TclError: Can't find a usable init.tcl in the following directories: 
E           {C:\hostedtoolcache\windows\Python\3.9.13\x64\tcl\tcl8.6}
E       
E       C:/hostedtoolcache/windows/Python/3.9.13/x64/tcl/tcl8.6/init.tcl: couldn't read file "C:/hostedtoolcache/windows/Python/3.9.13/x64/tcl/tcl8.6/init.tcl": No error
E       couldn't read file "C:/hostedtoolcache/windows/Python/3.9.13/x64/tcl/tcl8.6/init.tcl": No error
E           while executing
E       "source C:/hostedtoolcache/windows/Python/3.9.13/x64/tcl/tcl8.6/init.tcl"
E           ("uplevel" body line 1)
E           invoked from within
E       "uplevel #0 [list source $tclfile]"
E       
E       
E       This probably means that Tcl wasn't installed properly.

C:\hostedtoolcache\windows\Python\3.9.13\x64\lib\tkinter\__init__.py:2270: TclError
============================== warnings summary ===============================
src/python/test/test_persistence_graphical_tools.py::test_limit_plot_persistence
  D:\a\1\s\build\src\python\gudhi\persistence_graphical_tools.py:128: UserWarning: usetex mode requires TeX.
    warnings.warn("usetex mode requires TeX.")

src/python/test/test_persistence_graphical_tools.py: 112 warnings
  C:\hostedtoolcache\windows\Python\3.9.13\x64\lib\site-packages\matplotlib\backends\_backend_tk.py:754: DeprecationWarning: 'mode' parameter is deprecated and will be removed in Pillow 13 (2026-10-15)
    return Image.fromarray(image_data, mode="RGBA")

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html

```