### PR TITLE
New "C" 2-torus dataset generator to replace some `__root_source_dir__`

### DIFF
--- a/src/python/doc/datasets.rst
+++ b/src/python/doc/datasets.rst
@@ -147,6 +147,49 @@ Example
 .. autofunction:: gudhi.datasets.generators.points.torus
 
 
+Third function: **c_2_torus**
+"""""""""""""""""""""""""""""
+
+.. table::
+   :widths: 50 50
+
+   +---------------------------------------------+------------------------------------------+
+   | :Requires: `CGAL <installation.html#cgal>`_ | :License: MIT (`LGPL v3 </licensing/>`_) |
+   +---------------------------------------------+------------------------------------------+
+
+The user should provide the number of points to be generated on the 2-torus :code:`n_samples`,
+the :code:`major_radius`, the :code:`minor_radius` of the 2-torus on which points would be generated, uniformly or not
+(cf. :code:`uniform`), in :math:`R^3`.
+
+
+Example
+"""""""
+.. plot::
+   :include-source:
+
+    import numpy as np
+    import matplotlib.pyplot as plt
+    from gudhi.datasets.generators import points
+    
+    points1 = points.c_2_torus(n_samples=200, major_radius=4., minor_radius=1., uniform=False)
+    points2 = points.c_2_torus(n_samples=200, major_radius=4., minor_radius=1., uniform=True)
+    
+    fig = plt.figure(figsize=(12, 5))
+    
+    ax1 = fig.add_subplot(121, projection='3d')
+    ax1.scatter(points1[:, 0], points1[:, 1], points1[:, 2])
+    ax1.set_title('uniform=False')
+    ax1.set_zlim(-4., 4.)
+    
+    ax2 = fig.add_subplot(122, projection='3d')
+    ax2.scatter(points2[:, 0], points2[:, 1], points2[:, 2])
+    ax2.set_title('uniform=True')
+    ax2.set_zlim(-4., 4.)
+    
+    plt.show()
+
+.. autofunction:: gudhi.datasets.generators.points.c_2_torus
+
 Fetching datasets
 =================
 

--- a/src/python/doc/datasets.rst
+++ b/src/python/doc/datasets.rst
@@ -147,8 +147,8 @@ Example
 .. autofunction:: gudhi.datasets.generators.points.torus
 
 
-Third function: **c_2_torus**
-"""""""""""""""""""""""""""""
+Points on a 2-torus
+^^^^^^^^^^^^^^^^^^^
 
 .. table::
    :widths: 50 50

--- a/src/python/doc/persistence_graphical_tools_user.rst
+++ b/src/python/doc/persistence_graphical_tools_user.rst
@@ -41,6 +41,7 @@ This function can display the persistence result as a diagram:
     :include-source:
 
     import matplotlib.pyplot as plt
+    import numpy as np
     import gudhi
     from gudhi.datasets.generators import points
     
@@ -49,8 +50,9 @@ This function can display the persistence result as a diagram:
     
     simplex_tree = gudhi.RipsComplex(points=point_cloud, max_edge_length=0.67).create_simplex_tree(max_dimension=3)
     diags = simplex_tree.persistence(min_persistence=0.01)
-    # Save the persistence results in a file
-    simplex_tree.write_persistence_diagram("2-torus.pers")
+    # Save the H1 persistence results in a file
+    diags_H1 = simplex_tree.persistence_intervals_in_dimension(1)
+    np.save("2_torus_H1.npy", diags_H1)
     ax = gudhi.plot_persistence_diagram(diags)
     # We can modify the title, aspect, etc.
     ax.set_title("Persistence diagram of a torus")
@@ -83,10 +85,11 @@ If you want more information on a specific dimension, for instance:
     :include-source:
 
     import matplotlib.pyplot as plt
+    import numpy as np
     import gudhi
 
-    # "2-torus.pers" obtained from write_persistence_diagram method - cf. "Show persistence as a diagram"
-    birth_death = gudhi.read_persistence_intervals_in_dimension(persistence_file="2-torus.pers", only_this_dim=1)
+    # "2_torus_H1.npy" obtained from np.save method - cf. "Show persistence as a diagram"
+    birth_death = np.load("2_torus_H1.npy")
     # Use subplots to display diagram and density side by side
     fig, axes = plt.subplots(nrows=1, ncols=2, figsize=(12, 5))
     gudhi.plot_persistence_diagram(persistence=birth_death, axes=axes[0])

--- a/src/python/doc/persistence_graphical_tools_user.rst
+++ b/src/python/doc/persistence_graphical_tools_user.rst
@@ -15,21 +15,22 @@ Show persistence as a barcode
 This function can display the persistence result as a barcode:
 
 .. plot::
-   :include-source:
+    :include-source:
 
-   import matplotlib.pyplot as plt
-   import gudhi
-   from gudhi.datasets.generators import points
-   
-   gudhi.random.set_seed(42)
-   point_cloud = points.c_2_torus(n_samples=300, major_radius=2., minor_radius=1.)
-   
-   rips_complex = gudhi.RipsComplex(points=point_cloud, max_edge_length=0.7)
-   simplex_tree = rips_complex.create_simplex_tree(max_dimension=3)
-   diag = simplex_tree.persistence(min_persistence=0.4)
-   
-   gudhi.plot_persistence_barcode(diag)
-   plt.show()
+    import matplotlib.pyplot as plt
+    import gudhi
+    from gudhi.datasets.generators import points
+    
+    gudhi.random.set_seed(42)
+    point_cloud = points.c_2_torus(n_samples=300, major_radius=2., minor_radius=1.)
+    
+    rips_complex = gudhi.RipsComplex(points=point_cloud, max_edge_length=0.7)
+    simplex_tree = rips_complex.create_simplex_tree(max_dimension=3)
+    diag = simplex_tree.persistence(min_persistence=0.4)
+    
+    gudhi.plot_persistence_barcode(diag)
+    plt.show()
+
 
 Show persistence as a diagram
 -----------------------------
@@ -37,19 +38,25 @@ Show persistence as a diagram
 This function can display the persistence result as a diagram:
 
 .. plot::
-   :include-source:
+    :include-source:
 
     import matplotlib.pyplot as plt
     import gudhi
-
-    # rips_on_tore3D_1307.pers obtained from write_persistence_diagram method
-    persistence_file=gudhi.__root_source_dir__ + \
-        '/data/persistence_diagram/rips_on_tore3D_1307.pers'
-    ax = gudhi.plot_persistence_diagram(persistence_file=persistence_file)
+    from gudhi.datasets.generators import points
+    
+    gudhi.random.set_seed(42)
+    point_cloud = points.c_2_torus(n_samples=2500, major_radius=2., minor_radius=1.)
+    
+    simplex_tree = gudhi.RipsComplex(points=point_cloud, max_edge_length=0.67).create_simplex_tree(max_dimension=3)
+    diags = simplex_tree.persistence(min_persistence=0.01)
+    # Save the persistence results in a file
+    simplex_tree.write_persistence_diagram("2-torus.pers")
+    ax = gudhi.plot_persistence_diagram(diags)
     # We can modify the title, aspect, etc.
     ax.set_title("Persistence diagram of a torus")
     ax.set_aspect("equal")  # forces to be square shaped
     plt.show()
+
 
 Note that (as barcode and density) it can also take a simple `np.array`
 of shape (N x 2) encoding a persistence diagram (in a given dimension).
@@ -64,6 +71,7 @@ of shape (N x 2) encoding a persistence diagram (in a given dimension).
     gudhi.plot_persistence_diagram(d)
     plt.show()
 
+
 Persistence density
 -------------------
 
@@ -72,20 +80,19 @@ Persistence density
 If you want more information on a specific dimension, for instance:
 
 .. plot::
-   :include-source:
+    :include-source:
 
     import matplotlib.pyplot as plt
     import gudhi
-    # rips_on_tore3D_1307.pers obtained from write_persistence_diagram method
-    persistence_file=gudhi.__root_source_dir__ + \
-        '/data/persistence_diagram/rips_on_tore3D_1307.pers'
-    birth_death = gudhi.read_persistence_intervals_in_dimension(
-        persistence_file=persistence_file, only_this_dim=1)
+
+    # "2-torus.pers" obtained from write_persistence_diagram method - cf. "Show persistence as a diagram"
+    birth_death = gudhi.read_persistence_intervals_in_dimension(persistence_file="2-torus.pers", only_this_dim=1)
     # Use subplots to display diagram and density side by side
     fig, axes = plt.subplots(nrows=1, ncols=2, figsize=(12, 5))
     gudhi.plot_persistence_diagram(persistence=birth_death, axes=axes[0])
     gudhi.plot_persistence_density(persistence=birth_death, axes=axes[1])
     plt.show()
+
 
 LaTeX support
 -------------

--- a/src/python/doc/persistence_graphical_tools_user.rst
+++ b/src/python/doc/persistence_graphical_tools_user.rst
@@ -17,18 +17,19 @@ This function can display the persistence result as a barcode:
 .. plot::
    :include-source:
 
-    import matplotlib.pyplot as plt
-    import gudhi
-
-    off_file = gudhi.__root_source_dir__ + '/data/points/tore3D_300.off'
-    point_cloud = gudhi.read_points_from_off_file(off_file=off_file)
-
-    rips_complex = gudhi.RipsComplex(points=point_cloud, max_edge_length=0.7)
-    simplex_tree = rips_complex.create_simplex_tree(max_dimension=3)
-    diag = simplex_tree.persistence(min_persistence=0.4)
-
-    gudhi.plot_persistence_barcode(diag)
-    plt.show()
+   import matplotlib.pyplot as plt
+   import gudhi
+   from gudhi.datasets.generators import points
+   
+   gudhi.random.set_seed(42)
+   point_cloud = points.c_2_torus(n_samples=300, major_radius=2., minor_radius=1.)
+   
+   rips_complex = gudhi.RipsComplex(points=point_cloud, max_edge_length=0.7)
+   simplex_tree = rips_complex.create_simplex_tree(max_dimension=3)
+   diag = simplex_tree.persistence(min_persistence=0.4)
+   
+   gudhi.plot_persistence_barcode(diag)
+   plt.show()
 
 Show persistence as a diagram
 -----------------------------

--- a/src/python/example/rips_complex_edge_collapse_example.py
+++ b/src/python/example/rips_complex_edge_collapse_example.py
@@ -16,13 +16,13 @@ __license__ = "MIT"
 import matplotlib.pyplot as plt
 import time
 import gudhi as gd
-
+from gudhi.datasets.generators import points
 
 print("#####################################################################")
 print("RipsComplex (only the one-skeleton) creation from tore3D_300.off file")
 
-off_file = gd.__root_source_dir__ + "/data/points/tore3D_300.off"
-point_cloud = gd.read_points_from_off_file(off_file=off_file)
+gudhi.random.set_seed(42)
+point_cloud = points.c_2_torus(n_samples=300, major_radius=2., minor_radius=1.)
 rips_complex = gd.RipsComplex(points=point_cloud, max_edge_length=12.0)
 simplex_tree = rips_complex.create_simplex_tree(max_dimension=1)
 print(f"1. Rips complex has {simplex_tree.num_simplices()} simplices - {simplex_tree.num_vertices()} vertices.")

--- a/src/python/example/rips_complex_edge_collapse_example.py
+++ b/src/python/example/rips_complex_edge_collapse_example.py
@@ -21,9 +21,9 @@ from gudhi.datasets.generators import points
 print("#####################################################################")
 print("RipsComplex (only the one-skeleton) creation from tore3D_300.off file")
 
-gudhi.random.set_seed(42)
+gd.random.set_seed(42)
 point_cloud = points.c_2_torus(n_samples=300, major_radius=2., minor_radius=1.)
-rips_complex = gd.RipsComplex(points=point_cloud, max_edge_length=12.0)
+rips_complex = gd.RipsComplex(points=point_cloud)
 simplex_tree = rips_complex.create_simplex_tree(max_dimension=1)
 print(f"1. Rips complex has {simplex_tree.num_simplices()} simplices - {simplex_tree.num_vertices()} vertices.")
 

--- a/src/python/gudhi/datasets/generators/_points.cc
+++ b/src/python/gudhi/datasets/generators/_points.cc
@@ -10,6 +10,7 @@
  */
 
 #include <vector>
+#include <algorithm>  // for std::swap
 
 #include <nanobind/nanobind.h>
 #include <nanobind/stl/string.h>
@@ -70,6 +71,25 @@ auto generate_points_on_torus(size_t n_samples, int dim, std::string sample)
   return _wrap_as_numpy_array(points, npoints, 2 * dim);
 }
 
+auto generate_points_on_2_torus(size_t n_samples, double major_radius, double minor_radius, bool uniform)
+{
+  if (major_radius < minor_radius)
+    std::swap(major_radius, minor_radius);
+
+  std::vector<typename Kern::Point_d> points_generated;
+  {
+    nb::gil_scoped_release release;
+    points_generated = Gudhi::generate_points_on_torus_3D<Kern>(n_samples, major_radius, minor_radius, uniform);
+  }
+  
+  // Reserve sufficient memory space to copy data
+  auto points = new double[n_samples * 3];
+  for (size_t i = 0; i < n_samples; i++)
+    for (int j = 0; j < 3; j++) points[i * 3 + j] = points_generated[i][j];
+
+  return _wrap_as_numpy_array(points, n_samples, 3);
+}
+
 NB_MODULE(_points_ext, m)
 {
   m.attr("__license__") = "LGPL v3";
@@ -115,5 +135,28 @@ The shape of returned numpy array is:
 If sample is 'random': (n_samples, 2*dim).
 
 If sample is 'grid': (⌊n_samples**(1./dim)⌋**dim, 2*dim), where shape[0] is rounded down to the closest perfect 'dim'th power.
+        )doc");
+
+  m.def("c_2_torus",
+        &generate_points_on_2_torus,
+        nb::arg("n_samples"),
+        nb::arg("major_radius") = 1.,
+        nb::arg("minor_radius") = 0.5,
+        nb::arg("uniform") = false,
+        R"doc(
+Generate random i.i.d., or uniformly distributed points on a 2-torus in R^3d.
+
+:param n_samples: The number of points to be generated.
+:type n_samples: integer
+:param major_radius: The major radius of the 2-torus. Default value is `1.`.
+:type major_radius: float
+:param minor_radius: The minor radius of the 2-torus. Default value is `0.5`.
+:type minor_radius: float
+:param uniform: random i.i.d. points when `False`, or uniformly distributed points when `True`. Default value is
+    `False`.
+:type uniform: bool
+:returns: the generated points on a 2-torus.
+
+The shape of returned numpy array is (n_samples, 3).
         )doc");
 }

--- a/src/python/gudhi/datasets/generators/_points.cc
+++ b/src/python/gudhi/datasets/generators/_points.cc
@@ -144,7 +144,7 @@ If sample is 'grid': (⌊n_samples**(1./dim)⌋**dim, 2*dim), where shape[0] is 
         nb::arg("minor_radius") = 0.5,
         nb::arg("uniform") = false,
         R"doc(
-Generate random i.i.d., or uniformly distributed points on a 2-torus in R^3d.
+Generate random i.i.d., or uniformly distributed points on a 2-torus in R^3.
 
 :param n_samples: The number of points to be generated.
 :type n_samples: integer

--- a/src/python/gudhi/datasets/generators/points.py
+++ b/src/python/gudhi/datasets/generators/points.py
@@ -13,7 +13,7 @@ __license__ = "MIT"
 import numpy as np
 from typing import Literal
 
-from ._points_ext import ctorus, sphere
+from ._points_ext import ctorus, sphere, c_2_torus
 
 
 def _generate_random_points_on_torus(n_samples: int, dim: int):


### PR DESCRIPTION
Part of #179 (do not promote `__root_source_dir__`).

In `src/python/doc/persistence_graphical_tools_user.rst` it is using `numpy.save | load` but it could also use `gudhi.SimplexTree.write_persistence_diagram | gudhi.read_persistence_intervals_in_dimension`, but it requires #1361 fix. To be discussed.