### PR TITLE
[Simplex_tree] test fix

### DIFF
--- a/src/Simplex_tree/test/test_vector_filtration_simplex_tree.h
+++ b/src/Simplex_tree/test/test_vector_filtration_simplex_tree.h
@@ -192,6 +192,11 @@ class numeric_limits<Gudhi::Vector_filtration_value> {
     throw std::logic_error(
         "The maximal value cannot be represented with no finite numbers of parameters.");
   };
+
+  static Gudhi::Vector_filtration_value lowest() noexcept(false) {
+    throw std::logic_error(
+        "The minimal value cannot be represented with no finite numbers of parameters.");
+  };
 };
 
 }  // namespace std


### PR DESCRIPTION
Because `lowest` were not more hidden behind a `if constexpr` after the last modification in PR #1176 before it got merged, the tests are not compiling anymore (at least on windows). This should correct it.