### PR TITLE
correction of copyright years

### DIFF
--- a/src/Persistence_matrix/include/gudhi/Fields/Multi_field.h
+++ b/src/Persistence_matrix/include/gudhi/Fields/Multi_field.h
@@ -2,7 +2,7 @@
  *    See file LICENSE or go to https://gudhi.inria.fr/licensing/ for full license details.
  *    Author(s):       Hannah Schreiber, Clément Maria
  *
- *    Copyright (C) 2022-24 Inria
+ *    Copyright (C) 2022 Inria
  *
  *    Modification(s):
  *      - YYYY/MM Author: Description of the modification

--- a/src/Persistence_matrix/include/gudhi/Fields/Multi_field_operators.h
+++ b/src/Persistence_matrix/include/gudhi/Fields/Multi_field_operators.h
@@ -2,7 +2,7 @@
  *    See file LICENSE or go to https://gudhi.inria.fr/licensing/ for full license details.
  *    Author(s):       Hannah Schreiber, Clément Maria
  *
- *    Copyright (C) 2022-24 Inria
+ *    Copyright (C) 2022 Inria
  *
  *    Modification(s):
  *      - YYYY/MM Author: Description of the modification

--- a/src/Persistence_matrix/include/gudhi/Fields/Multi_field_shared.h
+++ b/src/Persistence_matrix/include/gudhi/Fields/Multi_field_shared.h
@@ -2,7 +2,7 @@
  *    See file LICENSE or go to https://gudhi.inria.fr/licensing/ for full license details.
  *    Author(s):       Hannah Schreiber, Clément Maria
  *
- *    Copyright (C) 2022-24 Inria
+ *    Copyright (C) 2022 Inria
  *
  *    Modification(s):
  *      - YYYY/MM Author: Description of the modification

--- a/src/Persistence_matrix/include/gudhi/Fields/Multi_field_small.h
+++ b/src/Persistence_matrix/include/gudhi/Fields/Multi_field_small.h
@@ -2,7 +2,7 @@
  *    See file LICENSE or go to https://gudhi.inria.fr/licensing/ for full license details.
  *    Author(s):       Hannah Schreiber, Clément Maria
  *
- *    Copyright (C) 2022-24 Inria
+ *    Copyright (C) 2022 Inria
  *
  *    Modification(s):
  *      - YYYY/MM Author: Description of the modification

--- a/src/Persistence_matrix/include/gudhi/Fields/Multi_field_small_operators.h
+++ b/src/Persistence_matrix/include/gudhi/Fields/Multi_field_small_operators.h
@@ -2,7 +2,7 @@
  *    See file LICENSE or go to https://gudhi.inria.fr/licensing/ for full license details.
  *    Author(s):       Hannah Schreiber, Clément Maria
  *
- *    Copyright (C) 2022-24 Inria
+ *    Copyright (C) 2022 Inria
  *
  *    Modification(s):
  *      - YYYY/MM Author: Description of the modification

--- a/src/Persistence_matrix/include/gudhi/Fields/Multi_field_small_shared.h
+++ b/src/Persistence_matrix/include/gudhi/Fields/Multi_field_small_shared.h
@@ -2,7 +2,7 @@
  *    See file LICENSE or go to https://gudhi.inria.fr/licensing/ for full license details.
  *    Author(s):       Hannah Schreiber, Clément Maria
  *
- *    Copyright (C) 2022-24 Inria
+ *    Copyright (C) 2022 Inria
  *
  *    Modification(s):
  *      - YYYY/MM Author: Description of the modification

--- a/src/Persistence_matrix/include/gudhi/Fields/Z2_field.h
+++ b/src/Persistence_matrix/include/gudhi/Fields/Z2_field.h
@@ -2,7 +2,7 @@
  *    See file LICENSE or go to https://gudhi.inria.fr/licensing/ for full license details.
  *    Author(s):       Hannah Schreiber
  *
- *    Copyright (C) 2022-24 Inria
+ *    Copyright (C) 2022 Inria
  *
  *    Modification(s):
  *      - YYYY/MM Author: Description of the modification

--- a/src/Persistence_matrix/include/gudhi/Fields/Zp_field.h
+++ b/src/Persistence_matrix/include/gudhi/Fields/Zp_field.h
@@ -2,7 +2,7 @@
  *    See file LICENSE or go to https://gudhi.inria.fr/licensing/ for full license details.
  *    Author(s):       Hannah Schreiber
  *
- *    Copyright (C) 2022-24 Inria
+ *    Copyright (C) 2022 Inria
  *
  *    Modification(s):
  *      - YYYY/MM Author: Description of the modification

--- a/src/Persistence_matrix/include/gudhi/Matrix.h
+++ b/src/Persistence_matrix/include/gudhi/Matrix.h
@@ -2,7 +2,7 @@
  *    See file LICENSE or go to https://gudhi.inria.fr/licensing/ for full license details.
  *    Author(s):       Hannah Schreiber
  *
- *    Copyright (C) 2022-24 Inria
+ *    Copyright (C) 2022 Inria
  *
  *    Modification(s):
  *      - YYYY/MM Author: Description of the modification

--- a/src/Persistence_matrix/include/gudhi/Persistence_matrix/Base_matrix.h
+++ b/src/Persistence_matrix/include/gudhi/Persistence_matrix/Base_matrix.h
@@ -2,7 +2,7 @@
  *    See file LICENSE or go to https://gudhi.inria.fr/licensing/ for full license details.
  *    Author(s):       Hannah Schreiber
  *
- *    Copyright (C) 2022-24 Inria
+ *    Copyright (C) 2022 Inria
  *
  *    Modification(s):
  *      - YYYY/MM Author: Description of the modification

--- a/src/Persistence_matrix/include/gudhi/Persistence_matrix/Base_matrix_with_column_compression.h
+++ b/src/Persistence_matrix/include/gudhi/Persistence_matrix/Base_matrix_with_column_compression.h
@@ -2,7 +2,7 @@
  *    See file LICENSE or go to https://gudhi.inria.fr/licensing/ for full license details.
  *    Author(s):       Hannah Schreiber
  *
- *    Copyright (C) 2022-24 Inria
+ *    Copyright (C) 2022 Inria
  *
  *    Modification(s):
  *      - YYYY/MM Author: Description of the modification

--- a/src/Persistence_matrix/include/gudhi/Persistence_matrix/Boundary_matrix.h
+++ b/src/Persistence_matrix/include/gudhi/Persistence_matrix/Boundary_matrix.h
@@ -2,7 +2,7 @@
  *    See file LICENSE or go to https://gudhi.inria.fr/licensing/ for full license details.
  *    Author(s):       Hannah Schreiber
  *
- *    Copyright (C) 2022-24 Inria
+ *    Copyright (C) 2022 Inria
  *
  *    Modification(s):
  *      - YYYY/MM Author: Description of the modification

--- a/src/Persistence_matrix/include/gudhi/Persistence_matrix/Chain_matrix.h
+++ b/src/Persistence_matrix/include/gudhi/Persistence_matrix/Chain_matrix.h
@@ -2,7 +2,7 @@
  *    See file LICENSE or go to https://gudhi.inria.fr/licensing/ for full license details.
  *    Author(s):       Hannah Schreiber
  *
- *    Copyright (C) 2022-24 Inria
+ *    Copyright (C) 2022 Inria
  *
  *    Modification(s):
  *      - YYYY/MM Author: Description of the modification

--- a/src/Persistence_matrix/include/gudhi/Persistence_matrix/Id_to_index_overlay.h
+++ b/src/Persistence_matrix/include/gudhi/Persistence_matrix/Id_to_index_overlay.h
@@ -2,7 +2,7 @@
  *    See file LICENSE or go to https://gudhi.inria.fr/licensing/ for full license details.
  *    Author(s):       Hannah Schreiber
  *
- *    Copyright (C) 2022-24 Inria
+ *    Copyright (C) 2022 Inria
  *
  *    Modification(s):
  *      - YYYY/MM Author: Description of the modification

--- a/src/Persistence_matrix/include/gudhi/Persistence_matrix/Position_to_index_overlay.h
+++ b/src/Persistence_matrix/include/gudhi/Persistence_matrix/Position_to_index_overlay.h
@@ -2,7 +2,7 @@
  *    See file LICENSE or go to https://gudhi.inria.fr/licensing/ for full license details.
  *    Author(s):       Hannah Schreiber
  *
- *    Copyright (C) 2022-24 Inria
+ *    Copyright (C) 2022 Inria
  *
  *    Modification(s):
  *      - YYYY/MM Author: Description of the modification

--- a/src/Persistence_matrix/include/gudhi/Persistence_matrix/RU_matrix.h
+++ b/src/Persistence_matrix/include/gudhi/Persistence_matrix/RU_matrix.h
@@ -2,7 +2,7 @@
  *    See file LICENSE or go to https://gudhi.inria.fr/licensing/ for full license details.
  *    Author(s):       Hannah Schreiber
  *
- *    Copyright (C) 2022-24 Inria
+ *    Copyright (C) 2022 Inria
  *
  *    Modification(s):
  *      - YYYY/MM Author: Description of the modification

--- a/src/Persistence_matrix/include/gudhi/Persistence_matrix/base_pairing.h
+++ b/src/Persistence_matrix/include/gudhi/Persistence_matrix/base_pairing.h
@@ -2,7 +2,7 @@
  *    See file LICENSE or go to https://gudhi.inria.fr/licensing/ for full license details.
  *    Author(s):       Hannah Schreiber
  *
- *    Copyright (C) 2022-24 Inria
+ *    Copyright (C) 2022 Inria
  *
  *    Modification(s):
  *      - YYYY/MM Author: Description of the modification

--- a/src/Persistence_matrix/include/gudhi/Persistence_matrix/base_swap.h
+++ b/src/Persistence_matrix/include/gudhi/Persistence_matrix/base_swap.h
@@ -2,7 +2,7 @@
  *    See file LICENSE or go to https://gudhi.inria.fr/licensing/ for full license details.
  *    Author(s):       Hannah Schreiber
  *
- *    Copyright (C) 2022-23 Inria
+ *    Copyright (C) 2022 Inria
  *
  *    Modification(s):
  *      - YYYY/MM Author: Description of the modification

--- a/src/Persistence_matrix/include/gudhi/Persistence_matrix/chain_pairing.h
+++ b/src/Persistence_matrix/include/gudhi/Persistence_matrix/chain_pairing.h
@@ -2,7 +2,7 @@
  *    See file LICENSE or go to https://gudhi.inria.fr/licensing/ for full license details.
  *    Author(s):       Hannah Schreiber
  *
- *    Copyright (C) 2022-24 Inria
+ *    Copyright (C) 2022 Inria
  *
  *    Modification(s):
  *      - YYYY/MM Author: Description of the modification

--- a/src/Persistence_matrix/include/gudhi/Persistence_matrix/chain_rep_cycles.h
+++ b/src/Persistence_matrix/include/gudhi/Persistence_matrix/chain_rep_cycles.h
@@ -2,7 +2,7 @@
  *    See file LICENSE or go to https://gudhi.inria.fr/licensing/ for full license details.
  *    Author(s):       Hannah Schreiber
  *
- *    Copyright (C) 2022-24 Inria
+ *    Copyright (C) 2022 Inria
  *
  *    Modification(s):
  *      - YYYY/MM Author: Description of the modification

--- a/src/Persistence_matrix/include/gudhi/Persistence_matrix/chain_vine_swap.h
+++ b/src/Persistence_matrix/include/gudhi/Persistence_matrix/chain_vine_swap.h
@@ -2,7 +2,7 @@
  *    See file LICENSE or go to https://gudhi.inria.fr/licensing/ for full license details.
  *    Author(s):       Hannah Schreiber
  *
- *    Copyright (C) 2022-24 Inria
+ *    Copyright (C) 2022 Inria
  *
  *    Modification(s):
  *      - YYYY/MM Author: Description of the modification

--- a/src/Persistence_matrix/include/gudhi/Persistence_matrix/columns/chain_column_extra_properties.h
+++ b/src/Persistence_matrix/include/gudhi/Persistence_matrix/columns/chain_column_extra_properties.h
@@ -2,7 +2,7 @@
  *    See file LICENSE or go to https://gudhi.inria.fr/licensing/ for full license details.
  *    Author(s):       Hannah Schreiber
  *
- *    Copyright (C) 2022-24 Inria
+ *    Copyright (C) 2022 Inria
  *
  *    Modification(s):
  *      - YYYY/MM Author: Description of the modification

--- a/src/Persistence_matrix/include/gudhi/Persistence_matrix/columns/column_dimension_holder.h
+++ b/src/Persistence_matrix/include/gudhi/Persistence_matrix/columns/column_dimension_holder.h
@@ -2,7 +2,7 @@
  *    See file LICENSE or go to https://gudhi.inria.fr/licensing/ for full license details.
  *    Author(s):       Hannah Schreiber
  *
- *    Copyright (C) 2022-24 Inria
+ *    Copyright (C) 2022 Inria
  *
  *    Modification(s):
  *      - YYYY/MM Author: Description of the modification

--- a/src/Persistence_matrix/include/gudhi/Persistence_matrix/columns/entry_types.h
+++ b/src/Persistence_matrix/include/gudhi/Persistence_matrix/columns/entry_types.h
@@ -2,7 +2,7 @@
  *    See file LICENSE or go to https://gudhi.inria.fr/licensing/ for full license details.
  *    Author(s):       Hannah Schreiber
  *
- *    Copyright (C) 2022-24 Inria
+ *    Copyright (C) 2022 Inria
  *
  *    Modification(s):
  *      - YYYY/MM Author: Description of the modification

--- a/src/Persistence_matrix/include/gudhi/Persistence_matrix/columns/heap_column.h
+++ b/src/Persistence_matrix/include/gudhi/Persistence_matrix/columns/heap_column.h
@@ -2,7 +2,7 @@
  *    See file LICENSE or go to https://gudhi.inria.fr/licensing/ for full license details.
  *    Author(s):       Hannah Schreiber
  *
- *    Copyright (C) 2022-24 Inria
+ *    Copyright (C) 2022 Inria
  *
  *    Modification(s):
  *      - YYYY/MM Author: Description of the modification

--- a/src/Persistence_matrix/include/gudhi/Persistence_matrix/columns/intrusive_list_column.h
+++ b/src/Persistence_matrix/include/gudhi/Persistence_matrix/columns/intrusive_list_column.h
@@ -2,7 +2,7 @@
  *    See file LICENSE or go to https://gudhi.inria.fr/licensing/ for full license details.
  *    Author(s):       Hannah Schreiber
  *
- *    Copyright (C) 2022-24 Inria
+ *    Copyright (C) 2022 Inria
  *
  *    Modification(s):
  *      - YYYY/MM Author: Description of the modification

--- a/src/Persistence_matrix/include/gudhi/Persistence_matrix/columns/intrusive_set_column.h
+++ b/src/Persistence_matrix/include/gudhi/Persistence_matrix/columns/intrusive_set_column.h
@@ -2,7 +2,7 @@
  *    See file LICENSE or go to https://gudhi.inria.fr/licensing/ for full license details.
  *    Author(s):       Hannah Schreiber
  *
- *    Copyright (C) 2022-24 Inria
+ *    Copyright (C) 2022 Inria
  *
  *    Modification(s):
  *      - YYYY/MM Author: Description of the modification

--- a/src/Persistence_matrix/include/gudhi/Persistence_matrix/columns/list_column.h
+++ b/src/Persistence_matrix/include/gudhi/Persistence_matrix/columns/list_column.h
@@ -2,7 +2,7 @@
  *    See file LICENSE or go to https://gudhi.inria.fr/licensing/ for full license details.
  *    Author(s):       Hannah Schreiber
  *
- *    Copyright (C) 2022-24 Inria
+ *    Copyright (C) 2022 Inria
  *
  *    Modification(s):
  *      - YYYY/MM Author: Description of the modification

--- a/src/Persistence_matrix/include/gudhi/Persistence_matrix/columns/naive_vector_column.h
+++ b/src/Persistence_matrix/include/gudhi/Persistence_matrix/columns/naive_vector_column.h
@@ -2,7 +2,7 @@
  *    See file LICENSE or go to https://gudhi.inria.fr/licensing/ for full license details.
  *    Author(s):       Hannah Schreiber
  *
- *    Copyright (C) 2022-24 Inria
+ *    Copyright (C) 2022 Inria
  *
  *    Modification(s):
  *      - YYYY/MM Author: Description of the modification

--- a/src/Persistence_matrix/include/gudhi/Persistence_matrix/columns/row_access.h
+++ b/src/Persistence_matrix/include/gudhi/Persistence_matrix/columns/row_access.h
@@ -2,7 +2,7 @@
  *    See file LICENSE or go to https://gudhi.inria.fr/licensing/ for full license details.
  *    Author(s):       Hannah Schreiber
  *
- *    Copyright (C) 2022-24 Inria
+ *    Copyright (C) 2022 Inria
  *
  *    Modification(s):
  *      - YYYY/MM Author: Description of the modification

--- a/src/Persistence_matrix/include/gudhi/Persistence_matrix/columns/set_column.h
+++ b/src/Persistence_matrix/include/gudhi/Persistence_matrix/columns/set_column.h
@@ -2,7 +2,7 @@
  *    See file LICENSE or go to https://gudhi.inria.fr/licensing/ for full license details.
  *    Author(s):       Hannah Schreiber
  *
- *    Copyright (C) 2022-24 Inria
+ *    Copyright (C) 2022 Inria
  *
  *    Modification(s):
  *      - YYYY/MM Author: Description of the modification

--- a/src/Persistence_matrix/include/gudhi/Persistence_matrix/columns/unordered_set_column.h
+++ b/src/Persistence_matrix/include/gudhi/Persistence_matrix/columns/unordered_set_column.h
@@ -2,7 +2,7 @@
  *    See file LICENSE or go to https://gudhi.inria.fr/licensing/ for full license details.
  *    Author(s):       Hannah Schreiber
  *
- *    Copyright (C) 2022-24 Inria
+ *    Copyright (C) 2022 Inria
  *
  *    Modification(s):
  *      - YYYY/MM Author: Description of the modification

--- a/src/Persistence_matrix/include/gudhi/Persistence_matrix/columns/vector_column.h
+++ b/src/Persistence_matrix/include/gudhi/Persistence_matrix/columns/vector_column.h
@@ -2,7 +2,7 @@
  *    See file LICENSE or go to https://gudhi.inria.fr/licensing/ for full license details.
  *    Author(s):       Hannah Schreiber
  *
- *    Copyright (C) 2022-24 Inria
+ *    Copyright (C) 2022 Inria
  *
  *    Modification(s):
  *      - YYYY/MM Author: Description of the modification

--- a/src/Persistence_matrix/include/gudhi/Persistence_matrix/index_mapper.h
+++ b/src/Persistence_matrix/include/gudhi/Persistence_matrix/index_mapper.h
@@ -2,7 +2,7 @@
  *    See file LICENSE or go to https://gudhi.inria.fr/licensing/ for full license details.
  *    Author(s):       Hannah Schreiber
  *
- *    Copyright (C) 2022-24 Inria
+ *    Copyright (C) 2022 Inria
  *
  *    Modification(s):
  *      - YYYY/MM Author: Description of the modification

--- a/src/Persistence_matrix/include/gudhi/Persistence_matrix/matrix_dimension_holders.h
+++ b/src/Persistence_matrix/include/gudhi/Persistence_matrix/matrix_dimension_holders.h
@@ -2,7 +2,7 @@
  *    See file LICENSE or go to https://gudhi.inria.fr/licensing/ for full license details.
  *    Author(s):       Hannah Schreiber
  *
- *    Copyright (C) 2022-24 Inria
+ *    Copyright (C) 2022 Inria
  *
  *    Modification(s):
  *      - YYYY/MM Author: Description of the modification

--- a/src/Persistence_matrix/include/gudhi/Persistence_matrix/matrix_row_access.h
+++ b/src/Persistence_matrix/include/gudhi/Persistence_matrix/matrix_row_access.h
@@ -2,7 +2,7 @@
  *    See file LICENSE or go to https://gudhi.inria.fr/licensing/ for full license details.
  *    Author(s):       Hannah Schreiber
  *
- *    Copyright (C) 2022-24 Inria
+ *    Copyright (C) 2022 Inria
  *
  *    Modification(s):
  *      - YYYY/MM Author: Description of the modification

--- a/src/Persistence_matrix/include/gudhi/Persistence_matrix/ru_pairing.h
+++ b/src/Persistence_matrix/include/gudhi/Persistence_matrix/ru_pairing.h
@@ -2,7 +2,7 @@
  *    See file LICENSE or go to https://gudhi.inria.fr/licensing/ for full license details.
  *    Author(s):       Hannah Schreiber
  *
- *    Copyright (C) 2022-24 Inria
+ *    Copyright (C) 2022 Inria
  *
  *    Modification(s):
  *      - YYYY/MM Author: Description of the modification

--- a/src/Persistence_matrix/include/gudhi/Persistence_matrix/ru_rep_cycles.h
+++ b/src/Persistence_matrix/include/gudhi/Persistence_matrix/ru_rep_cycles.h
@@ -2,7 +2,7 @@
  *    See file LICENSE or go to https://gudhi.inria.fr/licensing/ for full license details.
  *    Author(s):       Hannah Schreiber
  *
- *    Copyright (C) 2022-24 Inria
+ *    Copyright (C) 2022 Inria
  *
  *    Modification(s):
  *      - YYYY/MM Author: Description of the modification

--- a/src/Persistence_matrix/include/gudhi/Persistence_matrix/ru_vine_swap.h
+++ b/src/Persistence_matrix/include/gudhi/Persistence_matrix/ru_vine_swap.h
@@ -2,7 +2,7 @@
  *    See file LICENSE or go to https://gudhi.inria.fr/licensing/ for full license details.
  *    Author(s):       Hannah Schreiber
  *
- *    Copyright (C) 2022-24 Inria
+ *    Copyright (C) 2022 Inria
  *
  *    Modification(s):
  *      - YYYY/MM Author: Description of the modification

--- a/src/Persistence_matrix/include/gudhi/persistence_matrix_options.h
+++ b/src/Persistence_matrix/include/gudhi/persistence_matrix_options.h
@@ -2,7 +2,7 @@
  *    See file LICENSE or go to https://gudhi.inria.fr/licensing/ for full license details.
  *    Author(s):       Hannah Schreiber
  *
- *    Copyright (C) 2022-24 Inria
+ *    Copyright (C) 2022 Inria
  *
  *    Modification(s):
  *      - YYYY/MM Author: Description of the modification


### PR DESCRIPTION
Correction of the copyright years in my files after the discussion:

> The *normal* way to do it is to say `Copyright (C) 2023-2025 Inria`, but then every year you have to change **all** the copyrights with `Copyright (C) 2023-2026 Inria`.
> And we do not want to do that, so we just provide the year the file was created with `Copyright (C) 2023 Inria`.
> Some projects (like CGAL) have a script that generates header files with the proper date, but our license is very permissive (MIT), I think there is no real danger to do it this way.

_Originally posted by @VincentRouvreau in https://github.com/GUDHI/gudhi-devel/pull/1279#discussion_r2625995961_

By the way, I also saw additional files with the same problem:
- ./LICENSE
- ./src/python/gudhi/representations/kernel_methods.py
- ./src/python/gudhi/representations/metrics.py
- ./src/python/gudhi/representations/preprocessing.py
- ./src/python/gudhi/representations/vector_methods.py

Should I correct them too ?