### PR TITLE
Remove default empty list for points argument in the constructor of Alpha/Delaunay*Complex

### DIFF
--- a/src/python/gudhi/delaunay_complex.py
+++ b/src/python/gudhi/delaunay_complex.py
@@ -34,7 +34,7 @@ class DelaunayComplex(t.Delaunay_complex_interface):
 
     def __init__(
         self,
-        points: Sequence[Sequence[float]] = [],
+        points: Sequence[Sequence[float]],
         weights: Optional[Sequence[float]] = None,
         precision: Literal["fast", "safe", "exact"] = "safe",
     ):
@@ -154,7 +154,7 @@ class DelaunayCechComplex(DelaunayComplex):
         When DelaunayCechComplex is constructed with an infinite value of alpha, the complex is a Delaunay complex.
     """
 
-    def __init__(self, points=[], precision="safe"):
+    def __init__(self, points, precision="safe"):
         """
         Args:
             points (Sequence[Sequence[float]]): A list of points in d-Dimension.

--- a/src/python/test/test_delaunay_complex.py
+++ b/src/python/test/test_delaunay_complex.py
@@ -27,7 +27,7 @@ from gudhi import AlphaComplex, DelaunayComplex, DelaunayCechComplex
 
 
 def _empty_complex(simplicial_complex, precision):
-    cplx = simplicial_complex(precision=precision)
+    cplx = simplicial_complex(points=[], precision=precision)
 
 
 def _one_2d_point_complex(simplicial_complex, precision):


### PR DESCRIPTION
Fix #578 