### PR TITLE
[python] bug fix in plot

### DIFF
--- a/src/python/gudhi/persistence_graphical_tools.py
+++ b/src/python/gudhi/persistence_graphical_tools.py
@@ -111,8 +111,7 @@ def _get_number_of_pairs_by_dimension(barcode):
         pass
 
     # array of (dim, (b,d))
-    counts = Counter(bar[0] for bar in barcode)
-    return [counts[i] for i in range(barcode[-1][0] + 1)]
+    return Counter(bar[0] for bar in barcode)
 
 
 def _limit_to_max_intervals(persistence, max_intervals, key):


### PR DESCRIPTION
There was a small mistake which slipped in the last modifications we did for the persistence diagram plot. For diagrams of the form `(dim, (b,d))`, `_get_number_of_pairs_by_dimension` assumed that the array was ordered, which is generally not true. As maps work as arrays, the removed line was not necessary anyway...