### PR TITLE
Extend pyproject.toml

### DIFF
--- a/.github/workflows/pip-build-linux.yml
+++ b/.github/workflows/pip-build-linux.yml
@@ -33,7 +33,6 @@ jobs:
           $PYTHON310/bin/python -m pip install numpy~=1.21.6
           $PYTHON310/bin/python -m pip install --user pytest scipy matplotlib scikit-learn POT wheelhouse/*.whl
           $PYTHON310/bin/python -c "import gudhi; print(gudhi.__version__)"
-          cp data/points/human.off .
           $PYTHON310/bin/python -m pytest src/python/test/test_alpha_complex.py
           $PYTHON310/bin/python -m pytest src/python/test/test_betti_curve_representations.py
           $PYTHON310/bin/python -m pytest src/python/test/test_bottleneck_distance.py

--- a/.github/workflows/pip-build-osx.yml
+++ b/.github/workflows/pip-build-osx.yml
@@ -50,13 +50,13 @@ jobs:
           python --version
           python -m pip wheel -ve .
           export PATH="$PATH:`python -m site --user-base`/bin"
-          delocate-listdeps --depending *.whl
-          delocate-wheel --require-archs universal2 -w wheelhouse -v *.whl
+          delocate-listdeps --depending gudhi*.whl
+          delocate-wheel --require-archs universal2 -w wheelhouse -v gudhi*.whl
       - name: Upload OSx python wheel
         uses: actions/upload-artifact@v6
         with:
           name: osx python wheel
-          path: wheelhouse/*.whl
+          path: wheelhouse/gudhi*.whl
       # Test ABI compatibility with numpy 1.X
       - name: Install and test python wheel
         run: |
@@ -64,4 +64,4 @@ jobs:
           python -m uv sync --group test --no-install-project
           python -m uv lock --upgrade-package numpy~=${{ matrix.numpy-version }}
           python -m uv tree --group test
-          python -m uv run --isolated --no-project --with wheelhouse/*.whl pytest
+          python -m uv run --isolated --no-project --with wheelhouse/gudhi*.whl pytest

--- a/.github/workflows/pip-build-osx.yml
+++ b/.github/workflows/pip-build-osx.yml
@@ -33,11 +33,11 @@ jobs:
         run: |
           brew update || echo "brew update failed, continuing..."
           brew install boost eigen gmp mpfr cgal || echo "brew install failed, continuing..."
+          python -m pip install --user numpy>=2.0
+          python -m pip install --user -r ext/gudhi-deploy/build-requirements.txt
+          python -m pip install --user delocate
           ./scripts/build_osx_universal_gmpfr.sh
           # Now the universal libraries are in $PWD/deps-uni/lib
-          python -m pip install --user uv
-          python -m uv sync --group wheel
-          python -m uv tree --group wheel
       - name: Build python wheel
         # Force the use of apple clang - brew clang seems problematic for universal wheel
         env:
@@ -62,6 +62,5 @@ jobs:
         run: |
           python -m uv sync --group test --no-install-project
           python -m uv lock --upgrade-package numpy~=${{ matrix.numpy-version }}
-          python -m uv pip install wheelhouse/*.whl
           python -m uv tree --group test
-          python -m uv run pytest
+          python -m uv run --isolated --no-project --with dist/*.whl pytest

--- a/.github/workflows/pip-build-osx.yml
+++ b/.github/workflows/pip-build-osx.yml
@@ -63,7 +63,6 @@ jobs:
           python -m pip install --user numpy~=${{ matrix.numpy-version }}
           python -m pip install --user pytest scipy matplotlib scikit-learn POT wheelhouse/*.whl
           python -c "import gudhi; print(gudhi.__version__)"
-          cp data/points/human.off .
           python -m pytest src/python/test/test_alpha_complex.py
           python -m pytest src/python/test/test_betti_curve_representations.py
           python -m pytest src/python/test/test_bottleneck_distance.py

--- a/.github/workflows/pip-build-osx.yml
+++ b/.github/workflows/pip-build-osx.yml
@@ -33,11 +33,11 @@ jobs:
         run: |
           brew update || echo "brew update failed, continuing..."
           brew install boost eigen gmp mpfr cgal || echo "brew install failed, continuing..."
-          python -m pip install --user numpy>=2.0
-          python -m pip install --user -r ext/gudhi-deploy/build-requirements.txt
-          python -m pip install --user delocate
           ./scripts/build_osx_universal_gmpfr.sh
           # Now the universal libraries are in $PWD/deps-uni/lib
+          python -m pip install --user uv
+          python -m uv sync --group wheel
+          python -m uv tree --group wheel
       - name: Build python wheel
         # Force the use of apple clang - brew clang seems problematic for universal wheel
         env:
@@ -48,10 +48,10 @@ jobs:
           export GMPXX_LIB_DIR=$PWD/deps-uni/lib
           export  MPFR_LIB_DIR=$PWD/deps-uni/lib
           python --version
-          python -m pip wheel -ve .
-          export PATH="$PATH:`python -m site --user-base`/bin"
-          delocate-listdeps --depending *.whl
-          delocate-wheel --require-archs universal2 -w wheelhouse -v *.whl
+          python -m uv build --wheel
+          export PATH="$PATH:`python -m uv run python -m site --user-base`/bin"
+          delocate-listdeps --depending dist/*.whl
+          delocate-wheel --require-archs universal2 -w wheelhouse -v dist/*.whl
       - name: Upload OSx python wheel
         uses: actions/upload-artifact@v6
         with:
@@ -60,37 +60,8 @@ jobs:
       # Test ABI compatibility with numpy 1.X
       - name: Install and test python wheel
         run: |
-          python -m pip install --user numpy~=${{ matrix.numpy-version }}
-          python -m pip install --user pytest scipy matplotlib scikit-learn POT wheelhouse/*.whl
-          python -c "import gudhi; print(gudhi.__version__)"
-          python -m pytest src/python/test/test_alpha_complex.py
-          python -m pytest src/python/test/test_betti_curve_representations.py
-          python -m pytest src/python/test/test_bottleneck_distance.py
-          python -m pytest src/python/test/test_collapse_edges.py
-          python -m pytest src/python/test/test_cover_complex.py
-          python -m pytest src/python/test/test_cubical_complex.py
-          python -m pytest src/python/test/test_cubical_persistence_low_dim.py
-          python -m pytest src/python/test/test_datasets_generators.py
-          python -m pytest src/python/test/test_delaunay_complex.py
-          python -m pytest src/python/test/test_dtm_rips_complex.py
-          python -m pytest src/python/test/test_euclidean_witness_complex.py
-          python -m pytest src/python/test/test_off.py
-          python -m pytest src/python/test/test_persistence_graphical_tools.py
-          python -m pytest src/python/test/test_reader_utils.py
-          python -m pytest src/python/test/test_remote_datasets.py
-          python -m pytest src/python/test/test_representations_interface.py
-          python -m pytest src/python/test/test_representations_preprocessing.py
-          python -m pytest src/python/test/test_representations.py
-          python -m pytest src/python/test/test_rips_complex.py
-          python -m pytest src/python/test/test_simplex_generators.py
-          python -m pytest src/python/test/test_simplex_tree.py
-          python -m pytest src/python/test/test_simplex_tree_serialization.py
-          python -m pytest src/python/test/test_sklearn_cubical_persistence.py
-          python -m pytest src/python/test/test_sklearn_rips_persistence.py
-          python -m pytest src/python/test/test_subsampling.py
-          python -m pytest src/python/test/test_tangential_complex.py
-          python -m pytest src/python/test/test_time_delay.py
-          python -m pytest src/python/test/test_tomato.py
-          python -m pytest src/python/test/test_wasserstein_barycenter.py
-          python -m pytest src/python/test/test_weighted_rips_complex.py
-          python -m pytest src/python/test/test_witness_complex.py
+          python -m uv sync --group test --no-install-project
+          python -m uv lock --upgrade-package numpy~=${{ matrix.numpy-version }}
+          python -m uv pip install wheelhouse/*.whl
+          python -m uv tree --group test
+          python -m uv run pytest

--- a/.github/workflows/pip-build-osx.yml
+++ b/.github/workflows/pip-build-osx.yml
@@ -48,10 +48,10 @@ jobs:
           export GMPXX_LIB_DIR=$PWD/deps-uni/lib
           export  MPFR_LIB_DIR=$PWD/deps-uni/lib
           python --version
-          python -m uv build --wheel
-          export PATH="$PATH:`python -m uv run python -m site --user-base`/bin"
-          delocate-listdeps --depending dist/*.whl
-          delocate-wheel --require-archs universal2 -w wheelhouse -v dist/*.whl
+          python -m pip wheel -ve .
+          export PATH="$PATH:`python -m site --user-base`/bin"
+          delocate-listdeps --depending *.whl
+          delocate-wheel --require-archs universal2 -w wheelhouse -v *.whl
       - name: Upload OSx python wheel
         uses: actions/upload-artifact@v6
         with:
@@ -60,6 +60,7 @@ jobs:
       # Test ABI compatibility with numpy 1.X
       - name: Install and test python wheel
         run: |
+          python -m pip install uv
           python -m uv sync --group test --no-install-project
           python -m uv lock --upgrade-package numpy~=${{ matrix.numpy-version }}
           python -m uv tree --group test

--- a/.github/workflows/pip-build-osx.yml
+++ b/.github/workflows/pip-build-osx.yml
@@ -60,9 +60,37 @@ jobs:
       # Test ABI compatibility with numpy 1.X
       - name: Install and test python wheel
         run: |
-          python -m pip install uv
-          python -m uv sync --group test --no-install-project
-          python -m uv lock --upgrade-package numpy~=${{ matrix.numpy-version }}
-          python -m uv pip install wheelhouse/gudhi*.whl
-          python -m uv tree --group test
-          python -m uv run pytest
+          python -m pip install --user numpy~=${{ matrix.numpy-version }}
+          python -m pip install --user pytest scipy matplotlib scikit-learn POT wheelhouse/*.whl
+          python -c "import gudhi; print(gudhi.__version__)"
+          python -m pytest src/python/test/test_alpha_complex.py
+          python -m pytest src/python/test/test_betti_curve_representations.py
+          python -m pytest src/python/test/test_bottleneck_distance.py
+          python -m pytest src/python/test/test_collapse_edges.py
+          python -m pytest src/python/test/test_cover_complex.py
+          python -m pytest src/python/test/test_cubical_complex.py
+          python -m pytest src/python/test/test_cubical_persistence_low_dim.py
+          python -m pytest src/python/test/test_datasets_generators.py
+          python -m pytest src/python/test/test_delaunay_complex.py
+          python -m pytest src/python/test/test_dtm_rips_complex.py
+          python -m pytest src/python/test/test_euclidean_witness_complex.py
+          python -m pytest src/python/test/test_off.py
+          python -m pytest src/python/test/test_persistence_graphical_tools.py
+          python -m pytest src/python/test/test_reader_utils.py
+          python -m pytest src/python/test/test_remote_datasets.py
+          python -m pytest src/python/test/test_representations_interface.py
+          python -m pytest src/python/test/test_representations_preprocessing.py
+          python -m pytest src/python/test/test_representations.py
+          python -m pytest src/python/test/test_rips_complex.py
+          python -m pytest src/python/test/test_simplex_generators.py
+          python -m pytest src/python/test/test_simplex_tree.py
+          python -m pytest src/python/test/test_simplex_tree_serialization.py
+          python -m pytest src/python/test/test_sklearn_cubical_persistence.py
+          python -m pytest src/python/test/test_sklearn_rips_persistence.py
+          python -m pytest src/python/test/test_subsampling.py
+          python -m pytest src/python/test/test_tangential_complex.py
+          python -m pytest src/python/test/test_time_delay.py
+          python -m pytest src/python/test/test_tomato.py
+          python -m pytest src/python/test/test_wasserstein_barycenter.py
+          python -m pytest src/python/test/test_weighted_rips_complex.py
+          python -m pytest src/python/test/test_witness_complex.py

--- a/.github/workflows/pip-build-osx.yml
+++ b/.github/workflows/pip-build-osx.yml
@@ -64,4 +64,4 @@ jobs:
           python -m uv sync --group test --no-install-project
           python -m uv lock --upgrade-package numpy~=${{ matrix.numpy-version }}
           python -m uv tree --group test
-          python -m uv run --isolated --no-project --with dist/*.whl pytest
+          python -m uv run --isolated --no-project --with wheelhouse/*.whl pytest

--- a/.github/workflows/pip-build-osx.yml
+++ b/.github/workflows/pip-build-osx.yml
@@ -63,5 +63,6 @@ jobs:
           python -m pip install uv
           python -m uv sync --group test --no-install-project
           python -m uv lock --upgrade-package numpy~=${{ matrix.numpy-version }}
+          python -m uv pip install wheelhouse/gudhi*.whl
           python -m uv tree --group test
-          python -m uv run --isolated --no-project --with wheelhouse/gudhi*.whl pytest
+          python -m uv run pytest

--- a/.github/workflows/pip-build-windows.yml
+++ b/.github/workflows/pip-build-windows.yml
@@ -67,7 +67,6 @@ jobs:
           python -m pip install --user numpy~=${{ matrix.numpy-version }}
           python -m pip install --user pytest scipy matplotlib scikit-learn POT (Get-ChildItem wheelhouse\*.whl | % FullName)
           python -c "import gudhi; print(gudhi.__version__)"
-          cp data/points/human.off .
           python -m pytest src/python/test/test_alpha_complex.py
           python -m pytest src/python/test/test_betti_curve_representations.py
           python -m pytest src/python/test/test_bottleneck_distance.py

--- a/.github/workflows/pip-packaging-linux.yml
+++ b/.github/workflows/pip-packaging-linux.yml
@@ -28,7 +28,6 @@ jobs:
           $PYTHON310/bin/python -m pip install numpy~=1.21.6
           $PYTHON310/bin/python -m pip install --user pytest scipy matplotlib scikit-learn POT *cp310-linux_x86_64.whl
           $PYTHON310/bin/python -c "import gudhi; print(gudhi.__version__)"
-          cp data/points/human.off .
           $PYTHON310/bin/python -m pytest src/python/test/test_off.py
           $PYTHON310/bin/python -m pytest src/python/test/test_weighted_rips_complex.py
           $PYTHON310/bin/python -m pytest src/python/test/test_tomato.py

--- a/.github/workflows/pip-packaging-osx.yml
+++ b/.github/workflows/pip-packaging-osx.yml
@@ -68,7 +68,6 @@ jobs:
           python -m pip install --user numpy~=${{ matrix.numpy-version }}
           python -m pip install --user pytest scipy matplotlib scikit-learn POT wheelhouse/*.whl
           python -c "import gudhi; print(gudhi.__version__)"
-          cp data/points/human.off .
           python -m pytest src/python/test/test_alpha_complex.py
           python -m pytest src/python/test/test_betti_curve_representations.py
           python -m pytest src/python/test/test_bottleneck_distance.py

--- a/.github/workflows/pip-packaging-windows.yml
+++ b/.github/workflows/pip-packaging-windows.yml
@@ -69,7 +69,6 @@ jobs:
           python -m pip install --user numpy~=${{ matrix.numpy-version }}
           python -m pip install --user pytest scipy matplotlib scikit-learn POT (Get-ChildItem wheelhouse\*.whl | % FullName)
           python -c "import gudhi; print(gudhi.__version__)"
-          cp data/points/human.off .
           python -m pytest src/python/test/test_alpha_complex.py
           python -m pytest src/python/test/test_betti_curve_representations.py
           python -m pytest src/python/test/test_bottleneck_distance.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,9 +64,6 @@ keywords = [
     "deep-learning",
 ]
 
-[project.optional-dependencies]
-visu = [ "matplotlib" ]
-
 [dependency-groups]
 build = [
     "numpy>=1.21.6",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,7 @@ build = [
     "nanobind >=1.3.2",
 ]
 wheel = [
+    "cmake",
     "build",
     "wheel",
     {include-group = "build"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,9 @@ wheel = [
     "cmake",
     "build",
     "wheel",
+    "delocate ; sys_platform == 'darwin'",
+    "auditwheel ; sys_platform == 'linux'",
+    "delvewheel ; platform_system == 'Windows'",
     {include-group = "build"},
 ]
 common = [
@@ -87,7 +90,7 @@ test = [
     "pytest",
     "pytest-cov",
     "torch",
-    "pykeops",
+    "pykeops ; platform_system != 'Windows'",
     "hnswlib",
     "eagerpy",
     "networkx",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,9 @@
 [build-system]
-requires = ["numpy>=1.21.6", "scikit-build-core >=0.4.3", "nanobind >=1.3.2"]
+requires = [
+    "numpy>=1.21.6",
+    "scikit-build-core >=0.4.3",
+    "nanobind >=1.3.2",
+]
 build-backend = "scikit_build_core.build"
 
 [tool.scikit-build]
@@ -31,6 +35,7 @@ name = "gudhi"
 version = "3.13.0a0"
 description = "The Gudhi library is an open source library for Computational Topology and Topological Data Analysis (TDA)."
 readme = "src/python/doc/pypi_introduction.rst"
+dependencies = ["numpy>=1.21.6"]
 requires-python = ">=3.10"
 authors = [{ name = "GUDHI Editorial Board <https://gudhi.inria.fr/contact/>" }]
 classifiers = [
@@ -59,8 +64,47 @@ keywords = [
     "deep-learning",
 ]
 
+[project.optional-dependencies]
+build = [
+    "numpy>=1.21.6",
+    "scikit-build-core >=0.4.3",
+    "nanobind >=1.3.2",
+]
+test = [
+    "pytest",
+    "pytest-cov",
+    "matplotlib",
+    "scipy>=1.6.0",
+    "scikit-learn>=0.24.0",
+    "pandas", # Required by scikit-learn >= 1.5.0 for fetch_openml
+    "POT",
+    "tensorflow; python_version < '3.14'", # tensorflow is not available for python 3.14
+    "torch",
+    "pykeops",
+    "hnswlib",
+    "eagerpy",
+    "networkx",
+]
+doc = [
+    "cmake",
+    "sphinx",
+    "sphinxcontrib-bibtex",
+    "sphinx-paramlinks",
+    "sphinx-autodoc-typehints",
+    "pydata-sphinx-theme>=0.8.0",
+    "matplotlib",
+    "scipy>=1.6.0",
+    "scikit-learn>=0.24.0",
+    "pandas", # Required by scikit-learn >= 1.5.0 for fetch_openml
+    "POT",
+    "tensorflow; python_version < '3.14'", # tensorflow is not available for python 3.14
+]
+
 [project.urls]
 "Bug Tracker" = "https://github.com/GUDHI/gudhi-devel/issues"
 "Documentation" = "https://gudhi.inria.fr/python/latest/"
 "Source Code" = "https://github.com/GUDHI/gudhi-devel"
 "License" = "https://gudhi.inria.fr/licensing/"
+
+[tool.pytest.ini_options]
+norecursedirs = "ext" # Do not look for tests in git submodules (hera would be found)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,25 +65,35 @@ keywords = [
 ]
 
 [project.optional-dependencies]
+visu = [ "matplotlib" ]
+
+[dependency-groups]
 build = [
     "numpy>=1.21.6",
     "scikit-build-core >=0.4.3",
     "nanobind >=1.3.2",
 ]
-test = [
-    "pytest",
-    "pytest-cov",
+wheel = [
+    "build",
+    "wheel",
+    {include-group = "build"},
+]
+common = [
     "matplotlib",
     "scipy>=1.6.0",
     "scikit-learn>=0.24.0",
-    "pandas", # Required by scikit-learn >= 1.5.0 for fetch_openml
     "POT",
     "tensorflow; python_version < '3.14'", # tensorflow is not available for python 3.14
+]
+test = [
+    "pytest",
+    "pytest-cov",
     "torch",
     "pykeops",
     "hnswlib",
     "eagerpy",
     "networkx",
+    {include-group = "common"},
 ]
 doc = [
     "cmake",
@@ -92,12 +102,8 @@ doc = [
     "sphinx-paramlinks",
     "sphinx-autodoc-typehints",
     "pydata-sphinx-theme>=0.8.0",
-    "matplotlib",
-    "scipy>=1.6.0",
-    "scikit-learn>=0.24.0",
-    "pandas", # Required by scikit-learn >= 1.5.0 for fetch_openml
-    "POT",
-    "tensorflow; python_version < '3.14'", # tensorflow is not available for python 3.14
+    "pandas", # Required by scikit-learn >= 1.5.0 for fetch_openml used in doc
+    {include-group = "common"},
 ]
 
 [project.urls]

--- a/src/python/test/test_diff.py
+++ b/src/python/test/test_diff.py
@@ -5,12 +5,14 @@
     Copyright (C) 2020 Inria
 
     Modification(s):
+      - 2026/06 Vincent Rouvreau: Skip all tests if no tensorflow.
       - YYYY/MM Author: Description of the modification
 """
 
+import pytest
+tf = pytest.importorskip("tensorflow")  # All file is skipped if no tensorflow installed
 
 import numpy as np
-import tensorflow as tf
 
 from gudhi.tensorflow import *
 import gudhi as gd

--- a/src/python/test/test_off.py
+++ b/src/python/test/test_off.py
@@ -24,12 +24,6 @@ def test_off_rw():
         assert Y == pytest.approx(X)
 
 
-def test_human_off():
-    pts = gd.read_points_from_off_file("human.off")
-    # Should not try to read faces
-    assert pts.shape == (4706, 3)
-
-
 def test_invalid_off_file():
     name = NamedTemporaryFile().name
     with open(name, "w") as f:

--- a/src/python/test/test_perslay.py
+++ b/src/python/test/test_perslay.py
@@ -5,12 +5,14 @@
     Copyright (C) 2020 Inria
 
     Modification(s):
+      - 2026/06 Vincent Rouvreau: Skip all tests if no tensorflow.
       - YYYY/MM Author: Description of the modification
 """
 
+import pytest
+tf = pytest.importorskip("tensorflow")  # All file is skipped if no tensorflow installed
 
 import numpy as np
-import tensorflow as tf
 from sklearn.preprocessing import MinMaxScaler
 
 from gudhi.tensorflow.perslay import *

--- a/src/python/test/test_wasserstein_with_tensors.py
+++ b/src/python/test/test_wasserstein_with_tensors.py
@@ -5,13 +5,15 @@
     Copyright (C) 2020 Inria
 
     Modification(s):
+      - 2026/06 Vincent Rouvreau: Skip all tests if no tensorflow.
       - YYYY/MM Author: Description of the modification
 """
 
+import pytest
+tf = pytest.importorskip("tensorflow")  # All file is skipped if no tensorflow installed
 
 import numpy as np
 import torch
-import tensorflow as tf
 
 from gudhi.wasserstein import wasserstein_distance as pot
 


### PR DESCRIPTION
## PR scope

Fix numpy dependency (that must be installed when `pip install gudhi`).
Add some group dependencies in pyproject.toml in order to:
- `build` gudhi package with `pip install --group=build .`
- `wheel` gudhi wheel with `pip wheel --group=wheel .`
    - To be discussed, but maybe `build` and `wheel` groups may be redundant.
    - Known issue with `pip wheel --group=wheel .` that also creates the wheels of all dependencies (numpy.whl, build.whl, ...), but fixed in more modern tools like uv
- `doc` to build the python gudhi documentation with:
```bash
$ pip install --group=doc .
$ python -m sphinx.cmd.build -b html python/doc ./gudhi-python-doc # or src/python/doc for dev version, but no image, no biblio
```
- `test` to test the python gudhi package with:
```bash
$ pip install --group=test .
$ python -m pytest
$ python -m pytest  --cov-report html --cov=gudhi
```

## Additional notes

1. `dependency-groups` were preferred over `optional-dependencies` because these groups are more for developpers (cf. [The key difference](https://pydevtools.com/handbook/explanation/what-are-optional-dependencies-and-dependency-groups/#the-key-difference))

2. `dependency-groups` requires pip 24.X (Python >= 3.10).

3. We could also in the future add some `optional-dependencies` in the pyproject.toml,like:
```toml
[project.optional-dependencies]
visu = [ "matplotlib", "networkx" ]
```
And the user will be able to `pip install gudhi[visu]` and it will install gudhi + matplotlib and networkx.
To be discussed.