### PR TITLE
Document that sklearn interfaces can be faster

### DIFF
--- a/biblio/bibliography.bib
+++ b/biblio/bibliography.bib
@@ -1338,3 +1338,20 @@
   ee        = {http://doi.acm.org/10.1145/1998196.1998229},
   bibsource = {DBLP, http://dblp.uni-trier.de}
 }
+
+@article{Ripser,
+    AUTHOR = {Bauer, Ulrich},
+     TITLE = {Ripser: efficient computation of {V}ietoris-{R}ips persistence
+              barcodes},
+   JOURNAL = {J. Appl. Comput. Topol.},
+  FJOURNAL = {Journal of Applied and Computational Topology},
+    VOLUME = {5},
+      YEAR = {2021},
+    NUMBER = {3},
+     PAGES = {391--423},
+      ISSN = {2367-1726},
+   MRCLASS = {55N31 (55-04)},
+  MRNUMBER = {4298669},
+       DOI = {10.1007/s41468-021-00071-5},
+       URL = {https://doi.org/10.1007/s41468-021-00071-5},
+}

--- a/src/python/doc/cubical_complex_ref.rst
+++ b/src/python/doc/cubical_complex_ref.rst
@@ -5,6 +5,10 @@
 Cubical complex reference manual
 ################################
 
+.. tip::
+   If you only want to compute persistent homology, consider using :class:`~gudhi.sklearn.CubicalPersistence`,
+   which can be significantly faster than :class:`~gudhi.CubicalComplex` in some cases.
+
 .. autoclass:: gudhi.CubicalComplex
    :members:
    :inherited-members:

--- a/src/python/doc/cubical_complex_sklearn_itf_ref.rst
+++ b/src/python/doc/cubical_complex_sklearn_itf_ref.rst
@@ -58,3 +58,11 @@ Cubical complex persistence scikit-learn like interface reference
 .. autoclass:: gudhi.sklearn.CubicalPersistence
    :members:
    :show-inheritance:
+
+.. note::
+   This class uses specialized fast code for the following cases
+
+   * `dimension==1 and min_persistence>=0`
+   * `dimension==2 and min_persistence>=0 and input_type=="top_dimensional_cells"`
+
+   It falls back to :class:`~gudhi.CubicalComplex` in all other cases.

--- a/src/python/doc/rips_complex_ref.rst
+++ b/src/python/doc/rips_complex_ref.rst
@@ -6,6 +6,10 @@
 Rips complex reference manual
 =============================
 
+.. tip::
+   If you only want to compute persistent homology, consider using :class:`~gudhi.sklearn.RipsPersistence`,
+   which can be significantly faster than :class:`~gudhi.RipsComplex` in some cases.
+
 .. autoclass:: gudhi.RipsComplex
    :members:
    :undoc-members:

--- a/src/python/gudhi/sklearn/rips_persistence.py
+++ b/src/python/gudhi/sklearn/rips_persistence.py
@@ -42,7 +42,10 @@ from .. import SimplexTree
 
 class RipsPersistence(BaseEstimator, TransformerMixin):
     """
-    This is a class for constructing Vietoris-Rips complexes and computing the persistence diagrams from them.
+    This is a class for constructing Vietoris-Rips filtrations (possibly implicitly) and computing their persistence
+    diagrams.  It does not always use :class:`~gudhi.RipsComplex` or :class:`~gudhi.SimplexTree`, or not naively, it may
+    also use :func:`~gudhi.flag_filtration.edge_collapse.reduce_graph` and a fork of Ripser :cite:`Ripser` and can be
+    significantly faster.
     """
 
     def __init__(


### PR DESCRIPTION
A user contacted me complaining that it was hard to guess from the doc that XyzPersistence might be faster than XyzComplex.persistence, they are not wrong...
I am not attached to the exact way to include it in the doc, but it should be very visible in the doc of XyzComplex, since I expect most users would be better off using XyzPersistence.
We should probably update some tutorials to guide users towards those interfaces.
I also added a citation to Ripser, seems fair since we are using (a fork of) it.

(This PR does not preclude further improvements to the documentation or the code)

https://output.circle-artifacts.com/output/job/0c266627-116e-460b-b50a-d7c31ab5737a/artifacts/0/sphinx/index.html