### PR TITLE
Fix TangentialComplex intrinsic_dim spelling

### DIFF
--- a/src/python/doc/tangential_complex_user.rst
+++ b/src/python/doc/tangential_complex_user.rst
@@ -134,7 +134,7 @@ This example builds the Tangential complex of point set.
            [0., 14.],
            [2., 19.],
            [9., 17.]]
-    tc = TangentialComplex(intrisic_dim = 1, points = pts)
+    tc = TangentialComplex(intrinsic_dim = 1, points = pts)
     tc.compute_tangential_complex()
     print(f'Tangential contains {tc.num_simplices()} simplices - {tc.num_vertices()} vertices.')
 
@@ -176,7 +176,7 @@ simplices.
 .. testcode::
 
     from gudhi import TangentialComplex
-    tc = TangentialComplex(intrisic_dim = 1, points = [[0.0, 0.0], [1.0, 0.0], [0.0, 1.0], [1.0, 1.0]])
+    tc = TangentialComplex(intrinsic_dim = 1, points = [[0.0, 0.0], [1.0, 0.0], [0.0, 1.0], [1.0, 1.0]])
     tc.compute_tangential_complex()
     print(f'Tangential contains {tc.num_vertices()} vertices.')
 

--- a/src/python/example/tangential_complex_plain_homology_from_off_file_example.py
+++ b/src/python/example/tangential_complex_plain_homology_from_off_file_example.py
@@ -27,7 +27,7 @@ parser = argparse.ArgumentParser(
     "points from the given OFF file",
 )
 parser.add_argument("-f", "--file", type=str, required=True)
-parser.add_argument("-i", "--intrisic_dim", type=int, required=True)
+parser.add_argument("-i", "--intrinsic_dim", type=int, required=True)
 parser.add_argument("-b", "--band", type=float, default=0.0)
 parser.add_argument(
     "--no-diagram",
@@ -44,7 +44,7 @@ with open(args.file) as f:
         print("##############################################################")
         print("TangentialComplex creation from points read in a OFF file")
 
-        tc = gd.TangentialComplex(intrisic_dim=args.intrisic_dim, off_file=args.file)
+        tc = gd.TangentialComplex(intrinsic_dim=args.intrinsic_dim, off_file=args.file)
         tc.compute_tangential_complex()
         st = tc.create_simplex_tree()
 

--- a/src/python/gudhi/_tangential_complex.cc
+++ b/src/python/gudhi/_tangential_complex.cc
@@ -41,16 +41,16 @@ class Tangential_complex_interface
   }
 
  public:
-  Tangential_complex_interface(int intrisic_dim, const Sequence2D& points = Sequence2D())
-      : tangential_complex_(points, intrisic_dim, Dynamic_kernel())
+  Tangential_complex_interface(int intrinsic_dim, const Sequence2D& points = Sequence2D())
+      : tangential_complex_(points, intrinsic_dim, Dynamic_kernel())
   {}
 
-  Tangential_complex_interface(int intrisic_dim, const Tensor2D& points)
-      : Tangential_complex_interface(intrisic_dim, _get_sequence_from_tensor(points))
+  Tangential_complex_interface(int intrinsic_dim, const Tensor2D& points)
+      : Tangential_complex_interface(intrinsic_dim, _get_sequence_from_tensor(points))
   {}
 
-  Tangential_complex_interface(int intrisic_dim, const std::string& off_file_name)
-      : tangential_complex_(_get_points_from_file(off_file_name), intrisic_dim, Dynamic_kernel())
+  Tangential_complex_interface(int intrinsic_dim, const std::string& off_file_name)
+      : tangential_complex_(_get_points_from_file(off_file_name), intrinsic_dim, Dynamic_kernel())
   {}
 
   void compute_tangential_complex()
@@ -113,7 +113,7 @@ NB_MODULE(_tangential_complex_ext, m)
 
   nb::class_<gtci>(m, "_Tangential_complex_interface")
       .def(nb::init<int, const Sequence2D&>(),
-           nb::arg("intrisic_dim"),
+           nb::arg("intrinsic_dim"),
            nb::arg("points") = Sequence2D(),
            nb::call_guard<nb::gil_scoped_release>())
       .def(nb::init<int, const Tensor2D&>(), nb::call_guard<nb::gil_scoped_release>())

--- a/src/python/gudhi/tangential_complex.py
+++ b/src/python/gudhi/tangential_complex.py
@@ -24,11 +24,11 @@ class TangentialComplex(t._Tangential_complex_interface):
     can be run to attempt to remove inconsistencies.
     """
 
-    def __init__(self, intrisic_dim, points=None, off_file=""):
+    def __init__(self, intrinsic_dim, points=None, off_file=""):
         """TangentialComplex constructor.
 
-        :param intrisic_dim: Intrinsic dimension of the manifold.
-        :type intrisic_dim: integer
+        :param intrinsic_dim: Intrinsic dimension of the manifold.
+        :type intrinsic_dim: integer
 
         :param points: A list of points in d-Dimension.
         :type points (Sequence[Sequence[float]]): list of list of double
@@ -40,14 +40,14 @@ class TangentialComplex(t._Tangential_complex_interface):
         """
         if off_file:
             if os.path.isfile(off_file):
-                super().__init__(intrisic_dim, off_file)
+                super().__init__(intrinsic_dim, off_file)
             else:
                 raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), off_file)
         else:
             if points is None:
-                super().__init__(intrisic_dim)
+                super().__init__(intrinsic_dim)
             else:
-                super().__init__(intrisic_dim, points)
+                super().__init__(intrinsic_dim, points)
 
     def create_simplex_tree(self):
         """Exports the complex into a simplex tree.

--- a/src/python/gudhi/tangential_complex.py
+++ b/src/python/gudhi/tangential_complex.py
@@ -24,9 +24,6 @@ class TangentialComplex(t._Tangential_complex_interface):
     can be run to attempt to remove inconsistencies.
     """
 
-    def __init__(self, intrinsic_dim, points=None, off_file=""):
-# ^^ import warnings
-
     def __init__(self, intrinsic_dim, intrisic_dim=None, points=None, off_file=""):
         """TangentialComplex constructor.
 

--- a/src/python/gudhi/tangential_complex.py
+++ b/src/python/gudhi/tangential_complex.py
@@ -12,6 +12,7 @@
 __license__ = "GPL v3"
 
 import os
+import warnings
 
 from gudhi import _tangential_complex_ext as t
 from gudhi.simplex_tree import SimplexTree

--- a/src/python/gudhi/tangential_complex.py
+++ b/src/python/gudhi/tangential_complex.py
@@ -25,10 +25,15 @@ class TangentialComplex(t._Tangential_complex_interface):
     """
 
     def __init__(self, intrinsic_dim, points=None, off_file=""):
+# ^^ import warnings
+
+    def __init__(self, intrinsic_dim, intrisic_dim=None, points=None, off_file=""):
         """TangentialComplex constructor.
 
         :param intrinsic_dim: Intrinsic dimension of the manifold.
         :type intrinsic_dim: integer
+
+        :param intrisic_dim: **[deprecated]** consider using `intrinsic_dim` instead.
 
         :param points: A list of points in d-Dimension.
         :type points (Sequence[Sequence[float]]): list of list of double
@@ -38,6 +43,12 @@ class TangentialComplex(t._Tangential_complex_interface):
         :param off_file: An OFF file style name.
         :type off_file: string
         """
+        if intrisic_dim is not None:
+            warnings.warn(
+                "The 'intrisic_dim' argument is deprecated and will be removed in a future version. Use 'intrinsic_dim' instead.",
+                DeprecationWarning
+            )
+            intrinsic_dim = intrisic_dim
         if off_file:
             if os.path.isfile(off_file):
                 super().__init__(intrinsic_dim, off_file)

--- a/src/python/test/test_tangential_complex.py
+++ b/src/python/test/test_tangential_complex.py
@@ -9,13 +9,12 @@
       - YYYY/MM Author: Description of the modification
 """
 
-
 from gudhi import TangentialComplex, SimplexTree
 
 
 def test_tangential():
     point_list = [[0.0, 0.0], [1.0, 0.0], [0.0, 1.0], [1.0, 1.0]]
-    tc = TangentialComplex(intrisic_dim=1, points=point_list)
+    tc = TangentialComplex(intrinsic_dim=1, points=point_list)
     assert tc.num_vertices() == 4
     assert tc.num_simplices() == 0
     assert tc.num_inconsistent_simplices() == 0
@@ -51,12 +50,13 @@ def test_tangential():
     assert tc.get_point(4) == []
     assert tc.get_point(125) == []
 
+
 def test_tensors():
     try:
         import torch
 
         point_list = (torch.rand((5, 2))).requires_grad_()
-        cplex = TangentialComplex(intrisic_dim=1, points=point_list)
+        cplex = TangentialComplex(intrinsic_dim=1, points=point_list)
     except ImportError:
         pass
 
@@ -64,6 +64,6 @@ def test_tensors():
         import tensorflow as tf
 
         point_list = tf.random.uniform(shape=[5, 2])
-        cplex = TangentialComplex(intrisic_dim=1, points=point_list)
+        cplex = TangentialComplex(intrinsic_dim=1, points=point_list)
     except ImportError:
         pass


### PR DESCRIPTION
Renames `intrisic_dim` to `intrinsic_dim` in the TangentialComplex Python interface, tests, example, and documentation.

Resolves #1195