### PR TITLE
Make reader utilities fail explicitly on invalid file paths

### DIFF
--- a/.github/next_release.md
+++ b/.github/next_release.md
@@ -14,6 +14,7 @@ Below is a list of changes:
      - **...**
 
 - Miscellaneous
+     - Reader utilities now require an explicit file path and raise an exception when the file cannot be opened.
      - The [list of bugs that were solved](https://github.com/GUDHI/gudhi-devel/issues?q=label%3A3.14.0+is%3Aclosed) is available on GitHub.
 
 All modules are distributed under the terms of the MIT license.

--- a/src/common/include/gudhi/reader_utils.h
+++ b/src/common/include/gudhi/reader_utils.h
@@ -21,6 +21,7 @@
 #include <fstream>
 #include <map>
 #include <limits>  // for numeric_limits
+#include <stdexcept>
 #include <string>
 #include <vector>
 #include <utility>  // for pair
@@ -215,6 +216,8 @@ bool read_hasse_simplex(std::istream& in_, std::vector<Simplex_key>& boundary, F
  * ...<br>
  * Dj1;Dj2;...;Dj(j-1);<br>
  *
+ * @throws std::invalid_argument If `filename` cannot be opened.
+ *
  **/
 template <typename Filtration_value>
 std::vector<std::vector<Filtration_value>> read_lower_triangular_matrix_from_csv_file(const std::string& filename,
@@ -226,7 +229,10 @@ std::vector<std::vector<Filtration_value>> read_lower_triangular_matrix_from_csv
   std::ifstream in;
   in.open(filename.c_str());
   if (!in.is_open()) {
-    return result;
+    std::string error_str("read_lower_triangular_matrix_from_csv_file - Unable to open file ");
+    error_str.append(filename);
+    std::cerr << error_str << std::endl;
+    throw std::invalid_argument(error_str);
   }
 
   std::string line;

--- a/src/common/include/gudhi/reader_utils.h
+++ b/src/common/include/gudhi/reader_utils.h
@@ -231,7 +231,6 @@ std::vector<std::vector<Filtration_value>> read_lower_triangular_matrix_from_csv
   if (!in.is_open()) {
     std::string error_str("read_lower_triangular_matrix_from_csv_file - Unable to open file ");
     error_str.append(filename);
-    std::cerr << error_str << std::endl;
     throw std::invalid_argument(error_str);
   }
 

--- a/src/common/test/test_distance_matrix_reader.cpp
+++ b/src/common/test/test_distance_matrix_reader.cpp
@@ -23,10 +23,7 @@ using Distance_matrix = std::vector<std::vector<double>>;
 BOOST_AUTO_TEST_CASE( invalid_distance_matrix_file )
 {
   const std::string filename = "missing_distance_matrix.csv";
-  BOOST_CHECK_EXCEPTION(Gudhi::read_lower_triangular_matrix_from_csv_file<double>(filename), std::invalid_argument,
-                        [&filename](const std::invalid_argument& exception) {
-                          return std::string(exception.what()).find(filename) != std::string::npos;
-                        });
+  BOOST_CHECK_THROW(Gudhi::read_lower_triangular_matrix_from_csv_file<double>(filename), std::invalid_argument);
 }
 
 BOOST_AUTO_TEST_CASE( lower_triangular_distance_matrix )

--- a/src/common/test/test_distance_matrix_reader.cpp
+++ b/src/common/test/test_distance_matrix_reader.cpp
@@ -20,6 +20,15 @@
 
 using Distance_matrix = std::vector<std::vector<double>>;
 
+BOOST_AUTO_TEST_CASE( invalid_distance_matrix_file )
+{
+  const std::string filename = "missing_distance_matrix.csv";
+  BOOST_CHECK_EXCEPTION(Gudhi::read_lower_triangular_matrix_from_csv_file<double>(filename), std::invalid_argument,
+                        [&filename](const std::invalid_argument& exception) {
+                          return std::string(exception.what()).find(filename) != std::string::npos;
+                        });
+}
+
 BOOST_AUTO_TEST_CASE( lower_triangular_distance_matrix )
 {
   Distance_matrix from_lower_triangular;

--- a/src/python/gudhi/off_utils.py
+++ b/src/python/gudhi/off_utils.py
@@ -90,7 +90,7 @@ def _read_off_file_header(file_desc):
     return dim, nb_vertices
 
 
-def read_points_from_off_file(off_file=""):
+def read_points_from_off_file(off_file):
     """Read points from an `OFF file <fileformats.html#off-file-format>`_.
 
     :param off_file: An OFF file style name.
@@ -98,6 +98,8 @@ def read_points_from_off_file(off_file=""):
 
     :returns:  The point set.
     :rtype: numpy.ndarray
+
+    :raises FileNotFoundError: If the file cannot be opened.
 
     .. warning::
         This function is using `numpy.loadtxt <https://numpy.org/doc/stable/reference/generated/numpy.loadtxt.html>`_

--- a/src/python/gudhi/reader_utils.py
+++ b/src/python/gudhi/reader_utils.py
@@ -27,9 +27,12 @@ def read_lower_triangular_matrix_from_csv_file(csv_file, separator=";"):
     :returns:  The lower triangular matrix.
     :rtype: List[List[float]]
 
-    :raises ValueError: If the file cannot be opened.
+    :raises FileNotFoundError: If the file cannot be opened.
     """
-    return t._read_matrix_from_csv_file(csv_file, separator[0])
+    try:
+        return t._read_matrix_from_csv_file(csv_file, separator[0])
+    except ValueError as original_exception:
+        raise FileNotFoundError(f"{csv_file} not found") from original_exception
 
 
 def read_persistence_intervals_grouped_by_dimension(persistence_file):
@@ -45,9 +48,12 @@ def read_persistence_intervals_grouped_by_dimension(persistence_file):
     :returns:  The persistence pairs grouped by dimension.
     :rtype: Dict[int, List[Tuple[float, float]]]
 
-    :raises ValueError: If the file cannot be opened.
+    :raises FileNotFoundError: If the file cannot be opened.
     """
-    return t._read_pers_intervals_grouped_by_dimension(persistence_file)
+    try:
+        return t._read_pers_intervals_grouped_by_dimension(persistence_file)
+    except ValueError as original_exception:
+        raise FileNotFoundError(f"{persistence_file} not found") from original_exception
 
 
 def read_persistence_intervals_in_dimension(persistence_file, only_this_dim=-1):
@@ -67,6 +73,9 @@ def read_persistence_intervals_in_dimension(persistence_file, only_this_dim=-1):
     :returns:  The persistence intervals.
     :rtype: numpy array of dimension 2
 
-    :raises ValueError: If the file cannot be opened.
+    :raises FileNotFoundError: If the file cannot be opened.
     """
-    return np_array(t._read_pers_intervals_in_dimension(persistence_file, only_this_dim))
+    try:
+        return np_array(t._read_pers_intervals_in_dimension(persistence_file, only_this_dim))
+    except ValueError as original_exception:
+        raise FileNotFoundError(f"{persistence_file} not found") from original_exception

--- a/src/python/gudhi/reader_utils.py
+++ b/src/python/gudhi/reader_utils.py
@@ -11,13 +11,12 @@
 __license__ = "MIT"
 
 
-from os import path
 from numpy import array as np_array
 
 from gudhi import _reader_utils_ext as t
 
 
-def read_lower_triangular_matrix_from_csv_file(csv_file="", separator=";"):
+def read_lower_triangular_matrix_from_csv_file(csv_file, separator=";"):
     """Read lower triangular matrix from a CSV style file.
 
     :param csv_file: A CSV file style name.
@@ -27,15 +26,13 @@ def read_lower_triangular_matrix_from_csv_file(csv_file="", separator=";"):
 
     :returns:  The lower triangular matrix.
     :rtype: List[List[float]]
+
+    :raises ValueError: If the file cannot be opened.
     """
-    if csv_file:
-        if path.isfile(csv_file):
-            return t._read_matrix_from_csv_file(csv_file, separator[0])
-    print("file " + csv_file + " not set or not found.")
-    return []
+    return t._read_matrix_from_csv_file(csv_file, separator[0])
 
 
-def read_persistence_intervals_grouped_by_dimension(persistence_file=""):
+def read_persistence_intervals_grouped_by_dimension(persistence_file):
     """Reads a file containing persistence intervals.
     Each line might contain 2, 3 or 4 values: [[field] dimension] birth death
     The return value is a `dict(dim, list(tuple(birth, death)))`
@@ -47,15 +44,13 @@ def read_persistence_intervals_grouped_by_dimension(persistence_file=""):
 
     :returns:  The persistence pairs grouped by dimension.
     :rtype: Dict[int, List[Tuple[float, float]]]
+
+    :raises ValueError: If the file cannot be opened.
     """
-    if persistence_file:
-        if path.isfile(persistence_file):
-            return t._read_pers_intervals_grouped_by_dimension(persistence_file)
-    print("file " + persistence_file + " not set or not found.")
-    return []
+    return t._read_pers_intervals_grouped_by_dimension(persistence_file)
 
 
-def read_persistence_intervals_in_dimension(persistence_file="", only_this_dim=-1):
+def read_persistence_intervals_in_dimension(persistence_file, only_this_dim=-1):
     """Reads a file containing persistence intervals.
     Each line of persistence_file might contain 2, 3 or 4 values:
     [[field] dimension] birth death
@@ -71,11 +66,7 @@ def read_persistence_intervals_in_dimension(persistence_file="", only_this_dim=-
 
     :returns:  The persistence intervals.
     :rtype: numpy array of dimension 2
+
+    :raises ValueError: If the file cannot be opened.
     """
-    if persistence_file:
-        if path.isfile(persistence_file):
-            return np_array(
-                t._read_pers_intervals_in_dimension(persistence_file, only_this_dim)
-            )
-    print("file " + persistence_file + " not set or not found.")
-    return []
+    return np_array(t._read_pers_intervals_in_dimension(persistence_file, only_this_dim))

--- a/src/python/test/test_off.py
+++ b/src/python/test/test_off.py
@@ -16,6 +16,11 @@ from tempfile import NamedTemporaryFile
 import gudhi as gd
 
 
+def test_off_file_argument_is_required():
+    with pytest.raises(TypeError):
+        gd.read_points_from_off_file()
+
+
 def test_off_rw():
     for dim in range(2, 6):
         X = np.random.rand(123, dim)

--- a/src/python/test/test_reader_utils.py
+++ b/src/python/test/test_reader_utils.py
@@ -26,7 +26,7 @@ def test_file_arguments_are_required():
 
 def test_non_existing_csv_file():
     # Try to open a non existing file
-    with raises(ValueError, match="pouetpouettralala.toubiloubabdou"):
+    with raises(FileNotFoundError, match="pouetpouettralala.toubiloubabdou"):
         gd.read_lower_triangular_matrix_from_csv_file(
             csv_file="pouetpouettralala.toubiloubabdou"
         )
@@ -56,11 +56,11 @@ def test_lower_triangular_distance_matrix_csv_file():
 
 def test_non_existing_persistence_file():
     # Try to open a non existing file
-    with raises(ValueError, match="pouetpouettralala.toubiloubabdou"):
+    with raises(FileNotFoundError, match="pouetpouettralala.toubiloubabdou"):
         gd.read_persistence_intervals_grouped_by_dimension(
             persistence_file="pouetpouettralala.toubiloubabdou"
         )
-    with raises(ValueError, match="pouetpouettralala.toubiloubabdou"):
+    with raises(FileNotFoundError, match="pouetpouettralala.toubiloubabdou"):
         gd.read_persistence_intervals_in_dimension(
             persistence_file="pouetpouettralala.toubiloubabdou", only_this_dim=1
         )

--- a/src/python/test/test_reader_utils.py
+++ b/src/python/test/test_reader_utils.py
@@ -15,12 +15,21 @@ from pytest import raises
 import gudhi as gd
 
 
+def test_file_arguments_are_required():
+    with raises(TypeError):
+        gd.read_lower_triangular_matrix_from_csv_file()
+    with raises(TypeError):
+        gd.read_persistence_intervals_grouped_by_dimension()
+    with raises(TypeError):
+        gd.read_persistence_intervals_in_dimension()
+
+
 def test_non_existing_csv_file():
     # Try to open a non existing file
-    matrix = gd.read_lower_triangular_matrix_from_csv_file(
-        csv_file="pouetpouettralala.toubiloubabdou"
-    )
-    assert matrix == []
+    with raises(ValueError, match="pouetpouettralala.toubiloubabdou"):
+        gd.read_lower_triangular_matrix_from_csv_file(
+            csv_file="pouetpouettralala.toubiloubabdou"
+        )
 
 
 def test_full_square_distance_matrix_csv_file():
@@ -47,14 +56,14 @@ def test_lower_triangular_distance_matrix_csv_file():
 
 def test_non_existing_persistence_file():
     # Try to open a non existing file
-    persistence = gd.read_persistence_intervals_grouped_by_dimension(
-        persistence_file="pouetpouettralala.toubiloubabdou"
-    )
-    assert persistence == []
-    persistence = gd.read_persistence_intervals_in_dimension(
-        persistence_file="pouetpouettralala.toubiloubabdou", only_this_dim=1
-    )
-    np.testing.assert_array_equal(persistence, [])
+    with raises(ValueError, match="pouetpouettralala.toubiloubabdou"):
+        gd.read_persistence_intervals_grouped_by_dimension(
+            persistence_file="pouetpouettralala.toubiloubabdou"
+        )
+    with raises(ValueError, match="pouetpouettralala.toubiloubabdou"):
+        gd.read_persistence_intervals_in_dimension(
+            persistence_file="pouetpouettralala.toubiloubabdou", only_this_dim=1
+        )
 
 
 def test_read_persistence_intervals_without_dimension():


### PR DESCRIPTION
## Description

This PR updates the error-handling behavior of the reader utilities when a file path is missing or invalid, ensuring that the relevant APIs raise explicit exceptions instead of silently returning empty results.

Main changes:

- The C++ CSV reader now throws `std::invalid_argument` containing the provided file path when the file cannot be opened.
- Removed the empty-string default path from four Python reader APIs, so callers must now provide the path explicitly.
- Python readers now propagate `ValueError` or `FileNotFoundError` instead of printing an error and returning an empty list.
- Added C++ and Python regression tests covering missing arguments, invalid paths, and successful reads.

## Validation

- C++ reader test passed: `1/1`.
- `_reader_utils_ext` built successfully.
- Isolated tests using the actual Python extension passed, covering:
  - file path arguments are required;
  - invalid paths raise the expected exceptions;
  - valid files are read successfully.

Closes #1225
Closes #1226