### PR TITLE
Different filtration values support in python

### DIFF
--- a/src/python/gudhi/_cubical_complex.cc
+++ b/src/python/gudhi/_cubical_complex.cc
@@ -92,10 +92,10 @@ NB_MODULE(_cubical_complex_ext, m)
       using CC = typename decltype(identity_tag)::type;
       using Filtration_value = typename CC::Filtration_value;
 
-      std::string class_name = std::string("_Bitmap_cubical_complex_interface") +
-                                 get_string_filtration_type<Filtration_value>();
-      std::string persistence_class_name = std::string("_Cubical_complex_persistence_interface") +
-                                 get_string_filtration_type<Filtration_value>();
+      std::string class_name =
+        Gudhi::get_class_name_for_filtration_type<Filtration_value>("_Bitmap_cubical_complex_interface");
+      std::string persistence_class_name =
+        Gudhi::get_class_name_for_filtration_type<Filtration_value>("_Cubical_complex_persistence_interface");
 
       nb::class_<CC>(m, class_name.c_str())
           .def(nb::init<const std::vector<unsigned int>&, const std::vector<Filtration_value>&, bool>(),
@@ -134,19 +134,20 @@ NB_MODULE(_cubical_complex_ext, m)
 
   };
 
-  boost::mpl::for_each<
-    Data_structure_filtration_supported<Gudhi::cubical_complex::Cubical_complex_interface>::List
-  >(add_class_for_cubical_complex_interface);
-
+  Gudhi::for_each_filtration_value_type(
+    Gudhi::Supported_for_data_structure<Gudhi::cubical_complex::Cubical_complex_interface>::List{},
+    add_class_for_cubical_complex_interface
+  );
+  
   // Periodic_cubical_complex
   auto add_class_for_periodic_cubical_complex_interface = [&m](auto identity_tag) {
       using PCC = typename decltype(identity_tag)::type;
       using Filtration_value = typename PCC::Filtration_value;
 
-      std::string class_name = std::string("_Periodic_cubical_complex_interface") +
-                                 get_string_filtration_type<Filtration_value>();
-      std::string persistence_class_name = std::string("_Periodic_cubical_complex_persistence_interface") +
-                                 get_string_filtration_type<Filtration_value>();
+      std::string class_name =
+        Gudhi::get_class_name_for_filtration_type<Filtration_value>("_Periodic_cubical_complex_interface");
+      std::string persistence_class_name = 
+        Gudhi::get_class_name_for_filtration_type<Filtration_value>("_Periodic_cubical_complex_persistence_interface");
       
       nb::class_<PCC>(m, class_name.c_str())
           .def(nb::init<const std::vector<unsigned int>&, const std::vector<Filtration_value>&, const std::vector<bool>&, bool>(),
@@ -187,8 +188,9 @@ NB_MODULE(_cubical_complex_ext, m)
 
   };
   
-  boost::mpl::for_each<
-    Data_structure_filtration_supported<Gudhi::cubical_complex::Periodic_cubical_complex_interface>::List
-  >(add_class_for_periodic_cubical_complex_interface);
+  Gudhi::for_each_filtration_value_type(
+    Gudhi::Supported_for_data_structure<Gudhi::cubical_complex::Periodic_cubical_complex_interface>::List{},
+    add_class_for_periodic_cubical_complex_interface
+  );
 
 }

--- a/src/python/gudhi/_cubical_complex.cc
+++ b/src/python/gudhi/_cubical_complex.cc
@@ -18,17 +18,23 @@
 #include <nanobind/stl/pair.h>
 #include <nanobind/ndarray.h>
 
+#include <boost/mpl/for_each.hpp>
+
 #include <gudhi/Bitmap_cubical_complex.h>
 #include <gudhi/Bitmap_cubical_complex_base.h>
 #include <gudhi/Bitmap_cubical_complex_periodic_boundary_conditions_base.h>
 #include <python_interfaces/Persistent_cohomology_interface.h>
+#include <python_interfaces/filtration_value_types_support.h>
+
+namespace nb = nanobind;
 
 namespace Gudhi {
 namespace cubical_complex {
 
-class Cubical_complex_interface : public Bitmap_cubical_complex<Bitmap_cubical_complex_base<double>>
+template <class Filtration_value>
+class Cubical_complex_interface : public Bitmap_cubical_complex<Bitmap_cubical_complex_base<Filtration_value>>
 {
-  using Base = Bitmap_cubical_complex<Bitmap_cubical_complex_base<double>>;
+  using Base = Bitmap_cubical_complex<Bitmap_cubical_complex_base<Filtration_value>>;
 
  public:
   using Base::Base;  // inheriting constructors
@@ -40,16 +46,17 @@ class Cubical_complex_interface : public Bitmap_cubical_complex<Bitmap_cubical_c
   // But as the vector is probably very small (number of dimensions), it is perhaps not worth it.
   const std::vector<unsigned>& shape() { return this->sizes; };
 
-  nanobind::ndarray<double, nanobind::numpy> get_numpy_array()
+  nb::ndarray<Filtration_value, nb::numpy> get_numpy_array()
   {
-    return nanobind::ndarray<double, nanobind::numpy>(Base::data.data(), {Base::data.size()});
+    return nb::ndarray<Filtration_value, nb::numpy>(Base::data.data(), {Base::data.size()});
   }
 };
 
+template <class Filtration_value>
 class Periodic_cubical_complex_interface
-    : public Bitmap_cubical_complex<Bitmap_cubical_complex_periodic_boundary_conditions_base<double>>
+    : public Bitmap_cubical_complex<Bitmap_cubical_complex_periodic_boundary_conditions_base<Filtration_value>>
 {
-  using Base = Bitmap_cubical_complex<Bitmap_cubical_complex_periodic_boundary_conditions_base<double>>;
+  using Base = Bitmap_cubical_complex<Bitmap_cubical_complex_periodic_boundary_conditions_base<Filtration_value>>;
 
  public:
   using Base::Base;  // inheriting constructors
@@ -67,93 +74,121 @@ class Periodic_cubical_complex_interface
   // But as the vector is probably very small (number of dimensions), it is perhaps not worth it.
   const std::vector<bool>& periodicities() { return this->directions_in_which_periodic_b_cond_are_to_be_imposed; }
 
-  nanobind::ndarray<double, nanobind::numpy> get_numpy_array()
+  nb::ndarray<Filtration_value, nb::numpy> get_numpy_array()
   {
-    return nanobind::ndarray<double, nanobind::numpy>(Base::data.data(), {Base::data.size()});
+    return nb::ndarray<Filtration_value, nb::numpy>(Base::data.data(), {Base::data.size()});
   }
 };
 
 }  // namespace cubical_complex
 }  // namespace Gudhi
 
-namespace nb = nanobind;
-
-using CC = Gudhi::cubical_complex::Cubical_complex_interface;
-using CPers = Gudhi::Persistent_cohomology_interface<CC>;
-
-using PCC = Gudhi::cubical_complex::Periodic_cubical_complex_interface;
-using PCPers = Gudhi::Persistent_cohomology_interface<PCC>;
-
 NB_MODULE(_cubical_complex_ext, m)
 {
   m.attr("__license__") = "MIT";
+  
+  // Cubical_complex
+  auto add_class_for_cubical_complex_interface = [&m](auto identity_tag) {
+      using CC = typename decltype(identity_tag)::type;
+      using Filtration_value = typename CC::Filtration_value;
 
-  nb::class_<CC>(m, "_Bitmap_cubical_complex_interface")
-      .def(nb::init<const std::vector<unsigned int>&, const std::vector<double>&, bool>(),
-           nb::call_guard<nb::gil_scoped_release>())
-      .def(nb::init<const std::string&>(), nb::call_guard<nb::gil_scoped_release>())
-      .def("num_simplices", &CC::num_simplices, nb::call_guard<nb::gil_scoped_release>(), R"doc(
-This function returns the number of all cubes in the complex.
+      std::string class_name = std::string("_Bitmap_cubical_complex_interface") +
+                                 get_string_filtration_type<Filtration_value>();
+      std::string persistence_class_name = std::string("_Cubical_complex_persistence_interface") +
+                                 get_string_filtration_type<Filtration_value>();
 
-:returns:  int -- the number of all cubes in the complex.
-           )doc")
-      .def("dimension",
-           nb::overload_cast<>(&CC::dimension, nb::const_),
-           nb::call_guard<nb::gil_scoped_release>(),
-           R"doc(
-This function returns the dimension of the complex.
+      nb::class_<CC>(m, class_name.c_str())
+          .def(nb::init<const std::vector<unsigned int>&, const std::vector<Filtration_value>&, bool>(),
+               nb::call_guard<nb::gil_scoped_release>())
+          .def(nb::init<const std::string&>(), nb::call_guard<nb::gil_scoped_release>())
+          .def("num_simplices", &CC::num_simplices, nb::call_guard<nb::gil_scoped_release>(), R"doc(
+    This function returns the number of all cubes in the complex.
+    
+    :returns:  int -- the number of all cubes in the complex.
+               )doc")
+          .def("dimension",
+               nb::overload_cast<>(&CC::dimension, nb::const_),
+               nb::call_guard<nb::gil_scoped_release>(),
+               R"doc(
+    This function returns the dimension of the complex.
+    
+    :returns:  int -- the complex dimension.
+               )doc")
+          .def("_shape", &CC::shape)
+          .def("_get_numpy_array", &CC::get_numpy_array, nb::rv_policy::reference_internal);
 
-:returns:  int -- the complex dimension.
-           )doc")
-      .def("_shape", &CC::shape)
-      .def("_get_numpy_array", &CC::get_numpy_array, nb::rv_policy::reference_internal);
+      using CPers = Gudhi::Persistent_cohomology_interface<CC>;
+      nb::class_<CPers>(m, persistence_class_name.c_str())
+          .def(nb::init<CC&, bool>(), nb::call_guard<nb::gil_scoped_release>())
+          .def("_compute_persistence", &CPers::compute_persistence, nb::call_guard<nb::gil_scoped_release>())
+          .def("_get_persistence", &CPers::get_persistence)
+          .def("_cofaces_of_cubical_persistence_pairs",
+               &CPers::cofaces_of_cubical_persistence_pairs,
+               nb::call_guard<nb::gil_scoped_release>())
+          .def("_vertices_of_cubical_persistence_pairs",
+               &CPers::vertices_of_cubical_persistence_pairs,
+               nb::call_guard<nb::gil_scoped_release>())
+          .def("_betti_numbers", &CPers::betti_numbers)
+          .def("_persistent_betti_numbers", &CPers::persistent_betti_numbers)
+          .def("_intervals_in_dimension", &CPers::intervals_in_dimension);
 
-  nb::class_<CPers>(m, "_Cubical_complex_persistence_interface")
-      .def(nb::init<CC&, bool>(), nb::call_guard<nb::gil_scoped_release>())
-      .def("_compute_persistence", &CPers::compute_persistence, nb::call_guard<nb::gil_scoped_release>())
-      .def("_get_persistence", &CPers::get_persistence)
-      .def("_cofaces_of_cubical_persistence_pairs",
-           &CPers::cofaces_of_cubical_persistence_pairs,
-           nb::call_guard<nb::gil_scoped_release>())
-      .def("_vertices_of_cubical_persistence_pairs",
-           &CPers::vertices_of_cubical_persistence_pairs,
-           nb::call_guard<nb::gil_scoped_release>())
-      .def("_betti_numbers", &CPers::betti_numbers)
-      .def("_persistent_betti_numbers", &CPers::persistent_betti_numbers)
-      .def("_intervals_in_dimension", &CPers::intervals_in_dimension);
+  };
 
-  nb::class_<PCC>(m, "_Periodic_cubical_complex_interface")
-      .def(nb::init<const std::vector<unsigned int>&, const std::vector<double>&, const std::vector<bool>&, bool>(),
-           nb::call_guard<nb::gil_scoped_release>())
-      .def(nb::init<const std::string&>(), nb::call_guard<nb::gil_scoped_release>())
-      .def("num_simplices", &PCC::num_simplices, nb::call_guard<nb::gil_scoped_release>(), R"doc(
-This function returns the number of all cubes in the complex.
+  boost::mpl::for_each<
+    Data_structure_filtration_supported<Gudhi::cubical_complex::Cubical_complex_interface>::List
+  >(add_class_for_cubical_complex_interface);
 
-:returns:  int -- the number of all cubes in the complex.
-           )doc")
-      .def("dimension",
-           nb::overload_cast<>(&PCC::dimension, nb::const_),
-           nb::call_guard<nb::gil_scoped_release>(),
-           R"doc(
-This function returns the dimension of the complex.
+  // Periodic_cubical_complex
+  auto add_class_for_periodic_cubical_complex_interface = [&m](auto identity_tag) {
+      using PCC = typename decltype(identity_tag)::type;
+      using Filtration_value = typename PCC::Filtration_value;
 
-:returns:  int -- the complex dimension.
-           )doc")
-      .def("_shape", &PCC::shape)
-      .def("_periodicities", &PCC::periodicities)
-      .def("_get_numpy_array", &PCC::get_numpy_array, nb::rv_policy::reference_internal);
+      std::string class_name = std::string("_Periodic_cubical_complex_interface") +
+                                 get_string_filtration_type<Filtration_value>();
+      std::string persistence_class_name = std::string("_Periodic_cubical_complex_persistence_interface") +
+                                 get_string_filtration_type<Filtration_value>();
+      
+      nb::class_<PCC>(m, class_name.c_str())
+          .def(nb::init<const std::vector<unsigned int>&, const std::vector<Filtration_value>&, const std::vector<bool>&, bool>(),
+               nb::call_guard<nb::gil_scoped_release>())
+          .def(nb::init<const std::string&>(), nb::call_guard<nb::gil_scoped_release>())
+          .def("num_simplices", &PCC::num_simplices, nb::call_guard<nb::gil_scoped_release>(), R"doc(
+    This function returns the number of all cubes in the complex.
+    
+    :returns:  int -- the number of all cubes in the complex.
+               )doc")
+          .def("dimension",
+               nb::overload_cast<>(&PCC::dimension, nb::const_),
+               nb::call_guard<nb::gil_scoped_release>(),
+               R"doc(
+    This function returns the dimension of the complex.
+    
+    :returns:  int -- the complex dimension.
+               )doc")
+          .def("_shape", &PCC::shape)
+          .def("_periodicities", &PCC::periodicities)
+          .def("_get_numpy_array", &PCC::get_numpy_array, nb::rv_policy::reference_internal);
+    
+      using PCPers = Gudhi::Persistent_cohomology_interface<PCC>;
+      nb::class_<PCPers>(m, persistence_class_name.c_str())
+          .def(nb::init<PCC&, bool>(), nb::call_guard<nb::gil_scoped_release>())
+          .def("_compute_persistence", &PCPers::compute_persistence, nb::call_guard<nb::gil_scoped_release>())
+          .def("_get_persistence", &PCPers::get_persistence)
+          .def("_cofaces_of_cubical_persistence_pairs",
+               &PCPers::cofaces_of_cubical_persistence_pairs,
+               nb::call_guard<nb::gil_scoped_release>())
+          .def("_vertices_of_cubical_persistence_pairs",
+               &PCPers::vertices_of_cubical_persistence_pairs,
+               nb::call_guard<nb::gil_scoped_release>())
+          .def("_betti_numbers", &PCPers::betti_numbers)
+          .def("_persistent_betti_numbers", &PCPers::persistent_betti_numbers)
+          .def("_intervals_in_dimension", &PCPers::intervals_in_dimension);
 
-  nb::class_<PCPers>(m, "_Periodic_cubical_complex_persistence_interface")
-      .def(nb::init<PCC&, bool>(), nb::call_guard<nb::gil_scoped_release>())
-      .def("_compute_persistence", &PCPers::compute_persistence, nb::call_guard<nb::gil_scoped_release>())
-      .def("_get_persistence", &PCPers::get_persistence)
-      .def("_cofaces_of_cubical_persistence_pairs",
-           &PCPers::cofaces_of_cubical_persistence_pairs,
-           nb::call_guard<nb::gil_scoped_release>())
-      .def("_vertices_of_cubical_persistence_pairs",
-           &PCPers::vertices_of_cubical_persistence_pairs,
-           nb::call_guard<nb::gil_scoped_release>())
-      .def("_betti_numbers", &PCPers::betti_numbers)
-      .def("_persistent_betti_numbers", &PCPers::persistent_betti_numbers)
-      .def("_intervals_in_dimension", &PCPers::intervals_in_dimension);
+
+  };
+  
+  boost::mpl::for_each<
+    Data_structure_filtration_supported<Gudhi::cubical_complex::Periodic_cubical_complex_interface>::List
+  >(add_class_for_periodic_cubical_complex_interface);
+
 }

--- a/src/python/gudhi/_pers_cub_low_dim.cc
+++ b/src/python/gudhi/_pers_cub_low_dim.cc
@@ -18,35 +18,39 @@
 
 #include <boost/range/counting_range.hpp>
 #include <boost/range/adaptor/transformed.hpp>
+#include <boost/mpl/for_each.hpp>
 
 #include <gudhi/Persistence_on_a_line.h>
 #include <gudhi/Persistence_on_rectangle.h>
 #include <python_interfaces/numpy_utils.h>
+#include <python_interfaces/filtration_value_types_support.h>
 
 namespace nb = nanobind;
 
-template <class T>
-auto wrap_persistence_1d(nb::ndarray<const T, nb::ndim<1> > data)
+template <class Filtration_value>
+auto wrap_persistence_1d(nb::ndarray<const Filtration_value, nb::ndim<1> > data)
 {
   auto data_view = data.view();
   auto cnt = boost::counting_range<nb::ssize_t>(0, data_view.shape(0));
   auto proj = [&data_view](nb::ssize_t i) { return data_view(i); };
   auto r = boost::adaptors::transform(cnt, proj);
-  std::vector<std::array<T, 2> > dgm;
+  std::vector<std::array<Filtration_value, 2> > dgm;
   dgm.reserve(data_view.shape(0) + 1);  // rough upper bound
   {
     nb::gil_scoped_release release;
     Gudhi::persistent_cohomology::compute_persistence_of_function_on_line(
-        r, [&](T b, T d) { dgm.emplace_back(std::array<T, 2>{b, d}); });
+        r, [&](Filtration_value b, Filtration_value d) { dgm.emplace_back(std::array<Filtration_value, 2>{b, d}); });
   }
   if (dgm.size() < data_view.shape(0) / 2) dgm.shrink_to_fit();
   return _wrap_as_numpy_array(std::move(dgm));
 }
 
-nb::list wrap_persistence_2d(nb::ndarray<const double, nb::ndim<2>, nb::c_contig> data, double min_persistence)
+template <class Filtration_value>
+nb::list wrap_persistence_2d(nb::ndarray<const Filtration_value, nb::ndim<2>, nb::c_contig> data,
+                             Filtration_value min_persistence)
 {
-  std::vector<std::array<double, 2> > dgm0;
-  std::vector<std::array<double, 2> > dgm1;
+  std::vector<std::array<Filtration_value, 2> > dgm0;
+  std::vector<std::array<Filtration_value, 2> > dgm1;
   // rough upper bound: a bar for each possible square that do not touch anything else
   // + the rows and columns on the boundary are implicitly collapsed
   dgm0.reserve((data.shape(0) + 1) * (data.shape(1) + 1) / 4);
@@ -55,21 +59,21 @@ nb::list wrap_persistence_2d(nb::ndarray<const double, nb::ndim<2>, nb::c_contig
   dgm1.reserve(((data.shape(0) - 2) * (data.shape(1) - 2) + 1) / 2);
   {
     nb::gil_scoped_release release;
-    double mini = Gudhi::cubical_complex::persistence_on_rectangle_from_top_cells(
-        static_cast<double const*>(data.data()),
+    Filtration_value mini = Gudhi::cubical_complex::persistence_on_rectangle_from_top_cells(
+        static_cast<Filtration_value const*>(data.data()),
         static_cast<unsigned int>(data.shape(0)),
         static_cast<unsigned int>(data.shape(1)),
-        [&](double b, double d) {
+        [&](Filtration_value b, Filtration_value d) {
           if (d - b > min_persistence) {
-            dgm0.emplace_back(std::array<double, 2>{b, d});
+            dgm0.emplace_back(std::array<Filtration_value, 2>{b, d});
           }
         },
-        [&](double b, double d) {
+        [&](Filtration_value b, Filtration_value d) {
           if (d - b > min_persistence) {
-            dgm1.emplace_back(std::array<double, 2>{b, d});
+            dgm1.emplace_back(std::array<Filtration_value, 2>{b, d});
           }
         });
-    dgm0.emplace_back(std::array<double, 2>{mini, std::numeric_limits<double>::infinity()});
+    dgm0.emplace_back(std::array<Filtration_value, 2>{mini, std::numeric_limits<Filtration_value>::infinity()});
   }
   if (dgm0.size() < dgm0.capacity() / 2) dgm0.shrink_to_fit();
   if (dgm1.size() < dgm1.capacity() / 2) dgm1.shrink_to_fit();
@@ -82,7 +86,14 @@ nb::list wrap_persistence_2d(nb::ndarray<const double, nb::ndim<2>, nb::c_contig
 NB_MODULE(_pers_cub_low_dim_ext, m)
 {
   m.attr("__license__") = "MIT";
-  m.def("_persistence_on_a_line", &wrap_persistence_1d<float>, nb::arg().noconvert());
-  m.def("_persistence_on_a_line", &wrap_persistence_1d<double>);
-  m.def("_persistence_on_rectangle_from_top_cells", &wrap_persistence_2d);
+  boost::mpl::for_each<Filtration_value_types_supported::List>([&m](auto identity_tag) {
+    using Filtration_value = typename decltype(identity_tag)::type;
+    m.def("_persistence_on_a_line", &wrap_persistence_1d<Filtration_value>, nb::arg().noconvert());
+    // Do not modify nb::arg("data") with nb::arg("data").noconvert().
+    // It is required when a nb::f_contig is given as an input. Nanobind will convert it to a nb::c_contig
+    m.def("_persistence_on_rectangle_from_top_cells",
+          &wrap_persistence_2d<double>,
+          nb::arg("data"),
+          nb::arg("min_persistence"));
+    });
 }

--- a/src/python/gudhi/_pers_cub_low_dim.cc
+++ b/src/python/gudhi/_pers_cub_low_dim.cc
@@ -18,7 +18,6 @@
 
 #include <boost/range/counting_range.hpp>
 #include <boost/range/adaptor/transformed.hpp>
-#include <boost/mpl/for_each.hpp>
 
 #include <gudhi/Persistence_on_a_line.h>
 #include <gudhi/Persistence_on_rectangle.h>
@@ -28,8 +27,7 @@
 namespace nb = nanobind;
 
 template <class Filtration_value>
-auto wrap_persistence_1d(nb::ndarray<const Filtration_value, nb::ndim<1> > data)
-{
+auto wrap_persistence_1d(nb::ndarray<const Filtration_value, nb::ndim<1> > data) {
   auto data_view = data.view();
   auto cnt = boost::counting_range<nb::ssize_t>(0, data_view.shape(0));
   auto proj = [&data_view](nb::ssize_t i) { return data_view(i); };
@@ -47,8 +45,7 @@ auto wrap_persistence_1d(nb::ndarray<const Filtration_value, nb::ndim<1> > data)
 
 template <class Filtration_value>
 nb::list wrap_persistence_2d(nb::ndarray<const Filtration_value, nb::ndim<2>, nb::c_contig> data,
-                             Filtration_value min_persistence)
-{
+                             Filtration_value min_persistence) {
   std::vector<std::array<Filtration_value, 2> > dgm0;
   std::vector<std::array<Filtration_value, 2> > dgm1;
   // rough upper bound: a bar for each possible square that do not touch anything else
@@ -86,14 +83,16 @@ nb::list wrap_persistence_2d(nb::ndarray<const Filtration_value, nb::ndim<2>, nb
 NB_MODULE(_pers_cub_low_dim_ext, m)
 {
   m.attr("__license__") = "MIT";
-  boost::mpl::for_each<Filtration_value_types_supported::List>([&m](auto identity_tag) {
-    using Filtration_value = typename decltype(identity_tag)::type;
-    m.def("_persistence_on_a_line", &wrap_persistence_1d<Filtration_value>, nb::arg().noconvert());
-    // Do not modify nb::arg("data") with nb::arg("data").noconvert().
-    // It is required when a nb::f_contig is given as an input. Nanobind will convert it to a nb::c_contig
-    m.def("_persistence_on_rectangle_from_top_cells",
-          &wrap_persistence_2d<double>,
-          nb::arg("data"),
+  Gudhi::for_each_filtration_value_type(Gudhi::Supported::List{},
+    [&m](auto identity_tag) {
+      using Filtration_value = typename decltype(identity_tag)::type;
+      m.def("_persistence_on_a_line", &wrap_persistence_1d<Filtration_value>, nb::arg().noconvert());
+      // Do not modify nb::arg("data").noconvert()
+      // When calling this function user must pass a c_contig ndarray
+      m.def("_persistence_on_rectangle_from_top_cells",
+          &wrap_persistence_2d<Filtration_value>,
+          nb::arg("data").noconvert(),
           nb::arg("min_persistence"));
     });
+
 }

--- a/src/python/gudhi/cubical_complex.py
+++ b/src/python/gudhi/cubical_complex.py
@@ -14,13 +14,13 @@ __license__ = "MIT"
 import numpy as np
 
 from gudhi._cubical_complex_ext import (
-    _Bitmap_cubical_complex_interface,
-    _Cubical_complex_persistence_interface,
+    _Bitmap_cubical_complex_interface_float64,
+    _Cubical_complex_persistence_interface_float64,
 )
 
 
 # CubicalComplex python interface
-class CubicalComplex(_Bitmap_cubical_complex_interface):
+class CubicalComplex(_Bitmap_cubical_complex_interface_float64):
     """The CubicalComplex is an example of a structured complex useful in
     computational mathematics (specially rigorous numerics) and image
     analysis.
@@ -150,7 +150,7 @@ class CubicalComplex(_Bitmap_cubical_complex_interface):
         :type min_persistence: float.
         :returns: Nothing.
         """
-        self._pers = _Cubical_complex_persistence_interface(self, True)
+        self._pers = _Cubical_complex_persistence_interface_float64(self, True)
         self._pers._compute_persistence(homology_coeff_field, min_persistence)
 
     def persistence(self, homology_coeff_field=11, min_persistence=0):

--- a/src/python/gudhi/periodic_cubical_complex.py
+++ b/src/python/gudhi/periodic_cubical_complex.py
@@ -14,13 +14,13 @@ __license__ = "MIT"
 import numpy as np
 
 from gudhi._cubical_complex_ext import (
-    _Periodic_cubical_complex_interface,
-    _Periodic_cubical_complex_persistence_interface,
+    _Periodic_cubical_complex_interface_float64,
+    _Periodic_cubical_complex_persistence_interface_float64,
 )
 
 
 # PeriodicCubicalComplex python interface
-class PeriodicCubicalComplex(_Periodic_cubical_complex_interface):
+class PeriodicCubicalComplex(_Periodic_cubical_complex_interface_float64):
     """The PeriodicCubicalComplex is an example of a structured complex useful
     in computational mathematics (specially rigorous numerics) and image
     analysis.
@@ -163,7 +163,7 @@ class PeriodicCubicalComplex(_Periodic_cubical_complex_interface):
         :type min_persistence: float.
         :returns: Nothing.
         """
-        self._pers = _Periodic_cubical_complex_persistence_interface(self, True)
+        self._pers = _Periodic_cubical_complex_persistence_interface_float64(self, True)
         self._pers._compute_persistence(homology_coeff_field, min_persistence)
 
     def persistence(self, homology_coeff_field=11, min_persistence=0):

--- a/src/python/gudhi/sklearn/cubical_persistence.py
+++ b/src/python/gudhi/sklearn/cubical_persistence.py
@@ -153,7 +153,9 @@ class CubicalPersistence(BaseEstimator, TransformerMixin):
                 diags = _persistence_on_rectangle_from_top_cells(cells, self.min_persistence)
             return [diags[i] if i in (0, 1) else np.empty((0, 2)) for i in self._dim_list]
 
-        cells = np.asarray(cells, order="F")
+        cells = np.asarray(cells)
+        if not cells.flags.f_contiguous:
+            cells = cells.T
         dimensions = cells.shape
         cells = cells.ravel(order="F")
         CubicalComplexItf = self._DTYPE_CUBICAL_COMPLEX_MAP[cells.dtype]

--- a/src/python/gudhi/sklearn/cubical_persistence.py
+++ b/src/python/gudhi/sklearn/cubical_persistence.py
@@ -90,6 +90,8 @@ class CubicalPersistence(BaseEstimator, TransformerMixin):
 
     def __transform(self, cells):
         cells = np.asarray(cells)
+        if not np.issubdtype(type(cells.flat[0]), np.floating):
+            cells = cells.astype("float64")
         if len(cells.shape) == 1 and self.min_persistence >= 0:
             res = _persistence_on_a_line(cells)
             if self.min_persistence > 0:

--- a/src/python/gudhi/sklearn/cubical_persistence.py
+++ b/src/python/gudhi/sklearn/cubical_persistence.py
@@ -16,7 +16,12 @@ from typing import Literal, Optional
 from sklearn.base import BaseEstimator, TransformerMixin
 from joblib import Parallel, delayed
 
-from .. import CubicalComplex
+from .._cubical_complex_ext import (
+    _Bitmap_cubical_complex_interface_float64,
+    _Cubical_complex_persistence_interface_float64,
+    _Bitmap_cubical_complex_interface_float32,
+    _Cubical_complex_persistence_interface_float32,
+)
 from .._pers_cub_low_dim_ext import (
     _persistence_on_a_line,
     _persistence_on_rectangle_from_top_cells,
@@ -41,6 +46,16 @@ class CubicalPersistence(BaseEstimator, TransformerMixin):
     """
     This is a class for computing the persistence diagrams from a cubical complex.
     """
+
+    _DTYPE_CUBICAL_COMPLEX_MAP = {
+        np.dtype(np.float32): _Bitmap_cubical_complex_interface_float32,
+        np.dtype(np.float64): _Bitmap_cubical_complex_interface_float64,
+    }
+
+    _DTYPE_CUBICAL_COMPLEX_PERSISTENCE_MAP = {
+        np.dtype(np.float32): _Cubical_complex_persistence_interface_float32,
+        np.dtype(np.float64): _Cubical_complex_persistence_interface_float64,
+    }
 
     def __init__(
         self,
@@ -75,10 +90,16 @@ class CubicalPersistence(BaseEstimator, TransformerMixin):
         if dim_list.ndim not in [0, 1]:
             raise ValueError(f"Invalid dimension. Got {self.homology_dimensions=}, expected type=int|ArrayLike[int].")
 
+    def _validate_attributes(self):
+        # Must not be done in constructor, but in fit and transform methods
+        if self.input_type not in ["top_dimensional_cells", "vertices"]:
+            raise ValueError("input_type can only be 'top_dimensional_cells' or 'vertices'")
+
     def fit(self, X, Y=None):
         """
         Fit the `CubicalPersistence` class in function of `homology_dimensions` type.
         """
+        self._validate_attributes()
         # Must be in the `fit` part, as `transform` should be const and as `__init__` is not called on a parallel grid
         # search for instance
         self._dim_list = np.asarray(self.homology_dimensions, dtype=int)
@@ -88,9 +109,28 @@ class CubicalPersistence(BaseEstimator, TransformerMixin):
             self._dim_list = self._dim_list.reshape(1)
         return self
 
+    def _persistence_intervals_in_dimension(self, cub_pers, dimension):
+        """This function returns the persistence intervals of the complex in a
+        specific dimension.
+
+        :param dimension: The specific dimension.
+        :type dimension: int.
+        :returns: The persistence intervals.
+        :rtype:  numpy array of dimension 2
+        """
+        piid = np.array(cub_pers._intervals_in_dimension(dimension))
+        # Workaround https://github.com/GUDHI/gudhi-devel/issues/507
+        if len(piid) == 0:
+            return np.empty(shape=[0, 2])
+        return piid
+            
     def __transform(self, cells):
-        cells = np.asarray(cells)
-        if not np.issubdtype(type(cells.flat[0]), np.floating):
+        cells = np.asarray(cells, order="C")
+        # cf. src/python/test/test_sklearn_cubical_persistence.py - test_1d
+        # a = np.array([2, 4, 3, 5])
+        # ri = CubicalPersistence(0).fit_transform([a])[0]
+        # assert ri.dtype == np.dtype("float64") # whereas a.dtype == np.int64
+        if not np.issubdtype(cells.dtype, np.floating):
             cells = cells.astype("float64")
         if len(cells.shape) == 1 and self.min_persistence >= 0:
             res = _persistence_on_a_line(cells)
@@ -113,17 +153,16 @@ class CubicalPersistence(BaseEstimator, TransformerMixin):
                 diags = _persistence_on_rectangle_from_top_cells(cells, self.min_persistence)
             return [diags[i] if i in (0, 1) else np.empty((0, 2)) for i in self._dim_list]
 
-        if self.input_type == "top_dimensional_cells":
-            cubical_complex = CubicalComplex(top_dimensional_cells=cells)
-        elif self.input_type == "vertices":
-            cubical_complex = CubicalComplex(vertices=cells)
-        else:
-            raise ValueError("input_type can only be 'top_dimensional_cells' or 'vertices'")
-        cubical_complex.compute_persistence(
-            homology_coeff_field=self.homology_coeff_field,
-            min_persistence=self.min_persistence,
-        )
-        return [cubical_complex.persistence_intervals_in_dimension(dim) for dim in self._dim_list]
+        cells = np.asarray(cells, order="F")
+        dimensions = cells.shape
+        cells = cells.ravel(order="F")
+        CubicalComplexItf = self._DTYPE_CUBICAL_COMPLEX_MAP[cells.dtype]
+        cub = CubicalComplexItf(dimensions, cells, self.input_type == "top_dimensional_cells")
+
+        CubicalComplexPersistenceItf = self._DTYPE_CUBICAL_COMPLEX_PERSISTENCE_MAP[cells.dtype]
+        cub_pers = CubicalComplexPersistenceItf(cub, True)
+        cub_pers._compute_persistence(self.homology_coeff_field, self.min_persistence)
+        return [self._persistence_intervals_in_dimension(cub_pers, dim) for dim in self._dim_list]
 
     def transform(self, X, Y=None):
         """Compute all the cubical complexes and their associated persistence diagrams.
@@ -138,6 +177,8 @@ class CubicalPersistence(BaseEstimator, TransformerMixin):
                 `[[array( Hi(X[0]) ), array( Hj(X[0]) )], [array( Hi(X[1]) ), array( Hj(X[1]) )], ...]`
         :rtype: list of (,2) array_like or list of list of (,2) array_like
         """
+        self._validate_attributes()
+
         # threads is preferred as cubical construction and persistence computation releases the GIL
         res = Parallel(n_jobs=self.n_jobs, prefer="threads")(delayed(self.__transform)(cells) for cells in X)
         # cf. `fit`

--- a/src/python/include/python_interfaces/filtration_value_types_support.h
+++ b/src/python/include/python_interfaces/filtration_value_types_support.h
@@ -8,58 +8,74 @@
  *      - YYYY/MM Author: Description of the modification
  */
 
+#ifndef INCLUDE_FILTRATION_VALUE_TYPES_SUPPORT_H_
+#define INCLUDE_FILTRATION_VALUE_TYPES_SUPPORT_H_
+
 #include <string>
 #include <type_traits>  // for std::is_same_v
 
-#include <boost/mpl/list.hpp>
-#include <boost/mpl/identity.hpp>
-#include <boost/mpl/transform.hpp>
-#include <boost/mpl/placeholders.hpp>
+namespace Gudhi {
 
-// Developper notice:
-// If you need to add a new type to Filtration_value_types_supported, you will also have to add a condition to
-// get_string_filtration_type() for the python class name to be suffixed with the type. The class names must be
-// different (for example, _Bitmap_cubical_complex_interface and _Bitmap_cubical_complex_interface_float32)
-template<class Filtration_value>
-constexpr std::string get_string_filtration_type()
-{
-  if constexpr (std::is_same_v<Filtration_value, float>)
-    return std::string("_float32");
-  // for backward compatibility
-  return std::string("");
-}
+  // Developper notice:
+  // If you need to add a new type:
+  // 1. you have to add a condition to get_class_name_for_filtration_type() for the python class name to be suffixed
+  //    with the type as the class names must be different.
+  // 2. you need to add the new type in Supported::List
+  // 
+  // Supported_for_data_structure::List is automatically updated (nothing to be done here)
 
-struct Filtration_value_types_supported {
-  using List = boost::mpl::list<boost::mpl::identity<float>,
-                                boost::mpl::identity<double>>;
-};
+  template<class Filtration_value>
+  constexpr std::string get_class_name_for_filtration_type(const std::string& root_class_name)
+  {
+    if constexpr (std::is_same_v<Filtration_value, float>)
+      return root_class_name + std::string("_float32");
+    if constexpr (std::is_same_v<Filtration_value, double>)
+      return root_class_name + std::string("_float64");
+  }
 
+  // To get the identity of a type
+  template<class T>
+  struct identity { using type = T; };
 
-// Data_structure must accept Filtration_value as a template parameter (Data_structure<Filtration_value> shall compile)
-// Then boost::mpl::for_each<Data_structure_filtration_supported<Data_structure>::List>(my_lambda);
-// will call my_lambda for all Data_structure<Filtration_value>, where Filtration_value is one of
-// Filtration_value_types_supported
-// 
-// Equivalent to:
-//
-// template<template<typename> class Data_structure>
-// struct Data_structure_filtration_supported {
-//   using List = boost::mpl::list<
-//     boost::mpl::identity<Data_structure<float>>,
-//     boost::mpl::identity<Data_structure<double>>
-//   >;
-// };
-template<template<typename> class Data_structure>
-struct Data_structure_filtration_supported {
+  // A list of Types
+  template<class... Ts>
+  struct type_list {};
 
-  // metafunction: identity<T> -> identity<Data_structure<T>>
-  template<typename Wrapped>
-  struct wrap {
-    using type = boost::mpl::identity<Data_structure<typename Wrapped::type>>;
+  struct Supported {
+    using List = type_list<float, double>;
   };
 
-  using List = typename boost::mpl::transform<
-      typename Filtration_value_types_supported::List,
-      wrap<boost::mpl::_1>
-    >::type;
-};
+  // Data_structure must accept Filtration_value as a template parameter (Data_structure<Filtration_value> shall compile)
+  // Then for_each_filtration_value_type(Supported_for_data_structure<Data_structure>::List>,my_lambda);
+  // will call my_lambda for all Data_structure<Filtration_value>, where Filtration_value is one of
+  // Supported
+  // 
+  // Equivalent to:
+  //
+  // template<template<typename> class Data_structure>
+  // struct Supported_for_data_structure {
+  //   using List = type_list<Data_structure<float>, Data_structure<double>>;
+  // };
+  template<template<typename> class Data_structure>
+  struct Supported_for_data_structure {
+   private:
+    // metafunction (partial specialization): type_list<Ts...> -> type_list<Data_structure<Ts>...>
+    template<class L> struct wrap;
+    template<class... Ts>
+    struct wrap<type_list<Ts...>> {
+      using type = type_list<Data_structure<Ts>...>;
+    };
+
+   public:
+    using List = typename wrap<typename Supported::List>::type;
+  };
+
+  // Calls f(identity<T>{}) for every T in the list
+  template<class... Ts, class F>
+  void for_each_filtration_value_type(type_list<Ts...>, F&& f) {
+    (f(identity<Ts>{}), ...);
+  }
+
+}  // namespace Gudhi
+
+#endif  // INCLUDE_FILTRATION_VALUE_TYPES_SUPPORT_H_

--- a/src/python/include/python_interfaces/filtration_value_types_support.h
+++ b/src/python/include/python_interfaces/filtration_value_types_support.h
@@ -1,0 +1,65 @@
+/*    This file is part of the Gudhi Library - https://gudhi.inria.fr/ - which is released under MIT.
+ *    See file LICENSE or go to https://gudhi.inria.fr/licensing/ for full license details.
+ *    Author(s):       Vincent Rouvreau
+ *
+ *    Copyright (C) 2026 Inria
+ *
+ *    Modification(s):
+ *      - YYYY/MM Author: Description of the modification
+ */
+
+#include <string>
+#include <type_traits>  // for std::is_same_v
+
+#include <boost/mpl/list.hpp>
+#include <boost/mpl/identity.hpp>
+#include <boost/mpl/transform.hpp>
+#include <boost/mpl/placeholders.hpp>
+
+// Developper notice:
+// If you need to add a new type to Filtration_value_types_supported, you will also have to add a condition to
+// get_string_filtration_type() for the python class name to be suffixed with the type. The class names must be
+// different (for example, _Bitmap_cubical_complex_interface and _Bitmap_cubical_complex_interface_float32)
+template<class Filtration_value>
+constexpr std::string get_string_filtration_type()
+{
+  if constexpr (std::is_same_v<Filtration_value, float>)
+    return std::string("_float32");
+  // for backward compatibility
+  return std::string("");
+}
+
+struct Filtration_value_types_supported {
+  using List = boost::mpl::list<boost::mpl::identity<float>,
+                                boost::mpl::identity<double>>;
+};
+
+
+// Data_structure must accept Filtration_value as a template parameter (Data_structure<Filtration_value> shall compile)
+// Then boost::mpl::for_each<Data_structure_filtration_supported<Data_structure>::List>(my_lambda);
+// will call my_lambda for all Data_structure<Filtration_value>, where Filtration_value is one of
+// Filtration_value_types_supported
+// 
+// Equivalent to:
+//
+// template<template<typename> class Data_structure>
+// struct Data_structure_filtration_supported {
+//   using List = boost::mpl::list<
+//     boost::mpl::identity<Data_structure<float>>,
+//     boost::mpl::identity<Data_structure<double>>
+//   >;
+// };
+template<template<typename> class Data_structure>
+struct Data_structure_filtration_supported {
+
+  // metafunction: identity<T> -> identity<Data_structure<T>>
+  template<typename Wrapped>
+  struct wrap {
+    using type = boost::mpl::identity<Data_structure<typename Wrapped::type>>;
+  };
+
+  using List = typename boost::mpl::transform<
+      typename Filtration_value_types_supported::List,
+      wrap<boost::mpl::_1>
+    >::type;
+};

--- a/src/python/test/test_cubical_complex.py
+++ b/src/python/test/test_cubical_complex.py
@@ -15,6 +15,7 @@ import numpy as np
 import pytest
 
 from gudhi import CubicalComplex, PeriodicCubicalComplex
+from gudhi._cubical_complex_ext import _Bitmap_cubical_complex_interface_float64, _Bitmap_cubical_complex_interface_float32
 from numpy.testing import assert_almost_equal
 
 def test_empty_constructor():
@@ -442,3 +443,13 @@ def test_contiguity_for_top_dimensional_cells_input():
                                    periodic_dimensions=(False, False))
     # Test top_dimensional_cells() should be enough here, but let's go with all_cells()
     assert_almost_equal(cub_c.all_cells(), cub_r.all_cells())
+
+def test_filtration_types():
+    for from_vertices in [True, False]:
+        cells = np.array([1., 2., 3., 2., 4., 1., 3., 2., 1.], dtype=np.float64)
+        cub = _Bitmap_cubical_complex_interface_float64((3, 3), cells, from_vertices)
+        assert cub._get_numpy_array().dtype == np.float64
+    
+        cells = np.array([1., 2., 3., 2., 4., 1., 3., 2., 1.], dtype=np.float32)
+        cub = _Bitmap_cubical_complex_interface_float32((3, 3), cells, from_vertices)
+        assert cub._get_numpy_array().dtype == np.float32

--- a/src/python/test/test_cubical_persistence_low_dim.py
+++ b/src/python/test/test_cubical_persistence_low_dim.py
@@ -12,6 +12,7 @@
 
 import numpy as np
 from numpy.testing import assert_almost_equal
+import pytest
 
 from gudhi._pers_cub_low_dim_ext import _persistence_on_rectangle_from_top_cells
 from gudhi._pers_cub_low_dim_ext import _persistence_on_a_line
@@ -73,10 +74,21 @@ def test_contiguity_for_persistence_on_rectangle():
     # Get a 10x10 slice of a 20x10 random values - base is not contiguous
     base = rng.standard_normal((20, 10))[::2]
     persrec_c = _persistence_on_rectangle_from_top_cells(np.ascontiguousarray(base), 0.)
-    persrec_f = _persistence_on_rectangle_from_top_cells(np.asfortranarray(base), 0.)
-    for idx in range(2):
-        assert_almost_equal(persrec_c[idx], persrec_f[idx])
+    # _persistence_on_rectangle_from_top_cells only accepts c_contig
+    with pytest.raises(TypeError):
+        persrec_f = _persistence_on_rectangle_from_top_cells(np.asfortranarray(base), 0.)
+    
+    with pytest.raises(TypeError):
+        persrec_r = _persistence_on_rectangle_from_top_cells(base, 0.)
 
-    persrec_r = _persistence_on_rectangle_from_top_cells(base, 0.)
-    for idx in range(2):
-        assert_almost_equal(persrec_c[idx], persrec_r[idx])
+def test_filtration_types_for_persistence_on_a_line():
+    for type in [np.float32, np.float64]:
+        cells = np.array([1. ,2. ,3. ,2. ,4. ,1.], dtype=type)
+        diag = _persistence_on_a_line(cells)
+        assert diag.dtype == type
+    
+def test_filtration_types_for_persistence_on_rectangle():
+    for type in [np.float32, np.float64]:
+        cells = np.array([[1., 2., 3.], [2., 4., 1.], [3., 2., 1.]], dtype=type)
+        diag = _persistence_on_rectangle_from_top_cells(cells, 0.)
+        assert diag[0].dtype == type

--- a/src/python/test/test_sklearn_cubical_persistence.py
+++ b/src/python/test/test_sklearn_cubical_persistence.py
@@ -83,3 +83,23 @@ def test_compare_top_cells():
     cmp(np.array(a, order="F"))
     cmp(a[0:18])
     cmp(a[::2, ::-1])
+
+
+def test_filtration_types():
+    for type in [np.float32, np.float64]:
+        # 1d
+        a = np.array([2., 4., 3., 5.], dtype=type)
+        r = CubicalPersistence(0).fit_transform([a])[0]
+        assert r.dtype == type
+
+        # 2d
+        a = np.array([[1., 2., 3.], [2., 4., 1.], [3., 2., 1.]], dtype=type)
+        r = CubicalPersistence(0).fit_transform([a])[0]
+        assert r.dtype == type
+
+        # 3d
+        a = np.array([[ 1.,  8.,  7.],
+                      [ 4., 20.,  6.],
+                      [ 6.,  4.,  5.]], dtype=type)
+        r = CubicalPersistence(0).fit_transform([a])[0]
+        assert r.dtype == type


### PR DESCRIPTION
The aim of this PR is to discuss on the manner to manage float32/float64/... types for GUDHI's datastructures.
I started with the Cubical.


* src/python/include/python_interfaces/filtration_value_types_support.h
    - struct Supported { using List = type_list<float, double>; };
    - (equivalent) struct Supported_for_data_structure { using List = type_list<Data_structure<float>, Data_structure<double>>; };
    - for_each_filtration_value_type to loop on Supported or Supported_for_data_structure

* New classes generated in loop thanks to for_each_filtration_value_type in src/python/gudhi/_cubical_complex.cc
    - _Bitmap_cubical_complex_interface[_float32|_float64]
    - _Cubical_complex_persistence_interface[_float32|_float64]
    - _Periodic_cubical_complex_interface[_float32|_float64]
    - _Periodic_cubical_complex_persistence_interface[_float32|_float64]

* functions generated in loop thanks to for_each_filtration_value_type in src/python/gudhi/_pers_cub_low_dim.cc
    - _persistence_on_a_line nb::arg("data").noconvert() -> wrap_persistence_1d<[double|float]>(nb::ndarray<nb::c_contig>) 
    - _persistence_on_rectangle_from_top_cells nb::arg("data").noconvert() -> wrap_persistence_2d<[double|float]>(nb::ndarray<nb::c_contig>)
    - API change: _persistence_on_a_line and _persistence_on_rectangle_from_top_cells now accept only c_contig arrays

* src/python/gudhi/sklearn/cubical_persistence.py
    - def __transform(self, cells):
          cells = np.asarray(cells, order="C") # Conversion is now done here
          # This one is just to satisfy a test with integers. Should we also need int64 ?
          if not np.issubdtype(type(cells.flat[0]), np.floating):
              cells = cells.astype("float64")

I also needed to fix some unitary tests.
I didn't fix CubicalComplex and PeriodicCubicalComplex as conditional inheritance is not easy here.
I tried to add int64 type and only *few changes* were required (I can show on a gist).