### PR TITLE
Use boost::unordered_flat_map in pcoh

### DIFF
--- a/src/Collapse/example/edge_collapse_conserve_persistence.cpp
+++ b/src/Collapse/example/edge_collapse_conserve_persistence.cpp
@@ -36,7 +36,8 @@ using Persistent_cohomology = Gudhi::persistent_cohomology::Persistent_cohomolog
 
 using Persistence_interval = std::tuple<int, Filtration_value, Filtration_value>;
 /*
- * Compare two intervals by dimension, then by length.
+ * Compare two intervals lexicographically.
+ * (if you want to sort by length, remember to handle infinite intervals)
  */
 struct cmp_intervals_by_length {
   explicit cmp_intervals_by_length(Simplex_tree * sc)
@@ -44,8 +45,8 @@ struct cmp_intervals_by_length {
 
   template<typename Persistent_interval>
   bool operator()(const Persistent_interval & p1, const Persistent_interval & p2) {
-    return (sc_->filtration(get < 1 > (p1)) - sc_->filtration(get < 0 > (p1))
-            > sc_->filtration(get < 1 > (p2)) - sc_->filtration(get < 0 > (p2)));
+    return std::pair(sc_->filtration(get<0>(p1)), sc_->filtration(get<1>(p1)))
+         < std::pair(sc_->filtration(get<0>(p2)), sc_->filtration(get<1>(p2)));
   }
   Simplex_tree* sc_;
 };

--- a/src/Collapse/example/edge_collapse_conserve_persistence.cpp
+++ b/src/Collapse/example/edge_collapse_conserve_persistence.cpp
@@ -39,8 +39,8 @@ using Persistence_interval = std::tuple<int, Filtration_value, Filtration_value>
  * Compare two intervals lexicographically.
  * (if you want to sort by length, remember to handle infinite intervals)
  */
-struct cmp_intervals_by_length {
-  explicit cmp_intervals_by_length(Simplex_tree * sc)
+struct cmp_intervals {
+  explicit cmp_intervals(Simplex_tree * sc)
       : sc_(sc) { }
 
   template<typename Persistent_interval>
@@ -66,7 +66,7 @@ std::vector<Persistence_interval> get_persistence_intervals(Simplex_tree& st, in
   // Default min_interval_length = 0.
   pcoh.compute_persistent_cohomology();
   // Custom sort and output persistence
-  cmp_intervals_by_length cmp(&st);
+  cmp_intervals cmp(&st);
   auto persistent_pairs = pcoh.get_persistent_pairs();
   std::sort(std::begin(persistent_pairs), std::end(persistent_pairs), cmp);
   for (auto pair : persistent_pairs) {

--- a/src/Persistent_cohomology/include/gudhi/Persistent_cohomology.h
+++ b/src/Persistent_cohomology/include/gudhi/Persistent_cohomology.h
@@ -18,10 +18,10 @@
 #include <boost/intrusive/set.hpp>
 #include <boost/pending/disjoint_sets.hpp>
 #include <boost/intrusive/list.hpp>
+#include <boost/unordered_map.hpp>
 
 #include <iostream>
 #include <map>
-#include <unordered_map>
 #include <utility>
 #include <list>
 #include <vector>
@@ -326,7 +326,7 @@ class Persistent_cohomology {
       if (key != cpx_->null_key()) {  // A simplex with null_key is a killer, and have null annotation
         // Find its annotation vector
         curr_col = ds_repr_[dsets_.find_set(key)];
-        if (curr_col != NULL) {  // and insert it in annotations_in_boundary with multyiplicative factor "sign".
+        if (curr_col != NULL) {  // and insert it in annotations_in_boundary with multiplicative factor "sign".
           annotations_in_boundary.emplace_back(curr_col, sign);
         }
       }
@@ -348,11 +348,11 @@ class Persistent_cohomology {
       }
       // The following test is just a heuristic, it is not required, and it is fine that is misses p == 0.
       if (mult != coeff_field_.additive_identity()) {  // For all columns in the boundary,
-        for (auto cell_ref : col->col_) {  // insert every cell in map_a_ds with multiplicity
+        for (auto&& cell_ref : col->col_) {  // insert every cell in map_a_ds with multiplicity
           Arith_element w_y = coeff_field_.times(cell_ref.coefficient_, mult);  // coefficient * multiplicity
 
           if (w_y != coeff_field_.additive_identity()) {  // if != 0
-            result_insert_a_ds = map_a_ds.insert(std::pair<Simplex_key, Arith_element>(cell_ref.key_, w_y));
+            result_insert_a_ds = map_a_ds.emplace(cell_ref.key_, w_y);
             if (!(result_insert_a_ds.second)) {  // if cell_ref.key_ already a Key in map_a_ds
               result_insert_a_ds.first->second = coeff_field_.plus_equal(result_insert_a_ds.first->second, w_y);
               if (result_insert_a_ds.first->second == coeff_field_.additive_identity()) {
@@ -379,12 +379,10 @@ class Persistent_cohomology {
                        coeff_field_.characteristic());
       }
     } else {        // sigma is a destructor in at least a field in coeff_field_
-      // Convert map_a_ds to a vector
+      // Convert map_a_ds to a sorted vector
       A_ds_type a_ds;  // admits reverse iterators
       for (auto map_a_ds_ref : map_a_ds) {
-        a_ds.push_back(
-            std::pair<Simplex_key, Arith_element>(map_a_ds_ref.first,
-                                                  map_a_ds_ref.second));
+        a_ds.emplace_back(map_a_ds_ref.first, map_a_ds_ref.second);
       }
 
       Arith_element inv_x, charac;
@@ -750,9 +748,9 @@ class Persistent_cohomology {
   /*  Dictionary establishing the correspondence between the Simplex_key of
    * the root vertex in the union-find ds and the Simplex_key of the vertex which
    * created the connected component as a 0-dimension homology feature.*/
-  std::unordered_map<Simplex_key, Simplex_key> zero_cocycles_;
+  boost::unordered_map<Simplex_key, Simplex_key> zero_cocycles_;
   /*  Key -> row. */
-  std::map<Simplex_key, cocycle> transverse_idx_;
+  boost::unordered_map<Simplex_key, cocycle> transverse_idx_;
   /* Persistent intervals. */
   std::vector<Persistent_interval> persistent_pairs_;
   length_interval interval_length_policy;

--- a/src/Persistent_cohomology/include/gudhi/Persistent_cohomology.h
+++ b/src/Persistent_cohomology/include/gudhi/Persistent_cohomology.h
@@ -18,7 +18,12 @@
 #include <boost/intrusive/set.hpp>
 #include <boost/pending/disjoint_sets.hpp>
 #include <boost/intrusive/list.hpp>
+#include <boost/version.hpp>
+#if BOOST_VERSION >= 108100
+#include <boost/unordered/unordered_flat_map.hpp>
+#else
 #include <boost/unordered_map.hpp>
+#endif
 
 #include <iostream>
 #include <map>
@@ -745,12 +750,17 @@ class Persistent_cohomology {
   boost::disjoint_sets<int *, Simplex_key *> dsets_;
   /* The compressed annotation matrix fields.*/
   Cam cam_;
+#if BOOST_VERSION >= 108100
   /*  Dictionary establishing the correspondence between the Simplex_key of
    * the root vertex in the union-find ds and the Simplex_key of the vertex which
    * created the connected component as a 0-dimension homology feature.*/
-  boost::unordered_map<Simplex_key, Simplex_key> zero_cocycles_;
+  boost::unordered_flat_map<Simplex_key, Simplex_key> zero_cocycles_;
   /*  Key -> row. */
+  boost::unordered_flat_map<Simplex_key, cocycle> transverse_idx_;
+#else
+  boost::unordered_map<Simplex_key, Simplex_key> zero_cocycles_;
   boost::unordered_map<Simplex_key, cocycle> transverse_idx_;
+#endif
   /* Persistent intervals. */
   std::vector<Persistent_interval> persistent_pairs_;
   length_interval interval_length_policy;


### PR DESCRIPTION
plus minor clean-ups.
The change for `transverse_idx_` from std::map to boost::unordered_map speeds up `compute_persistent_cohomology` by about 15% for a random 3d cubical complex and more than 20% in 5d. The rest has no measurable impact on performance, in my limited tests.
And then moving to the flat version speeds up everything (about 10%), even the 1d cubical case.
I only benchmarked on random cubical complexes, so you can check on a different type of complex if the performance also goes in the expected direction.

I found this old patch while moving to a new laptop, and it still seemed relevant. The patch also turned `annotations_in_boundary` back into a map, but even with unordered_flat_map that wasn't always a win (depends on the dimension, V vs T, etc), so I didn't include that part.