### PR TITLE
Fix notebook links in doc

### DIFF
--- a/src/python/doc/cover_complex_sklearn_user.rst
+++ b/src/python/doc/cover_complex_sklearn_user.rst
@@ -40,8 +40,9 @@ Class for cover complexes
      - :License: MIT
      - :Requires: `Scikit-learn <installation.html#scikit-learn>`_
 
-We provide classes for computing cover complexes, i.e., Nerve, Graph Induced and Mapper complexes. Detailed examples on how to use these classes in practice are available
-in the following `notebook <https://github.com/GUDHI/TDA-tutorial/blob/master/Tuto-GUDHI-cover-complex.ipynb>`_.
+We provide classes for computing cover complexes, i.e., Nerve, Graph Induced and Mapper complexes. Detailed examples on
+how to use these classes in practice are available in the following
+`notebook <https://github.com/GUDHI/TDA-tutorial/blob/master/tutorials/Tuto-GUDHI-cover-complex.ipynb>`_.
 
 Example of Mapper cover complex computed from a point cloud
 -----------------------------------------------------------

--- a/src/python/doc/cubical_complex_user.rst
+++ b/src/python/doc/cubical_complex_user.rst
@@ -131,5 +131,5 @@ End user programs are available in python/example/ folder.
 Tutorial
 --------
 
-This `notebook <https://github.com/GUDHI/TDA-tutorial/blob/master/Tuto-GUDHI-cubical-complexes.ipynb>`_
+This `notebook <https://github.com/GUDHI/TDA-tutorial/blob/master/tutorials/Tuto-GUDHI-cubical-complexes.ipynb>`_
 explains how to represent sublevels sets of functions using cubical complexes.

--- a/src/python/doc/differentiation_sum.inc
+++ b/src/python/doc/differentiation_sum.inc
@@ -6,7 +6,9 @@
      - :License: MIT
      - :Requires: `TensorFlow <installation.html#tensorflow>`_
 
-We provide TensorFlow 2 models that can handle automatic differentiation for the computation of persistence diagrams from complexes available in the Gudhi library. 
-This includes simplex trees, cubical complexes and Vietoris-Rips complexes. Detailed example on how to use these layers in practice are available
-in the following `notebook <https://github.com/GUDHI/TDA-tutorial/blob/master/Tuto-GUDHI-optimization.ipynb>`_. Note that even if TensorFlow GPU is enabled, all 
-internal computations using Gudhi will be done on CPU. 
+We provide TensorFlow 2 models that can handle automatic differentiation for the computation of persistence diagrams
+from complexes available in the Gudhi library. 
+This includes simplex trees, cubical complexes and Vietoris-Rips complexes.
+Detailed example on how to use these layers in practice are available in the following
+`notebook <https://github.com/GUDHI/TDA-tutorial/blob/master/tutorials/Tuto-GUDHI-optimization.ipynb>`_.
+Note that even if TensorFlow GPU is enabled, all internal computations using Gudhi will be done on CPU.

--- a/src/python/doc/representations.rst
+++ b/src/python/doc/representations.rst
@@ -20,8 +20,8 @@ diagrams at once. In that case, the diagrams are provided as a list of numpy arr
 the diagrams to have the same number of points, i.e., for the corresponding arrays to have the same number of rows: all
 classes can handle arrays with different shapes.
 
-This `notebook <https://github.com/GUDHI/TDA-tutorial/blob/master/Tuto-GUDHI-representations.ipynb>`__ explains how to
-efficiently combine machine learning and topological data analysis with the
+This `notebook <https://github.com/GUDHI/TDA-tutorial/blob/master/tutorials/Tuto-GUDHI-representations.ipynb>`__
+explains how to efficiently combine machine learning and topological data analysis with the
 :doc:`representations module<representations>` in a scikit-learn fashion.
 
 

--- a/src/python/doc/representations_tflow_itf_ref.rst
+++ b/src/python/doc/representations_tflow_itf_ref.rst
@@ -14,8 +14,8 @@ training time. Its parameters allow to reproduce most of the known finite-dimens
 landscapes and images), and can be combined to create even new ones, that are best suited for a given supervised
 machine learning task with persistence diagrams. PersLay is implemented in TensorFlow.
 
-This `notebook <https://github.com/GUDHI/TDA-tutorial/blob/master/Tuto-GUDHI-perslay-visu.ipynb>`__ explains how to use
-PersLay.
+This `notebook <https://github.com/GUDHI/TDA-tutorial/blob/master/tutorials/Tuto-GUDHI-perslay-visu.ipynb>`__ explains
+how to use PersLay.
 
 Example
 -------

--- a/src/python/doc/rips_complex_user.rst
+++ b/src/python/doc/rips_complex_user.rst
@@ -36,7 +36,7 @@ set with :math:`max(filtration(4,5), filtration(4,6), filtration(5,6))`. And so 
 
 A Rips complex can easily become huge, even if we limit the length of the edges
 and the dimension of the simplices. One easy trick, before building a Rips
-complex on a point cloud, is to call :func:`~gudhi.sparsify_point_set` which removes points
+complex on a point cloud, is to call :func:`~gudhi.subsampling.sparsify_point_set` which removes points
 that are too close to each other. This does not change its persistence diagram
 by more than the length used to define "too close".
 
@@ -220,7 +220,9 @@ until dimension 1 - one skeleton graph in other words), the output is:
     [4, 6] -> 9.49
     [3, 6] -> 11.00
 
-In case this lower triangular matrix is stored in a CSV file, like `data/distance_matrix/full_square_distance_matrix.csv` in the Gudhi distribution, you can read it with :func:`~gudhi.read_lower_triangular_matrix_from_csv_file`.
+In case this lower triangular matrix is stored in a CSV file, like
+`data/distance_matrix/full_square_distance_matrix.csv` in the Gudhi distribution, you can read it with
+:func:`~gudhi.read_lower_triangular_matrix_from_csv_file`.
 
 Correlation matrix
 ------------------
@@ -295,7 +297,8 @@ until dimension 1 - one skeleton graph in other words), the output is:
 Weighted Rips Complex
 ---------------------
 
-`WeightedRipsComplex <rips_complex_ref.html#weighted-rips-complex-reference-manual>`_ builds a simplicial complex from a distance matrix and weights on vertices.
+`WeightedRipsComplex <rips_complex_ref.html#weighted-rips-complex-reference-manual>`_ builds a simplicial complex from
+a distance matrix and weights on vertices.
 
 
 Example from a distance matrix and weights
@@ -321,7 +324,8 @@ The output is:
 Example from a point cloud combined with DistanceToMeasure
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Combining with DistanceToMeasure, one can compute the DTM-filtration of a point set, as in `this notebook <https://github.com/GUDHI/TDA-tutorial/blob/master/Tuto-GUDHI-DTM-filtrations.ipynb>`_. 
+Combining with DistanceToMeasure, one can compute the DTM-filtration of a point set, as in
+`this notebook <https://github.com/GUDHI/TDA-tutorial/blob/master/tutorials/Tuto-GUDHI-DTM-filtrations.ipynb>`_.
 Remark that `DTMRipsComplex <rips_complex_user.html#dtm-rips-complex>`_ class provides exactly this function.
 
 .. testcode::
@@ -347,8 +351,12 @@ The output is:
 DTM Rips Complex
 ----------------
 
-:class:`~gudhi.dtm_rips_complex.DTMRipsComplex` builds a simplicial complex from a point set or a full distance matrix (in the form of ndarray), as described in the above example.
-This class constructs a weighted Rips complex giving larger weights to outliers, which reduces their impact on the persistence diagram. See `this notebook <https://github.com/GUDHI/TDA-tutorial/blob/master/Tuto-GUDHI-DTM-filtrations.ipynb>`_ for some experiments.
+:class:`~gudhi.dtm_rips_complex.DTMRipsComplex` builds a simplicial complex from a point set or a full distance matrix
+(in the form of ndarray), as described in the above example.
+This class constructs a weighted Rips complex giving larger weights to outliers, which reduces their impact on the
+persistence diagram.
+See `this notebook <https://github.com/GUDHI/TDA-tutorial/blob/master/tutorials/Tuto-GUDHI-DTM-filtrations.ipynb>`_
+for some experiments.
 
 .. testcode::
 

--- a/src/python/doc/wasserstein_distance_user.rst
+++ b/src/python/doc/wasserstein_distance_user.rst
@@ -202,5 +202,5 @@ Tutorial
 ********
 
 This
-`notebook <https://github.com/GUDHI/TDA-tutorial/blob/master/Tuto-GUDHI-Barycenters-of-persistence-diagrams.ipynb>`_
+`notebook <https://github.com/GUDHI/TDA-tutorial/blob/master/tutorials/Tuto-GUDHI-Barycenters-of-persistence-diagrams.ipynb>`_
 presents the concept of barycenter, or Fréchet mean, of a family of persistence diagrams.

--- a/src/python/gudhi/_simplex_tree.cc
+++ b/src/python/gudhi/_simplex_tree.cc
@@ -282,7 +282,7 @@ computed with these values.
     Note that this code creates an extra vertex internally, so you should make sure that the simplex tree does not
     contain a vertex with the largest possible value (i.e., 4294967295).
 
-This `notebook <https://github.com/GUDHI/TDA-tutorial/blob/master/Tuto-GUDHI-extended-persistence.ipynb>`_
+This `notebook <https://github.com/GUDHI/TDA-tutorial/blob/master/tutorials/Tuto-GUDHI-extended-persistence.ipynb>`_
 explains how to compute an extension of persistence called extended persistence.
            )doc")
       .def("_collapse_edges",

--- a/src/python/gudhi/simplex_tree.py
+++ b/src/python/gudhi/simplex_tree.py
@@ -193,7 +193,8 @@ class SimplexTree(t._Simplex_tree_python_interface):
             original filtration values due to the internal transformation (scaling to [-2,-1]) that is
             performed on these values during the computation of extended persistence.
 
-        This `notebook <https://github.com/GUDHI/TDA-tutorial/blob/master/Tuto-GUDHI-extended-persistence.ipynb>`_
+        This
+        `notebook <https://github.com/GUDHI/TDA-tutorial/blob/master/tutorials/Tuto-GUDHI-extended-persistence.ipynb>`_
         explains how to compute an extension of persistence called extended persistence.
         """
         self._pers = t._Simplex_tree_persistence_interface(self, False)


### PR DESCRIPTION
`+` some identation
`+` broken link to `gudhi.subsampling.sparsify_point_set` in `RipsComplex` user guide.