### PR TITLE
Try CI without brew update

### DIFF
--- a/.github/workflows/pip-build-osx.yml
+++ b/.github/workflows/pip-build-osx.yml
@@ -31,7 +31,6 @@ jobs:
       # cf. https://numpy.org/doc/stable/dev/depending_on_numpy.html#numpy-2-0-specific-advice
       - name: Install dependencies
         run: |
-          brew update || echo "brew update failed, continuing..."
           brew install boost eigen gmp mpfr cgal || echo "brew install failed, continuing..."
           python -m pip install --user numpy>=2.0
           python -m pip install --user -r ext/gudhi-deploy/build-requirements.txt

--- a/.github/workflows/pip-packaging-osx.yml
+++ b/.github/workflows/pip-packaging-osx.yml
@@ -40,7 +40,6 @@ jobs:
       # cf. https://numpy.org/doc/stable/dev/depending_on_numpy.html#numpy-2-0-specific-advice
       - name: Install dependencies
         run: |
-          brew update || echo "brew update failed, continuing..."
           brew install boost eigen gmp mpfr cgal || echo "brew install failed, continuing..."
           python -m pip install --user numpy>=2.0
           python -m pip install --user -r ext/gudhi-deploy/build-requirements.txt

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -38,9 +38,6 @@ jobs:
           python -m pip install --user -r ext/gudhi-deploy/build-requirements.txt
           python -m pip install --user -r ext/gudhi-deploy/test-requirements.txt
           python -m pip uninstall -y pykeops
-          if ! brew update; then
-            echo "Warning: brew update returned a non-zero exit code."
-          fi
           if ! brew install ninja graphviz doxygen boost eigen gmp mpfr tbb cgal; then
             echo "Warning: brew install returned a non-zero exit code."
           fi


### PR DESCRIPTION
When `brew update` and/or  `brew upgrade`, `brew doctor` fails.
Same behavior on a virtual machine.

Seems to come from brew 5.15.1 -> brew 6.0.1, where formulaes seem broken:

```bash
$ brew --version
Homebrew 6.0.1
$ brew info gmp --json=v2  | jq '.formulae[] | .bottle[] '
{
  "rebuild": 0,
  "root_url": "https://ghcr.io/v2/homebrew/core",
  "files": {
    "arm64_sonoma": {
      "cellar": ":any",
      "url": "https://ghcr.io/v2/homebrew/core/gmp/blobs/sha256:78e4f40cba6419cf7e2d81e9c945d1e93744511bd5230bdfac1b69ed894914b4",
      "sha256": "78e4f40cba6419cf7e2d81e9c945d1e93744511bd5230bdfac1b69ed894914b4"
    }
  }
}
```

Tests performed here: https://github.com/VincentRouvreau/play_with_github_actions