### PR TITLE
Rename `expansion_with_blocker` as `expansion_with_blockers`

### DIFF
--- a/.github/next_release.md
+++ b/.github/next_release.md
@@ -10,8 +10,8 @@ Below is a list of changes:
 - [Module](link)
      - **...**
 
-- [Module](link)
-     - **...**
+- Simplex tree [`[Python`](https://gudhi.inria.fr/python/latest/simplex_tree_ref.html)
+     - `expansion_with_blocker` is deprecated. Please consider using `expansion_with_blockers`.
 
 - Miscellaneous
      - Reader utilities now require an explicit file path and raise an exception when the file cannot be opened.

--- a/src/python/gudhi/_simplex_tree.cc
+++ b/src/python/gudhi/_simplex_tree.cc
@@ -359,7 +359,7 @@ If you do not need the filtration values, the boundary can also be obtained as
 :returns:  The (simplices of the) boundary of a simplex
 :rtype:  Iterator over tuples(simplex, filtration)
           )doc")
-      .def("expansion_with_blocker",
+      .def("expansion_with_blockers",
            &gsti::expansion_with_blockers_callback,
            nb::arg("max_dim"),
            nb::arg("blocker_func"),

--- a/src/python/gudhi/simplex_tree.py
+++ b/src/python/gudhi/simplex_tree.py
@@ -18,6 +18,7 @@ __license__ = "MIT"
 import numpy as np
 from numpy.typing import ArrayLike
 import warnings
+from collections.abc import Callable, Sequence
 
 from gudhi import _simplex_tree_ext as t
 
@@ -82,8 +83,6 @@ class SimplexTree(t._Simplex_tree_python_interface):
 
         .. deprecated:: 3.2.0
         """
-        import warnings
-
         warnings.warn(
             "Since Gudhi 3.2, calling SimplexTree.initialize_filtration is unnecessary.",
             DeprecationWarning,
@@ -426,3 +425,21 @@ class SimplexTree(t._Simplex_tree_python_interface):
             warnings.warn(message, RuntimeWarning)
         super()._collapse_edges(nb_iterations)
         return self
+
+    def expansion_with_blocker(self, max_dim: int, blocker_func: Callable[[Sequence[int]], bool]) -> None:
+        """Please consider using :func:`expansion_with_blockers`
+
+        :param max_dim: Expansion maximal dimension value.
+        :type max_dim: int
+        :param blocker_func: Blocker oracle.
+        :type blocker_func: Callable[[Sequence[int]], bool]
+        :rtype: None
+
+        .. deprecated:: 3.14.0
+        """
+        warnings.warn(
+            "Since Gudhi 3.14, calling SimplexTree.expansion_with_blocker is deprecated. Please consider using "\
+            "SimplexTree.expansion_with_blockers.",
+            DeprecationWarning,
+        )
+        super().expansion_with_blockers(max_dim, blocker_func)

--- a/src/python/test/test_simplex_tree.py
+++ b/src/python/test/test_simplex_tree.py
@@ -687,7 +687,7 @@ def test_expansion_with_blocker():
             st.assign_filtration(simplex, st.filtration(simplex) + 1.0)
             return False
 
-    st.expansion_with_blocker(2, blocker)
+    st.expansion_with_blockers(2, blocker)
     assert st.num_simplices() == 22
     assert st.dimension() == 2
     assert st.find([4, 5, 6]) == False
@@ -696,7 +696,7 @@ def test_expansion_with_blocker():
     assert st.filtration([0, 2, 3]) == 6.0
     assert st.filtration([1, 2, 3]) == 6.0
 
-    st.expansion_with_blocker(3, blocker)
+    st.expansion_with_blockers(3, blocker)
     assert st.num_simplices() == 23
     assert st.dimension() == 3
     assert st.find([4, 5, 6]) == False


### PR DESCRIPTION
Fix #936 
`expansion_with_blocker` is deprecated for backward compatibility.