### PR TITLE
Avoid crash in `flag_persistence_generators` on non-flag filtrations

### DIFF
--- a/src/python/include/python_interfaces/Persistent_cohomology_interface.h
+++ b/src/python/include/python_interfaces/Persistent_cohomology_interface.h
@@ -15,6 +15,7 @@
 #include <vector>
 #include <utility>    // for std::pair
 #include <algorithm>  // for sort
+#include <stdexcept>
 #include <unordered_map>
 
 #include <nanobind/nanobind.h>
@@ -228,6 +229,8 @@ class Persistent_cohomology_interface
     auto& diags = out.first;
     // diagsinf[0] should be interpreted as vector<int> and other diagsinf[i] as vector<array<int,2>>
     auto& diagsinf = out.second;
+    constexpr const char* non_flag_complex_error =
+        "flag_persistence_generators() requires a flag complex: a simplex has no edge with the same filtration";
     for (auto pair : Base::get_persistent_pairs()) {
       auto s = std::get<0>(pair);
       auto t = std::get<1>(pair);
@@ -240,6 +243,9 @@ class Persistent_cohomology_interface
           diagsinf[0].push_back(v);
         } else {
           auto e = stptr_->edge_with_same_filtration(s);
+          if (e == stptr_->null_simplex()) {
+            throw std::invalid_argument(non_flag_complex_error);
+          }
           auto&& e_vertices = stptr_->simplex_vertex_range(e);
           auto i = std::begin(e_vertices);
           auto v1 = *i;
@@ -251,6 +257,9 @@ class Persistent_cohomology_interface
         }
       } else {
         auto et = stptr_->edge_with_same_filtration(t);
+        if (et == stptr_->null_simplex()) {
+          throw std::invalid_argument(non_flag_complex_error);
+        }
         auto&& et_vertices = stptr_->simplex_vertex_range(et);
         auto it = std::begin(et_vertices);
         auto w1 = *it;
@@ -263,6 +272,9 @@ class Persistent_cohomology_interface
           d.insert(d.end(), {v, w1, w2});
         } else {
           auto es = stptr_->edge_with_same_filtration(s);
+          if (es == stptr_->null_simplex()) {
+            throw std::invalid_argument(non_flag_complex_error);
+          }
           auto&& es_vertices = stptr_->simplex_vertex_range(es);
           auto is = std::begin(es_vertices);
           auto v1 = *is;

--- a/src/python/test/test_simplex_generators.py
+++ b/src/python/test/test_simplex_generators.py
@@ -10,6 +10,7 @@
 
 
 import numpy as np
+import pytest
 
 import gudhi
 
@@ -52,6 +53,21 @@ def test_flag_generators():
     assert {(i[0], i[1]) for i in g[3][0]} == {
         tuple(i[0]) for i in pairs if len(i[0]) == 2 and len(i[1]) == 0
     }
+
+
+def test_flag_generators_requires_flag_filtration():
+    st = gudhi.SimplexTree()
+    st.insert([0], 0)
+    st.insert([1], 0)
+    st.insert([2], 0)
+    st.insert([0, 1], 1)
+    st.insert([0, 2], 1)
+    st.insert([1, 2], 1)
+    st.insert([0, 1, 2], 2)
+    st.persistence()
+
+    with pytest.raises(ValueError, match="requires a flag complex"):
+        st.flag_persistence_generators()
 
 
 def test_lower_star_generators():


### PR DESCRIPTION
Resolves #1331 

Checks whether `edge_with_same_filtration()` actually finds an edge before `flag_persistence_generators()` tries to read its vertices.

For non-flag filtrations, the function can hit a simplex whose filtration was not inherited from any edge. Previously that could lead to calling `simplex_vertex_range()` on `null_simplex()`, which could crash the Python process. With this change, it raises a `ValueError` instead.

I also added a regression test with a small non-flag simplex tree to cover the error path.