### PR TITLE
Try macos-14 to build universal pip packages

### DIFF
--- a/.github/next_release.md
+++ b/.github/next_release.md
@@ -27,7 +27,8 @@ Below is a list of changes:
 
 - Installation
      - Pip package is now available for OSx &ge; 13.0 (was &ge; 12.0).
-
+     - Support Eigen 3.4.1 and 5.X.X
+     
 - Miscellaneous
      - The [list of bugs that were solved](https://github.com/GUDHI/gudhi-devel/issues?q=label%3A3.12.0+is%3Aclosed) is available on GitHub.
 

--- a/.github/workflows/pip-build-osx.yml
+++ b/.github/workflows/pip-build-osx.yml
@@ -3,21 +3,21 @@ name: pip build osx
 on: [push, pull_request]
 
 env:
-  MACOSX_DEPLOYMENT_TARGET: 13.0
-  _PYTHON_HOST_PLATFORM: macosx-13.0-universal2
+  MACOSX_DEPLOYMENT_TARGET: 14.0
+  _PYTHON_HOST_PLATFORM: macosx-14.0-universal2
   ARCHFLAGS: "-arch arm64 -arch x86_64"
 
 jobs:
   build:
-    # Should use macos-latest, but python 3.9 is no more available from macos-14
-    runs-on: macos-13
+    # Python 3.11+ is only available for MacOS free version cf. https://github.com/actions/runner-images
+    runs-on: macos-14
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ["3.9"]
+        python-version: ["3.11"]
         include:
-          - python-version: "3.9"
-            numpy-version: "1.21.4"
+          - python-version: "3.11"
+            numpy-version: "1.23.2"
     name: Build wheels for Python ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/pip-packaging-osx.yml
+++ b/.github/workflows/pip-packaging-osx.yml
@@ -1,29 +1,26 @@
 name: pip packaging osx
 
-on:
-  release:
-    types: [published]
+# on:
+#   release:
+#     types: [published]
+on: [push, pull_request]
 
 env:
-  MACOSX_DEPLOYMENT_TARGET: 13.0
-  _PYTHON_HOST_PLATFORM: macosx-13.0-universal2
+  MACOSX_DEPLOYMENT_TARGET: 14.0
+  _PYTHON_HOST_PLATFORM: macosx-14.0-universal2
   ARCHFLAGS: "-arch arm64 -arch x86_64"
 
 jobs:
   # Python 3.9+ specific case where NumPy 2.x will be supported
   # NumPy packages for osx x86 and arm are only available from 1.21.2, but stable for both versions from 1.21.4 and python 3.9+
   wheels:
-    # Should use macos-latest, but python 3.9 is no more available from macos-14
-    runs-on: macos-13
+    # Python 3.11+ is only available for MacOS free version cf. https://github.com/actions/runner-images
+    runs-on: macos-14
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.12", "3.13"]
         include:
-          - python-version: "3.9"
-            numpy-version: "1.21.4"
-          - python-version: "3.10"
-            numpy-version: "1.21.6"
           - python-version: "3.11"
             numpy-version: "1.23.2"
           - python-version: "3.12"
@@ -99,9 +96,14 @@ jobs:
           python -m pytest src/python/test/test_wasserstein_barycenter.py
           python -m pytest src/python/test/test_weighted_rips_complex.py
           python -m pytest src/python/test/test_witness_complex.py
-      - name: Publish on PyPi
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-        run: |
-          python -m twine upload wheelhouse/*.whl
+      - name: Upload OSx python wheel
+        uses: actions/upload-artifact@v4
+        with:
+          name: osx python wheel
+          path: wheelhouse/*.whl
+#      - name: Publish on PyPi
+#        env:
+#          TWINE_USERNAME: __token__
+#          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+#        run: |
+#          python -m twine upload wheelhouse/*.whl

--- a/.github/workflows/pip-packaging-osx.yml
+++ b/.github/workflows/pip-packaging-osx.yml
@@ -1,9 +1,8 @@
 name: pip packaging osx
 
-# on:
-#   release:
-#     types: [published]
-on: [push, pull_request]
+on:
+  release:
+    types: [published]
 
 env:
   MACOSX_DEPLOYMENT_TARGET: 14.0
@@ -96,14 +95,9 @@ jobs:
           python -m pytest src/python/test/test_wasserstein_barycenter.py
           python -m pytest src/python/test/test_weighted_rips_complex.py
           python -m pytest src/python/test/test_witness_complex.py
-      - name: Upload OSx python wheel
-        uses: actions/upload-artifact@v4
-        with:
-          name: osx python wheel
-          path: wheelhouse/*.whl
-#      - name: Publish on PyPi
-#        env:
-#          TWINE_USERNAME: __token__
-#          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-#        run: |
-#          python -m twine upload wheelhouse/*.whl
+      - name: Publish on PyPi
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        run: |
+          python -m twine upload wheelhouse/*.whl

--- a/.github/workflows/pip-packaging-osx.yml
+++ b/.github/workflows/pip-packaging-osx.yml
@@ -10,8 +10,7 @@ env:
   ARCHFLAGS: "-arch arm64 -arch x86_64"
 
 jobs:
-  # Python 3.9+ specific case where NumPy 2.x will be supported
-  # NumPy packages for osx x86 and arm are only available from 1.21.2, but stable for both versions from 1.21.4 and python 3.9+
+  # Build with minimal supported version of NumPy 1.X with ABI compatibility feature
   wheels:
     # Python 3.11+ is only available for MacOS free version cf. https://github.com/actions/runner-images
     runs-on: macos-14
@@ -35,7 +34,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           architecture: x64
-      # For python>=3.9, numpy>=2.0 for package build and ABI compatibility with numpy 1.X and 2.X
+      # For python>=3.11, numpy>=2.0 for package build and ABI compatibility with numpy 1.X and 2.X
       # cf. https://numpy.org/doc/stable/dev/depending_on_numpy.html#numpy-2-0-specific-advice
       - name: Install dependencies
         run: |

--- a/src/cmake/modules/GUDHI_third_party_libraries.cmake
+++ b/src/cmake/modules/GUDHI_third_party_libraries.cmake
@@ -41,8 +41,12 @@ endif()
 if(TARGET Eigen3::Eigen)
     # Not mandatory as it is set by Eigen3Config.cmake
     get_target_property(EIGEN3_INCLUDE_DIRS Eigen3::Eigen INTERFACE_INCLUDE_DIRECTORIES)
-    # EIGEN_VERSION_STRING for Eigen 5.X, and EIGEN3_VERSION_STRING otherwise
-    message("++ Eigen 3 version ${EIGEN3_VERSION_STRING}${EIGEN_VERSION_STRING}. Includes found in ${EIGEN3_INCLUDE_DIRS}")
+    # Eigen3_VERSION for Eigen 5.X, and EIGEN3_VERSION_STRING otherwise
+    # EIGEN3_VERSION_STRING also used by src/python/CMakeLists.txt
+    if(NOT EIGEN3_VERSION_STRING)
+      set(EIGEN3_VERSION_STRING ${Eigen3_VERSION})
+    endif()
+    message("++ Eigen 3 version ${EIGEN3_VERSION_STRING}. Includes found in ${EIGEN3_INCLUDE_DIRS}")
 endif()
 
 option(WITH_GUDHI_USE_TBB "Build with Intel TBB parallelization" ON)

--- a/src/cmake/modules/GUDHI_third_party_libraries.cmake
+++ b/src/cmake/modules/GUDHI_third_party_libraries.cmake
@@ -34,7 +34,7 @@ if (TARGET CGAL::CGAL)
 endif ()
 
 find_package(Eigen3 3.3 NO_MODULE)
-if(TARGET Eigen3::Eigen)
+if(NOT TARGET Eigen3::Eigen)
   find_package(Eigen3 5.0 NO_MODULE)
 endif()
 

--- a/src/cmake/modules/GUDHI_third_party_libraries.cmake
+++ b/src/cmake/modules/GUDHI_third_party_libraries.cmake
@@ -35,6 +35,10 @@ endif ()
 
 find_package(Eigen3 3.3 NO_MODULE)
 if(TARGET Eigen3::Eigen)
+  find_package(Eigen3 5.0 NO_MODULE)
+endif()
+
+if(TARGET Eigen3::Eigen)
     # Not mandatory as it is set by Eigen3Config.cmake
     get_target_property(EIGEN3_INCLUDE_DIRS Eigen3::Eigen INTERFACE_INCLUDE_DIRECTORIES)
     message("++ Eigen 3 version ${EIGEN3_VERSION_STRING}. Includes found in ${EIGEN3_INCLUDE_DIRS}")

--- a/src/cmake/modules/GUDHI_third_party_libraries.cmake
+++ b/src/cmake/modules/GUDHI_third_party_libraries.cmake
@@ -33,9 +33,9 @@ if (TARGET CGAL::CGAL)
     message("++ CGAL version: ${CGAL_VERSION}. Includes found in ${CGAL_INCLUDE_DIRS}")
 endif ()
 
-find_package(Eigen3 3.3 NO_MODULE)
+find_package(Eigen3 5.0 QUIET NO_MODULE)
 if(NOT TARGET Eigen3::Eigen)
-  find_package(Eigen3 5.0 NO_MODULE)
+  find_package(Eigen3 3.3 NO_MODULE)
 endif()
 
 if(TARGET Eigen3::Eigen)

--- a/src/cmake/modules/GUDHI_third_party_libraries.cmake
+++ b/src/cmake/modules/GUDHI_third_party_libraries.cmake
@@ -41,7 +41,8 @@ endif()
 if(TARGET Eigen3::Eigen)
     # Not mandatory as it is set by Eigen3Config.cmake
     get_target_property(EIGEN3_INCLUDE_DIRS Eigen3::Eigen INTERFACE_INCLUDE_DIRECTORIES)
-    message("++ Eigen 3 version ${EIGEN3_VERSION_STRING}. Includes found in ${EIGEN3_INCLUDE_DIRS}")
+    # EIGEN_VERSION_STRING for Eigen 5.X, and EIGEN3_VERSION_STRING otherwise
+    message("++ Eigen 3 version ${EIGEN3_VERSION_STRING}${EIGEN_VERSION_STRING}. Includes found in ${EIGEN3_INCLUDE_DIRS}")
 endif()
 
 option(WITH_GUDHI_USE_TBB "Build with Intel TBB parallelization" ON)


### PR DESCRIPTION
Fix #1256 

... But we lose support for Python 3.9 and 3.10

Also fix https://github.com/GUDHI/gudhi-devel/issues/1260 (required by macos14 where brew install Eigen 5.0.0)