### PR TITLE
Fix bottleneck distance asymmetry

### DIFF
--- a/src/Bottleneck_distance/include/gudhi/Graph_matching.h
+++ b/src/Bottleneck_distance/include/gudhi/Graph_matching.h
@@ -67,8 +67,9 @@ inline bool Graph_matching::multi_augment() {
     return false;
   Layered_neighbors_finder layered_nf(layering());
   int max_depth = layered_nf.vlayers_number()*2 - 1;
+  double rn = sqrt(2. * gp->size());
   // verification of a necessary criterion in order to shortcut if possible
-  if (max_depth < 0)
+  if (max_depth < 0 || (unmatched_in_u.size() > rn && max_depth >= rn))
     return false;
   bool successful = false;
   std::vector<int> tries(unmatched_in_u.cbegin(), unmatched_in_u.cend());

--- a/src/Bottleneck_distance/include/gudhi/Graph_matching.h
+++ b/src/Bottleneck_distance/include/gudhi/Graph_matching.h
@@ -67,9 +67,8 @@ inline bool Graph_matching::multi_augment() {
     return false;
   Layered_neighbors_finder layered_nf(layering());
   int max_depth = layered_nf.vlayers_number()*2 - 1;
-  double rn = sqrt(gp->size());
   // verification of a necessary criterion in order to shortcut if possible
-  if (max_depth < 0 || (unmatched_in_u.size() > rn && max_depth >= rn))
+  if (max_depth < 0)
     return false;
   bool successful = false;
   std::vector<int> tries(unmatched_in_u.cbegin(), unmatched_in_u.cend());

--- a/src/Bottleneck_distance/test/bottleneck_unit_test.cpp
+++ b/src/Bottleneck_distance/test/bottleneck_unit_test.cpp
@@ -132,7 +132,23 @@ BOOST_AUTO_TEST_CASE(graph_matching) {
   BOOST_CHECK(!m1.perfect());
 }
 
-BOOST_AUTO_TEST_CASE(exact_bottleneck_is_symmetric_with_reused_matching) {
+void check_bottleneck_counterexample(const std::vector<std::pair<double, double>>& a,
+                                     const std::vector<std::pair<double, double>>& b,
+                                     double expected) {
+  double exact_ab = bottleneck_distance(a, b, 0.);
+  double exact_ba = bottleneck_distance(b, a, 0.);
+  // Python's e=None maps to this overload's default value, the smallest positive double.
+  double default_ab = bottleneck_distance(a, b);
+  double default_ba = bottleneck_distance(b, a);
+
+  BOOST_CHECK_EQUAL(exact_ab, exact_ba);
+  BOOST_CHECK_CLOSE_FRACTION(exact_ab, expected, 1e-14);
+  BOOST_CHECK_EQUAL(default_ab, default_ba);
+  BOOST_CHECK_CLOSE_FRACTION(default_ab, expected, 1e-14);
+}
+
+// With the old shortcut, MSVC reaches n=6, k=3, l=3: k>sqrt(n), l>=sqrt(n), and k(l+1)=2n.
+BOOST_AUTO_TEST_CASE(bottleneck_windows_counterexample) {
   std::vector<std::pair<double, double>> a = {
       {0.8657832199712898, 1.1256902536912314},
       {0.16921569257803723, 0.6031897594038342},
@@ -144,11 +160,59 @@ BOOST_AUTO_TEST_CASE(exact_bottleneck_is_symmetric_with_reused_matching) {
       {0.6796253715781101, 1.3001211960521455},
   };
 
-  double ab = bottleneck_distance(a, b, 0.);
-  double ba = bottleneck_distance(b, a, 0.);
+  check_bottleneck_counterexample(a, b, 0.28348368108915978);
+}
 
-  BOOST_CHECK_EQUAL(ab, ba);
-  BOOST_CHECK_CLOSE_FRACTION(ab, 0.28348368108915978, 1e-14);
+// A non-affine perturbation of the previous diagram reaches the same (n,k,l) on MSVC.
+BOOST_AUTO_TEST_CASE(bottleneck_windows_perturbed_counterexample) {
+  std::vector<std::pair<double, double>> a = {
+      {0.86588321997128981, 1.1257902536912314},
+      {0.16901569257803722, 0.60298975940383426},
+      {-0.046456417456722458, 0.52051094472159698},
+  };
+  std::vector<std::pair<double, double>> b = {
+      {0.15033295756523576, 0.18404854990571343},
+      {0.15033295756523576, 0.18404854990571343},
+      {0.67982537157811007, 1.3003211960521455},
+  };
+
+  check_bottleneck_counterexample(a, b, 0.28348368108915972);
+}
+
+// With the old shortcut, GCC reaches n=8, k=3, l=3: k>sqrt(n), l>=sqrt(n), and k(l+1)<2n.
+BOOST_AUTO_TEST_CASE(bottleneck_linux_counterexample) {
+  std::vector<std::pair<double, double>> a = {
+      {-0.7734086850435968, -0.7734065850126042},
+      {0.4057382451550824, 0.40574118001625126},
+      {-0.8218366177063472, -0.8136106266959778},
+      {0.4057382451550824, 0.40574118001625126},
+  };
+  std::vector<std::pair<double, double>> b = {
+      {-0.6759744467664093, 0.17199054436205374},
+      {-0.4787571504589536, -0.47692522493813944},
+      {-0.6759744467664093, 0.17199054436205374},
+      {-0.6759744467664093, 0.17199054436205374},
+  };
+
+  check_bottleneck_counterexample(a, b, 0.4239824955642315);
+}
+
+// A non-affine perturbation of the previous diagram reaches the same (n,k,l) on GCC.
+BOOST_AUTO_TEST_CASE(bottleneck_linux_perturbed_counterexample) {
+  std::vector<std::pair<double, double>> a = {
+      {-0.77340768504359680, -0.77340558501260415},
+      {0.40573624515508239, 0.40573918001625126},
+      {-0.82183361770634722, -0.81360762669597786},
+      {0.40573624515508239, 0.40573918001625126},
+  };
+  std::vector<std::pair<double, double>> b = {
+      {-0.67597544676640930, 0.17198954436205374},
+      {-0.47875515045895362, -0.47692322493813943},
+      {-0.67597544676640930, 0.17198954436205374},
+      {-0.67597544676640930, 0.17198954436205374},
+  };
+
+  check_bottleneck_counterexample(a, b, 0.4239824955642315);
 }
 
 BOOST_AUTO_TEST_CASE(global) {

--- a/src/Bottleneck_distance/test/bottleneck_unit_test.cpp
+++ b/src/Bottleneck_distance/test/bottleneck_unit_test.cpp
@@ -132,6 +132,25 @@ BOOST_AUTO_TEST_CASE(graph_matching) {
   BOOST_CHECK(!m1.perfect());
 }
 
+BOOST_AUTO_TEST_CASE(exact_bottleneck_is_symmetric_with_reused_matching) {
+  std::vector<std::pair<double, double>> a = {
+      {0.8657832199712898, 1.1256902536912314},
+      {0.16921569257803723, 0.6031897594038342},
+      {-0.04675641745672246, 0.5202109447215970},
+  };
+  std::vector<std::pair<double, double>> b = {
+      {0.15043295756523575, 0.18414854990571342},
+      {0.15043295756523575, 0.18414854990571342},
+      {0.6796253715781101, 1.3001211960521455},
+  };
+
+  double ab = bottleneck_distance(a, b, 0.);
+  double ba = bottleneck_distance(b, a, 0.);
+
+  BOOST_CHECK_EQUAL(ab, ba);
+  BOOST_CHECK_CLOSE_FRACTION(ab, 0.28348368108915978, 1e-14);
+}
+
 BOOST_AUTO_TEST_CASE(global) {
   double delta_min = upper_bound / 1000.;
   double delta_max = upper_bound / 100.;


### PR DESCRIPTION
## Root Cause

The issue is located in the early-exit condition of `Graph_matching::multi_augment()`:

```cpp
unmatched_in_u.size() > sqrt(gp->size()) &&
max_depth >= sqrt(gp->size())
```

The exact Bottleneck search reuses a partial matching obtained at a smaller radius.

At the correct threshold for this counterexample, we have $n=6$, $k=3$, and $\ell=3$.The original condition triggers because $3>\sqrt 6$ and $3\geq\sqrt 6$, so `multi_augment()` returns `false` early. However, an augmenting path of depth $3$ still exists, and continuing the augmentation leads to a perfect matching.The problem is not caused by candidate-distance generation, but by the interaction between matching-state reuse and the early-exit shortcut.


## Mathematical Justification

Suppose the current matching leaves $k$ vertices in $U$ unmatched, and the shortest augmenting path has depth $\ell$. To obtain a perfect matching, the remaining $k$ unmatched vertices must eventually be matched through $k$ vertex-disjoint augmenting paths.

Each such augmenting path uses at least $(\ell+1)/2$ vertices from $U$. Since there are only $n$ vertices in $U$, a necessary condition is

$$
k\frac{\ell+1}{2}\leq n,
\qquad\text{hence}\qquad
k(\ell+1)\leq 2n.
$$

In particular, if $k\ell>2n$, then the current matching cannot be extended to a perfect matching.

Now choose the shortcut threshold $r=\sqrt{2n}$. If both $k>r$ and $\ell\geq r$, then $k\ell>r^2=2n$, so the necessary condition above is violated and returning `false` is safe.

The original threshold $r=\sqrt n$ only guarantees $k\ell>n$, which is not sufficient to rule out a perfect matching.

The counterexample demonstrates exactly this gap: for $n=6$, $k=3$, and $\ell=3$, we have $k\ell=9$. Thus $k\ell>n=6$, so the original $\sqrt n$ shortcut triggers, but $k\ell<2n=12$, so a perfect matching is still possible.

Therefore, replacing $\sqrt n$ with $\sqrt{2n}$ gives a sufficient condition for the early exit while retaining the intended optimization.

## Validation

After the change:

- Both `A -> B` and `B -> A` return `0.28348368108915978` on the minimal $3\times 3$ counterexample.
- A regression test has been added to check both exact Bottleneck symmetry and the expected numerical value.