### PR TITLE
[Simplex_tree] Versioning for serialization

### DIFF
--- a/src/Simplex_tree/include/gudhi/Simplex_tree.h
+++ b/src/Simplex_tree/include/gudhi/Simplex_tree.h
@@ -2898,12 +2898,13 @@ class Simplex_tree {
    *   architecture.
    */
   std::size_t get_serialization_size() const {
+    const std::size_t version_byte_size = sizeof(int);
     const std::size_t vh_byte_size = sizeof(Vertex_handle);
     std::size_t fv_byte_size = 0;
     const std::size_t tree_size = num_simplices_and_filtration_serialization_size(&root_, fv_byte_size);
-    const std::size_t buffer_byte_size = vh_byte_size + fv_byte_size + tree_size * 2 * vh_byte_size;
+    const std::size_t buffer_byte_size = version_byte_size + vh_byte_size + fv_byte_size + tree_size * 2 * vh_byte_size;
 #ifdef DEBUG_TRACES
-      std::clog << "Gudhi::simplex_tree::get_serialization_size - buffer size = " << buffer_byte_size << std::endl;
+    std::clog << "Gudhi::simplex_tree::get_serialization_size - buffer size = " << buffer_byte_size << std::endl;
 #endif  // DEBUG_TRACES
     return buffer_byte_size;
   }
@@ -2942,7 +2943,8 @@ class Simplex_tree {
   /* Without explanation and with filtration values:                                                                 */
   /* 04 0a F(a) 0b F(b) 0c F(c) 0d F(d) 01 0b F(a,b) 00 02 0c F(b,c) 0d F(b,d) 01 0d F(b,c,d) 00 00 01 0d F(c,d) 00 00 */
   void serialize(char* buffer, const std::size_t buffer_size) const {
-    char* buffer_end = rec_serialize(&root_, buffer);
+    char* buffer_end = serialize_value_to_char_buffer(SER_VERSION, buffer);
+    buffer_end = rec_serialize(&root_, buffer_end);
     if (static_cast<std::size_t>(buffer_end - buffer) != buffer_size)
       throw std::invalid_argument("Serialization does not match end of buffer");
   }
@@ -2986,6 +2988,8 @@ class Simplex_tree {
    * @param[in] buffer_size The size of the buffer.
    *
    * @exception std::invalid_argument In case the deserialization does not finish at the correct buffer_size.
+   * @exception std::invalid_argument If the buffer was certifiably constructed from a non-compatible simplex tree
+   * serialization version.
    * @exception std::logic_error In debug mode, if the Simplex_tree is not 'empty'.
    *
    * @warning Serialize/Deserialize is not portable. It is meant to be read in a Simplex_tree with the same
@@ -3015,6 +3019,8 @@ class Simplex_tree {
    * reading.
    *
    * @exception std::invalid_argument In case the deserialization does not finish at the correct buffer_size.
+   * @exception std::invalid_argument If the buffer was certifiably constructed from a non-compatible simplex tree
+   * serialization version.
    * @exception std::logic_error In debug mode, if the Simplex_tree is not 'empty'.
    *
    * @warning Serialize/Deserialize is not portable. It is meant to be read in a Simplex_tree with the same
@@ -3025,6 +3031,11 @@ class Simplex_tree {
   void deserialize(const char* buffer, const std::size_t buffer_size, F&& deserialize_filtration_value) {
     GUDHI_CHECK(num_vertices() == 0, std::logic_error("Simplex_tree::deserialize - Simplex_tree must be empty"));
     const char* ptr = buffer;
+    int version;
+    ptr = deserialize_value_from_char_buffer(version, ptr);
+    if (version != SER_VERSION) {
+      throw std::invalid_argument("The buffer comes from an non-compatible serialization version of the simplex tree.");
+    }
     // Needs to read size before recursivity to manage new siblings for children
     Vertex_handle members_size;
     ptr = deserialize_value_from_char_buffer(members_size, ptr);
@@ -3090,6 +3101,11 @@ class Simplex_tree {
   /** \brief Upper bound on the dimension of the simplicial complex.*/
   mutable int dimension_;
   mutable bool dimension_to_be_lowered_;
+
+  /**
+   * @brief Serialization version number. Should be incremented for each change in the serialization strategy.
+   */
+  static constexpr int SER_VERSION = 0;
 };
 
 // Print a Simplex_tree in os.

--- a/src/Simplex_tree/include/gudhi/Simplex_tree.h
+++ b/src/Simplex_tree/include/gudhi/Simplex_tree.h
@@ -2898,7 +2898,7 @@ class Simplex_tree {
    *   architecture.
    */
   std::size_t get_serialization_size() const {
-    const std::size_t version_byte_size = sizeof(int);
+    const std::size_t version_byte_size = sizeof(std::int16_t);
     const std::size_t vh_byte_size = sizeof(Vertex_handle);
     std::size_t fv_byte_size = 0;
     const std::size_t tree_size = num_simplices_and_filtration_serialization_size(&root_, fv_byte_size);
@@ -2943,7 +2943,7 @@ class Simplex_tree {
   /* Without explanation and with filtration values:                                                                 */
   /* 04 0a F(a) 0b F(b) 0c F(c) 0d F(d) 01 0b F(a,b) 00 02 0c F(b,c) 0d F(b,d) 01 0d F(b,c,d) 00 00 01 0d F(c,d) 00 00 */
   void serialize(char* buffer, const std::size_t buffer_size) const {
-    char* buffer_end = serialize_value_to_char_buffer(SER_VERSION, buffer);
+    char* buffer_end = serialize_value_to_char_buffer(SERIALIZATION_VERSION, buffer);
     buffer_end = rec_serialize(&root_, buffer_end);
     if (static_cast<std::size_t>(buffer_end - buffer) != buffer_size)
       throw std::invalid_argument("Serialization does not match end of buffer");
@@ -3031,9 +3031,9 @@ class Simplex_tree {
   void deserialize(const char* buffer, const std::size_t buffer_size, F&& deserialize_filtration_value) {
     GUDHI_CHECK(num_vertices() == 0, std::logic_error("Simplex_tree::deserialize - Simplex_tree must be empty"));
     const char* ptr = buffer;
-    int version;
+    std::int16_t version;
     ptr = deserialize_value_from_char_buffer(version, ptr);
-    if (version != SER_VERSION) {
+    if (version != SERIALIZATION_VERSION) {
       throw std::invalid_argument("The buffer comes from an non-compatible serialization version of the simplex tree.");
     }
     // Needs to read size before recursivity to manage new siblings for children
@@ -3105,7 +3105,7 @@ class Simplex_tree {
   /**
    * @brief Serialization version number. Should be incremented for each change in the serialization strategy.
    */
-  static constexpr int SER_VERSION = 0;
+  static constexpr std::int16_t SERIALIZATION_VERSION = 0;
 };
 
 // Print a Simplex_tree in os.

--- a/src/Simplex_tree/test/simplex_tree_serialization_unit_test.cpp
+++ b/src/Simplex_tree/test/simplex_tree_serialization_unit_test.cpp
@@ -123,7 +123,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(basic_simplex_tree_serialization, Stree, list_of_t
 
   char* buffer = new char[256];
   char* ptr = buffer;
-  ptr = serialize_value_to_char_buffer(int(-1)     , ptr); // version number
+  ptr = serialize_value_to_char_buffer(std::int16_t(-1)     , ptr); // version number
   // 3 simplices ({0}, {1}, {2}) and its filtration values
   ptr = serialize_value_to_char_buffer(static_cast<Vertex_type>(3)     , ptr);
   ptr = serialize_value_to_char_buffer(static_cast<Vertex_type>(0)     , ptr);
@@ -151,14 +151,14 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(basic_simplex_tree_serialization, Stree, list_of_t
   const std::size_t filtration_size =
       Stree::Options::store_filtration ? get_serialization_size_of(random_filtration<Filtration_type>()) : 0;
   const std::size_t serialization_size =
-      sizeof(int) + vertex_size + st.num_simplices() * (2 * vertex_size + filtration_size);
+      sizeof(std::int16_t) + vertex_size + st.num_simplices() * (2 * vertex_size + filtration_size);
   BOOST_CHECK_EQUAL(serialization_size, buffer_size);
 
   Vertex_type vertex = 0;
   Filtration_type filtration(0);
   // Reset position pointer at start
   const char* c_ptr = buffer;
-  int version;
+  std::int16_t version;
   c_ptr = deserialize_value_from_char_buffer(version, c_ptr);
   BOOST_CHECK_EQUAL(version, -1);
   // 3 simplices ({0}, {1}, {2}) and its filtration values
@@ -224,7 +224,8 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(basic_simplex_tree_serialization, Stree, list_of_t
               << std::hex << (0xFF & buffer[idx]) << " " << std::dec;
   }
   // skip version number for comparision
-  BOOST_CHECK(strncmp(stree_buffer + sizeof(int), buffer + sizeof(int), stree_buffer_size - sizeof(int)) == 0);
+  BOOST_CHECK(strncmp(stree_buffer + sizeof(std::int16_t), buffer + sizeof(std::int16_t),
+                      stree_buffer_size - sizeof(std::int16_t)) == 0);
 
   Stree st_from_buffer;
   st_from_buffer.deserialize(stree_buffer, serialization_size);
@@ -332,7 +333,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(simplex_tree_non_empty_deserialize_throw, Stree, l
   auto start = stree_buffer;
 
   st.serialize(stree_buffer, stree_buffer_size);
-  serialize_value_to_char_buffer(int(-1), start); // overwrites version in buffer with a wrong version
+  serialize_value_to_char_buffer(std::int16_t(-1), start); // overwrites version in buffer with a wrong version
 
   Stree st_from_buffer2;
   BOOST_CHECK_THROW(st_from_buffer2.deserialize(stree_buffer, stree_buffer_size), std::invalid_argument);

--- a/src/Simplex_tree/test/simplex_tree_serialization_unit_test.cpp
+++ b/src/Simplex_tree/test/simplex_tree_serialization_unit_test.cpp
@@ -11,6 +11,7 @@
 
 #include <iostream>
 #include <cstring>  // for std::size_t and strncmp
+#include <stdexcept>
 #include <type_traits>
 #include <cstdint>  // for std::uint8_t
 #include <iomanip>  // for std::setfill, setw
@@ -122,6 +123,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(basic_simplex_tree_serialization, Stree, list_of_t
 
   char* buffer = new char[256];
   char* ptr = buffer;
+  ptr = serialize_value_to_char_buffer(int(-1)     , ptr); // version number
   // 3 simplices ({0}, {1}, {2}) and its filtration values
   ptr = serialize_value_to_char_buffer(static_cast<Vertex_type>(3)     , ptr);
   ptr = serialize_value_to_char_buffer(static_cast<Vertex_type>(0)     , ptr);
@@ -148,13 +150,17 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(basic_simplex_tree_serialization, Stree, list_of_t
   const std::size_t vertex_size = sizeof(Vertex_type);
   const std::size_t filtration_size =
       Stree::Options::store_filtration ? get_serialization_size_of(random_filtration<Filtration_type>()) : 0;
-  const std::size_t serialization_size = vertex_size + st.num_simplices() * (2 * vertex_size + filtration_size);
+  const std::size_t serialization_size =
+      sizeof(int) + vertex_size + st.num_simplices() * (2 * vertex_size + filtration_size);
   BOOST_CHECK_EQUAL(serialization_size, buffer_size);
 
   Vertex_type vertex = 0;
   Filtration_type filtration(0);
   // Reset position pointer at start
   const char* c_ptr = buffer;
+  int version;
+  c_ptr = deserialize_value_from_char_buffer(version, c_ptr);
+  BOOST_CHECK_EQUAL(version, -1);
   // 3 simplices ({0}, {1}, {2}) and its filtration values
   c_ptr = deserialize_value_from_char_buffer(vertex, c_ptr);
   BOOST_CHECK(vertex == 3);
@@ -217,7 +223,8 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(basic_simplex_tree_serialization, Stree, list_of_t
               << std::uppercase 
               << std::hex << (0xFF & buffer[idx]) << " " << std::dec;
   }
-  BOOST_CHECK(strncmp(stree_buffer, buffer, stree_buffer_size) == 0);
+  // skip version number for comparision
+  BOOST_CHECK(strncmp(stree_buffer + sizeof(int), buffer + sizeof(int), stree_buffer_size - sizeof(int)) == 0);
 
   Stree st_from_buffer;
   st_from_buffer.deserialize(stree_buffer, serialization_size);
@@ -296,7 +303,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(simplex_tree_non_empty_deserialize_throw, Stree, l
   std::clog << "NON EMPTY SIMPLEX TREE DESERIALIZATION EXCEPTION" << std::endl;
   Stree st;
 
-  const std::size_t stree_buffer_size = st.get_serialization_size();
+  std::size_t stree_buffer_size = st.get_serialization_size();
   std::clog << "Serialization (from the simplex tree) size in bytes = " << stree_buffer_size << std::endl;
   char* stree_buffer = new char[stree_buffer_size];
 
@@ -311,6 +318,24 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(simplex_tree_non_empty_deserialize_throw, Stree, l
   // throw exception because st_from_buffer is not empty
   BOOST_CHECK_THROW (st_from_buffer.deserialize(stree_buffer, stree_buffer_size),
                      std::logic_error);
+  delete[] stree_buffer;
+
+  Stree st2;
+  st2.insert_simplex_and_subfaces({2, 1, 0});
+  st2.insert_simplex_and_subfaces({3, 0});
+  st2.insert_simplex_and_subfaces({3, 4, 5});
+  st2.insert_simplex_and_subfaces({0, 1, 6, 7});
+
+  stree_buffer_size = st.get_serialization_size();
+  std::clog << "Serialization (from the simplex tree) size in bytes = " << stree_buffer_size << std::endl;
+  stree_buffer = new char[stree_buffer_size];
+  auto start = stree_buffer;
+
+  st.serialize(stree_buffer, stree_buffer_size);
+  serialize_value_to_char_buffer(int(-1), start); // overwrites version in buffer with a wrong version
+
+  Stree st_from_buffer2;
+  BOOST_CHECK_THROW(st_from_buffer2.deserialize(stree_buffer, stree_buffer_size), std::invalid_argument);
   delete[] stree_buffer;
 }
 #endif


### PR DESCRIPTION
Added a version number in front of the serialization buffer. The number will be incremented to 1 in PR #1191.

I named the version number with capital letters like a Macro, as it is a bit how it is used, but perhaps I should match it to the other variable names instead?