### PR TITLE
Use CMake version ranges to support Eigen versions from 3.3 up to 5.X.X

### DIFF
--- a/.github/next_release.md
+++ b/.github/next_release.md
@@ -27,6 +27,8 @@ Below is a list of changes:
 
 - Installation
      - Pip package is now available for OSx &ge; 13.0 (was &ge; 12.0).
+     - CMake minimal version is now 3.19
+     - Support Eigen 3.4.1 and 5.X.X
 
 - Miscellaneous
      - The [list of bugs that were solved](https://github.com/GUDHI/gudhi-devel/issues?q=label%3A3.12.0+is%3Aclosed) is available on GitHub.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15)
+cmake_minimum_required(VERSION 3.19)
 
 project(GUDHIdev)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15)
+cmake_minimum_required(VERSION 3.19)
 
 project(GUDHI)
 

--- a/src/cmake/modules/GUDHI_third_party_libraries.cmake
+++ b/src/cmake/modules/GUDHI_third_party_libraries.cmake
@@ -33,7 +33,7 @@ if (TARGET CGAL::CGAL)
     message("++ CGAL version: ${CGAL_VERSION}. Includes found in ${CGAL_INCLUDE_DIRS}")
 endif ()
 
-find_package(Eigen3 3.3 NO_MODULE)
+find_package(Eigen3 3.3...5 NO_MODULE) # Any version >=3.3.0 but <6.0.0
 if(TARGET Eigen3::Eigen)
     # Not mandatory as it is set by Eigen3Config.cmake
     get_target_property(EIGEN3_INCLUDE_DIRS Eigen3::Eigen INTERFACE_INCLUDE_DIRECTORIES)

--- a/src/common/doc/installation.h
+++ b/src/common/doc/installation.h
@@ -6,7 +6,7 @@
  * 
  * \section compiling Compiling
  * The library uses c++17 and requires <a target="_blank" href="https://www.boost.org/">Boost</a>  &ge; 1.71.0
- * and <a target="_blank" href="https://cmake.org/">CMake</a> &ge; 3.15.
+ * and <a target="_blank" href="https://cmake.org/">CMake</a> &ge; 3.19.
  * It is a multi-platform library and compiles on Linux, Mac OSX and Visual Studio 2017.
  * 
  * \subsection utilities Utilities and examples

--- a/src/python/doc/installation.rst
+++ b/src/python/doc/installation.rst
@@ -40,7 +40,7 @@ different, and in particular the `python/` subdirectory is actually `src/python/
 there.
 
 The library uses c++17 and requires `Boost <https://www.boost.org/>`_ :math:`\geq` 1.71.0,
-`CMake <https://www.cmake.org/>`_ :math:`\geq` 3.15,
+`CMake <https://www.cmake.org/>`_ :math:`\geq` 3.19,
 Python :math:`\geq` 3.9, `NumPy <http://numpy.org>`_ :math:`\geq` 1.15.0,
 `scikit-build-core <https://scikit-build-core.readthedocs.io>`_ :math:`\geq` 0.4.3
 `nanobind <https://nanobind.readthedocs.io>`_ :math:`\geq` 1.3.2 to compile the GUDHI Python module.


### PR DESCRIPTION
CMake version ranges requires CMake >= 3.19

Fix #1260 

Tested with Eigen 3.3.1, 3.4.1 and 5.0.0