### PR TITLE
Expand doc of symmetrize_graph in Tomato

### DIFF
--- a/src/python/gudhi/clustering/tomato.py
+++ b/src/python/gudhi/clustering/tomato.py
@@ -82,8 +82,10 @@ class Tomato:
             n_clusters (int): number of clusters requested. Defaults to None, i.e. no merging occurs and we get
                 the maximal number of clusters.
             merge_threshold (float): minimum prominence of a cluster so it doesn't get merged.
-            symmetrize_graph (bool): whether we should add edges to make the neighborhood graph symmetric.
-                This can be useful with k-NN for small k. Defaults to false.
+            symmetrize_graph (bool): whether we should add neighbors to make the neighborhood graph symmetric.
+                For each point, Tomato only looks at its neighbors with a larger weight, so the actual graph used
+                depends on the weights for non-symmetric input graphs. This is usually not a problem, but the option
+                can be useful with k-NN for small k. Defaults to false.
             p (float): norm L^p on input points. Defaults to 2.
             q (float): order used to compute the distance to measure. Defaults to dim.
             dim (float): final exponent in DTM density estimation, representing the dimension. Defaults to the


### PR DESCRIPTION
Hopefully this makes it a tiny bit easier to guess what the problem might be, for the next user facing mysterious behavior where the same graph has a different number of connected components depending on the weights.