### PR TITLE
[python] inverse Sequence and Tensor order in bindings

### DIFF
--- a/src/python/gudhi/_delaunay_complex.cc
+++ b/src/python/gudhi/_delaunay_complex.cc
@@ -154,10 +154,10 @@ NB_MODULE(_delaunay_complex_ext, m)
       .value("ALPHA", gdc::Delaunay_filtration::ALPHA, "Alpha Complex");
 
   nb::class_<gdci>(m, "Delaunay_complex_interface")
-      .def(nb::init<const Sequence2D&, const Sequence1D&, bool, bool>(), nb::call_guard<nb::gil_scoped_release>())
       .def(nb::init<const Tensor2D&, const Tensor1D&, bool, bool>(), nb::call_guard<nb::gil_scoped_release>())
-      .def(nb::init<const Sequence2D&, bool, bool>(), nb::call_guard<nb::gil_scoped_release>())
+      .def(nb::init<const Sequence2D&, const Sequence1D&, bool, bool>(), nb::call_guard<nb::gil_scoped_release>())
       .def(nb::init<const Tensor2D&, bool, bool>(), nb::call_guard<nb::gil_scoped_release>())
+      .def(nb::init<const Sequence2D&, bool, bool>(), nb::call_guard<nb::gil_scoped_release>())
       .def("create_simplex_tree", &gdci::create_simplex_tree, nb::call_guard<nb::gil_scoped_release>())
       .def("get_point", &gdci::get_point, nb::arg("vertex"), R"doc(
 This function returns the point corresponding to a given vertex from the :class:`~gudhi.SimplexTree` (the

--- a/src/python/gudhi/_euclidean_strong_witness_complex.cc
+++ b/src/python/gudhi/_euclidean_strong_witness_complex.cc
@@ -94,8 +94,8 @@ NB_MODULE(_euclidean_strong_witness_complex_ext, m)
 
   nb::class_<gwci>(m, "Euclidean_strong_witness_complex_interface")
       .def(nb::init<>(), nb::call_guard<nb::gil_scoped_release>())
-      .def(nb::init<const Sequence2D&, const Sequence2D&>(), nb::call_guard<nb::gil_scoped_release>())
       .def(nb::init<const Tensor2D&, const Tensor2D&>(), nb::call_guard<nb::gil_scoped_release>())
+      .def(nb::init<const Sequence2D&, const Sequence2D&>(), nb::call_guard<nb::gil_scoped_release>())
       .def("create_simplex_tree",
            &gwci::create_simplex_tree,
            nb::arg("simplex_tree"),

--- a/src/python/gudhi/_euclidean_witness_complex.cc
+++ b/src/python/gudhi/_euclidean_witness_complex.cc
@@ -94,8 +94,8 @@ NB_MODULE(_euclidean_witness_complex_ext, m)
 
   nb::class_<egwci>(m, "Euclidean_witness_complex_interface")
       .def(nb::init<>(), nb::call_guard<nb::gil_scoped_release>())
-      .def(nb::init<const Sequence2D&, const Sequence2D&>(), nb::call_guard<nb::gil_scoped_release>())
       .def(nb::init<const Tensor2D&, const Tensor2D&>(), nb::call_guard<nb::gil_scoped_release>())
+      .def(nb::init<const Sequence2D&, const Sequence2D&>(), nb::call_guard<nb::gil_scoped_release>())
       .def("create_simplex_tree",
            &egwci::create_simplex_tree,
            nb::arg("simplex_tree"),

--- a/src/python/gudhi/_rips_complex.cc
+++ b/src/python/gudhi/_rips_complex.cc
@@ -110,15 +110,14 @@ namespace nb = nanobind;
 namespace grc = Gudhi::rips_complex;
 using grci = grc::Rips_complex_interface;
 
-NB_MODULE(_rips_complex_ext, m)
-{
+NB_MODULE(_rips_complex_ext, m) {
   m.attr("__license__") = "MIT";
 
   nb::class_<grci>(m, "Rips_complex_interface")
-      .def(nb::init<const Sequence2D&, double, bool>(), nb::call_guard<nb::gil_scoped_release>())
       .def(nb::init<const Tensor2D&, double, bool>(), nb::call_guard<nb::gil_scoped_release>())
-      .def(nb::init<const Sequence2D&, double, double, bool>(), nb::call_guard<nb::gil_scoped_release>())
+      .def(nb::init<const Sequence2D&, double, bool>(), nb::call_guard<nb::gil_scoped_release>())
       .def(nb::init<const Tensor2D&, double, double, bool>(), nb::call_guard<nb::gil_scoped_release>())
+      .def(nb::init<const Sequence2D&, double, double, bool>(), nb::call_guard<nb::gil_scoped_release>())
       .def("create_simplex_tree", &grci::create_simplex_tree, nb::call_guard<nb::gil_scoped_release>());
 }
 


### PR DESCRIPTION
Just realized that nanobind is not differentiating method overloads by closest type, but by "first argument type which fits" in order of ".def" definition. Which means that if you do:
```C++
.def(nb::init<const Sequence1D&>())
.def(nb::init<const Tensor1D&>())
```
the second version is never reached as any numpy array etc. can also be converted into a std::vector<...>. And a copy is made.
So I changed everything to:
```C++
.def(nb::init<const Tensor1D&>())
.def(nb::init<const Sequence1D&>())
```