### PR TITLE
Add BEFORE to GUDHI include_directories

### DIFF
--- a/src/cmake/modules/GUDHI_modules.cmake
+++ b/src/cmake/modules/GUDHI_modules.cmake
@@ -12,7 +12,7 @@ function(add_gudhi_module file_path)
   set(GUDHI_MODULES_FULL_LIST ${GUDHI_MODULES_FULL_LIST} ${file_path} PARENT_SCOPE)
   # Include module headers is independent - You may ask for no Alpha complex module but Python interface i.e.
   if(IS_DIRECTORY ${CMAKE_SOURCE_DIR}/src/${file_path}/include/)
-    include_directories(src/${file_path}/include/)
+    include_directories(BEFORE src/${file_path}/include/)
   endif()
 
 endfunction(add_gudhi_module)
@@ -36,6 +36,3 @@ if (WITH_GUDHI_UTILITIES)
 endif()
 
 message("++ GUDHI_SUB_DIRECTORIES list is:\"${GUDHI_SUB_DIRECTORIES}\"")
-
-
-

--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -216,7 +216,7 @@ execute_process(
 find_package(nanobind CONFIG REQUIRED)
 
 # Add src/python/include directory
-include_directories(include)
+include_directories(BEFORE include)
 add_subdirectory("gudhi")
 add_subdirectory("gudhi/clustering")
 add_subdirectory("gudhi/datasets/generators")


### PR DESCRIPTION
Fix #1272 

### Before the fix

```log
cd /home/gudhi/gudhi-devel/build/src/python/gudhi && ccache /usr/bin/g++ -DBOOST_ALL_DYN_LINK -DBOOST_ALL_NO_LIB -DBOOST_RESULT_OF_USE_DECLTYPE -DBOOST_SYSTEM_NO_DEPRECATED -DGUDHI_USE_TBB -D_reader_utils_ext_EXPORTS -I/home/gudhi/gudhi-devel/ext/hera/include -I/home/gailuron/miniconda/envs/gudhi-devel/include -I/home/gudhi/gudhi-devel/src/common/include -I/home/gudhi/gudhi-devel/src/Alpha_complex/include -I/home/gudhi/gudhi-devel/src/Bitmap_cubical_complex/include -I/home/gudhi/gudhi-devel/src/Bottleneck_distance/include -I/home/gudhi/gudhi-devel/src/Collapse/include -I/home/gudhi/gudhi-devel/src/Contraction/include -I/home/gudhi/gudhi-devel/src/Coxeter_triangulation/include -I/home/gudhi/gudhi-devel/src/Cech_complex/include -I/home/gudhi/gudhi-devel/src/Hasse_complex/include -I/home/gudhi/gudhi-devel/src/Persistence_representations/include -I/home/gudhi/gudhi-devel/src/Persistent_cohomology/include -I/home/gudhi/gudhi-devel/src/Rips_complex/include -I/home/gudhi/gudhi-devel/src/Ripser/include -I/home/gudhi/gudhi-devel/src/Simplex_tree/include -I/home/gudhi/gudhi-devel/src/Skeleton_blocker/include -I/home/gudhi/gudhi-devel/src/Spatial_searching/include -I/home/gudhi/gudhi-devel/src/Subsampling/include -I/home/gudhi/gudhi-devel/src/Tangential_complex/include -I/home/gudhi/gudhi-devel/src/Toplex_map/include -I/home/gudhi/gudhi-devel/src/Witness_complex/include -I/home/gudhi/gudhi-devel/src/Nerve_GIC/include -I/home/gudhi/gudhi-devel/src/Persistence_matrix/include -I/home/gudhi/gudhi-devel/src/Zigzag_persistence/include -I/home/gudhi/gudhi-devel/src/python/include -I/home/gailuron/miniconda/envs/gudhi-devel/include/python3.10 -I/home/gailuron/miniconda/envs/gudhi-devel/lib/python3.10/site-packages/nanobind/include -Wall -pedantic -O3 -DNDEBUG -std=gnu++17 -fPIC -fvisibility=hidden -fno-stack-protector -ffunction-sections -fdata-sections -MD -MT src/python/gudhi/CMakeFiles/_reader_utils_ext.dir/_reader_utils.cc.o -MF CMakeFiles/_reader_utils_ext.dir/_reader_utils.cc.o.d -o CMakeFiles/_reader_utils_ext.dir/_reader_utils.cc.o -c /home/gudhi/gudhi-devel/src/python/gudhi/_reader_utils.cc
```

### After the fix

```log
cd /home/gudhi/gudhi-devel/build/src/python/gudhi && ccache /usr/bin/g++ -DBOOST_ALL_DYN_LINK -DBOOST_ALL_NO_LIB -DBOOST_RESULT_OF_USE_DECLTYPE -DBOOST_SYSTEM_NO_DEPRECATED -DGUDHI_USE_TBB -D_reader_utils_ext_EXPORTS -I/home/gudhi/gudhi-devel/src/python/include -I/home/gudhi/gudhi-devel/src/Zigzag_persistence/include -I/home/gudhi/gudhi-devel/src/Persistence_matrix/include -I/home/gudhi/gudhi-devel/src/Nerve_GIC/include -I/home/gudhi/gudhi-devel/src/Witness_complex/include -I/home/gudhi/gudhi-devel/src/Toplex_map/include -I/home/gudhi/gudhi-devel/src/Tangential_complex/include -I/home/gudhi/gudhi-devel/src/Subsampling/include -I/home/gudhi/gudhi-devel/src/Spatial_searching/include -I/home/gudhi/gudhi-devel/src/Skeleton_blocker/include -I/home/gudhi/gudhi-devel/src/Simplex_tree/include -I/home/gudhi/gudhi-devel/src/Ripser/include -I/home/gudhi/gudhi-devel/src/Rips_complex/include -I/home/gudhi/gudhi-devel/src/Persistent_cohomology/include -I/home/gudhi/gudhi-devel/src/Persistence_representations/include -I/home/gudhi/gudhi-devel/src/Hasse_complex/include -I/home/gudhi/gudhi-devel/src/Cech_complex/include -I/home/gudhi/gudhi-devel/src/Coxeter_triangulation/include -I/home/gudhi/gudhi-devel/src/Contraction/include -I/home/gudhi/gudhi-devel/src/Collapse/include -I/home/gudhi/gudhi-devel/src/Bottleneck_distance/include -I/home/gudhi/gudhi-devel/src/Bitmap_cubical_complex/include -I/home/gudhi/gudhi-devel/src/Alpha_complex/include -I/home/gudhi/gudhi-devel/src/common/include -I/home/gudhi/gudhi-devel/ext/hera/include -I/home/gailuron/miniconda/envs/gudhi-devel/include -I/home/gailuron/miniconda/envs/gudhi-devel/include/python3.10 -I/home/gailuron/miniconda/envs/gudhi-devel/lib/python3.10/site-packages/nanobind/include -Wall -pedantic -O3 -DNDEBUG -std=gnu++17 -fPIC -fvisibility=hidden -fno-stack-protector -ffunction-sections -fdata-sections -MD -MT src/python/gudhi/CMakeFiles/_reader_utils_ext.dir/_reader_utils.cc.o -MF CMakeFiles/_reader_utils_ext.dir/_reader_utils.cc.o.d -o CMakeFiles/_reader_utils_ext.dir/_reader_utils.cc.o -c /home/gudhi/gudhi-devel/src/python/gudhi/_reader_utils.cc
```

The idea is to move `/home/gailuron/miniconda/envs/gudhi-devel/include` (the conda environment includes) where another version of GUDHI could be installed.